### PR TITLE
Hotfix: Direct CellRanger output to the intended directory (TenX module)

### DIFF
--- a/lib/realms/tenx/run_sample.py
+++ b/lib/realms/tenx/run_sample.py
@@ -258,8 +258,8 @@ class TenXRunSample(AbstractSample):
         required_args = self.pipeline_info.get("required_arguments", [])
         additional_args = self.pipeline_info.get("fixed_arguments", [])
 
-        # Add output directory
-        # additional_args.append(f'{"--output-dir"}={str(self.file_handler.sample_dir)}')
+        # Add output directory argument
+        additional_args.append(f"--output-dir={str(self.file_handler.sample_dir)}")
 
         # Mapping of argument names to their values
         arg_values: Dict[str, Any] = {

--- a/lib/realms/tenx/run_sample.py
+++ b/lib/realms/tenx/run_sample.py
@@ -199,7 +199,7 @@ class TenXRunSample(AbstractSample):
         slurm_metadata = {
             "sample_id": self.run_sample_id,
             "project_name": self.project_info.get("project_name", ""),
-            "output_dir": str(self.file_handler.sample_dir),
+            "output_dir": str(self.file_handler.base_dir),
             "cellranger_command": cellranger_command,
         }
 
@@ -257,6 +257,9 @@ class TenXRunSample(AbstractSample):
 
         required_args = self.pipeline_info.get("required_arguments", [])
         additional_args = self.pipeline_info.get("fixed_arguments", [])
+
+        # Add output directory
+        # additional_args.append(f'{"--output-dir"}={str(self.file_handler.sample_dir)}')
 
         # Mapping of argument names to their values
         arg_values: Dict[str, Any] = {

--- a/lib/realms/tenx/tenx_project.py
+++ b/lib/realms/tenx/tenx_project.py
@@ -289,6 +289,7 @@ class TenXProject(AbstractProject):
             # Handle original samples without features
             library_prep_option = self.project_info.get("library_prep_option", "")
             feature = self.get_default_feature(library_prep_option)
+            # NOTE: If you want to name samples with the customer name, comment out the line below
             original_sample_id = sample_id
             return feature, original_sample_id
 
@@ -390,6 +391,7 @@ class TenXProject(AbstractProject):
         sample_data = self.filter_aborted_samples(sample_data)
         # Step 2: Create lab samples
         lab_samples = self.create_lab_samples(sample_data)
+        logging.info(f"Lab samples: {lab_samples}")
         # Step 3: Group lab samples by original sample ID
         grouped_lab_samples = self.group_lab_samples(lab_samples)
         # Step 4: Create run samples


### PR DESCRIPTION
Added `--output-dir` option in the cellranger command