### PR TITLE
Minor adjustment in the order and naming CellRanger needs the Multi CSV library fields

### DIFF
--- a/lib/realms/tenx/run_sample.py
+++ b/lib/realms/tenx/run_sample.py
@@ -398,11 +398,11 @@ class TenXRunSample(AbstractSample):
 
             # Write the [libraries] section
             multi_file.write("[libraries]\n")
-            multi_file.write("fastqs,sample,library_type\n")
+            multi_file.write("fastq_id,fastqs,feature_types\n")
             libraries_data = self.collect_libraries_data()
             for lib in libraries_data:
                 multi_file.write(
-                    f"{lib['fastqs']},{lib['sample']},{lib['library_type']}\n"
+                    f"{lib['sample']},{lib['fastqs']},{lib['library_type']}\n"
                 )
 
         logging.info(


### PR DESCRIPTION
This pull request includes a change to the `generate_multi_sample_csv` method in the `lib/realms/tenx/run_sample.py` file to update the CSV format for the libraries section.

CSV Format Update:

* [`lib/realms/tenx/run_sample.py`](diffhunk://#diff-752bedf2961fe47eb5b6cb7afe61078f3615f2d764c1b8ef58c5861e510b68e6L401-R405): Modified the header and the order of fields written to the CSV file in the `generate_multi_sample_csv` method. The header now includes `fastq_id`, `fastqs`, and `feature_types`, and the fields are written in the order of `sample`, `fastqs`, and `library_type`.