### PR TITLE
Refactor/project name formatting

### DIFF
--- a/lib/realms/smartseq3/smartseq3.py
+++ b/lib/realms/smartseq3/smartseq3.py
@@ -64,7 +64,7 @@ class SmartSeq3(AbstractProject):
         """
         try:
             project_info = {
-                "project_name": self.doc.get("project_name", "").replace(".", "__"),
+                "project_name": self.doc.get("project_name", ""),
                 "project_id": self.doc.get("project_id", "Unknown_Project"),
                 "escg_id": self.doc.get("customer_project_reference"),
                 "library_prep_option": self.doc.get("details", {}).get(

--- a/lib/realms/tenx/tenx_project.py
+++ b/lib/realms/tenx/tenx_project.py
@@ -62,7 +62,7 @@ class TenXProject(AbstractProject):
         try:
             details = self.doc.get("details", {})
             project_info: Dict[str, Any] = {
-                "project_name": self.doc.get("project_name", "").replace(".", "__"),
+                "project_name": self.doc.get("project_name", ""),
                 "project_id": self.doc.get("project_id", "Unknown_Project"),
                 "customer_reference": self.doc.get("customer_project_reference", ""),
                 "library_prep_method": details.get("library_construction_method", ""),
@@ -194,8 +194,11 @@ class TenXProject(AbstractProject):
             Optional[Path]: The Path object of the project directory, or None if creation fails.
         """
         try:
-            project_base_dir = Path(self.config["10x_dir"])
-            project_dir = project_base_dir / self.project_info["project_name"]
+            project_dir = (
+                Path(self.config["10x_dir"])
+                / "projects"
+                / self.project_info["project_name"]
+            )
             project_dir.mkdir(parents=True, exist_ok=True)
             return project_dir
         except Exception as e:


### PR DESCRIPTION
This pull request includes changes to the project information extraction and directory creation logic in the `smartseq3` and `tenx` realms. More specifically, we used to replace "." in the project name with "__". With this PR this won't happen anymore.

Changes to project information extraction:

* [`lib/realms/smartseq3/smartseq3.py`](diffhunk://#diff-74e1b57a1c9ee04389b18767e3f5a56f84603ee3bf60db5a794ab51bf40a1016L67-R67): Removed the replacement of dots with double underscores in the `project_name` field in the `_extract_project_info` method.
* [`lib/realms/tenx/tenx_project.py`](diffhunk://#diff-dc3ac22d5b8fcf4f646c26032dca15be67d91928029577a61dcfc420f4498bb4L65-R65): Removed the replacement of dots with double underscores in the `project_name` field in the `_extract_project_info` method.

Changes to directory creation:

* [`lib/realms/tenx/tenx_project.py`](diffhunk://#diff-dc3ac22d5b8fcf4f646c26032dca15be67d91928029577a61dcfc420f4498bb4L197-R201): Updated the `ensure_project_directory` method to create the project directory under a "projects" subdirectory within the base directory specified by the `10x_dir` configuration.