### PR TITLE
Fix prompt issue in ngi_report_generator

### DIFF
--- a/lib/module_utils/ngi_report_generator.py
+++ b/lib/module_utils/ngi_report_generator.py
@@ -44,7 +44,11 @@ def generate_ngi_report(
         # NOTE: Perhaps use `check=False` to prevent raising
         #       CalledProcessError on non-zero exit codes
         process = subprocess.run(
-            full_cmd, shell=True, text=True, capture_output=True  # , check=False
+            full_cmd,
+            shell=True,
+            text=True,
+            capture_output=True,
+            input="y\n",  # , check=False
         )
 
         # Check the outcome of the subprocess


### PR DESCRIPTION
After an update `ngi_report` tool asks for user input if conditions are not met. This pull request includes a fix to the `generate_ngi_report` function in the `lib/module_utils/ngi_report_generator.py` file. The change modifies the `subprocess.run` call to include an `input` parameter to overcome the raised issue.

* [`lib/module_utils/ngi_report_generator.py`](diffhunk://#diff-aff1f85a57bc1ab53c8d696545aa6adc154761c006cc24f984223a312d0d6c5cL47-R51): Added the `input="y\n"` parameter to the `subprocess.run` call in the `generate_ngi_report` function.