### PR TITLE
Rename 'process' method to 'launch' across core and realms

### DIFF
--- a/lib/base/abstract_project.py
+++ b/lib/base/abstract_project.py
@@ -33,19 +33,14 @@ class AbstractProject(ABC):
         self.yggdrasil_db_manager: Any = yggdrasil_db_manager
 
     @abstractmethod
-    def pre_process(self) -> None:
-        """Handle preliminary processing specific to the realm's requirements."""
-        pass
-
-    @abstractmethod
-    async def process(self) -> None:
+    async def launch(self) -> None:
         """Define the main processing logic for the project.
 
         This method should be implemented by each project class to define how the processing
         of the document unfolds.
 
         Note:
-            Since processing might involve asynchronous operations (e.g., submitting and monitoring jobs),
+            Since its course might involve asynchronous operations (e.g., submitting and monitoring jobs),
             this method is defined as asynchronous.
         """
         pass

--- a/lib/realms/smartseq3/smartseq3.py
+++ b/lib/realms/smartseq3/smartseq3.py
@@ -151,10 +151,8 @@ class SmartSeq3(AbstractProject):
             logging.error(f"Failed to create project directory: {e}")
             return None
 
-    async def process(self):
-        """
-        Process the SmartSeq3 project by handling its samples.
-        """
+    async def launch(self):
+        """Launch the SmartSeq3 Realm to handle its samples."""
         self.status = "processing"
         logging.info(
             f"Processing SmartSeq3 project {self.project_info['project_name']}"
@@ -211,15 +209,6 @@ class SmartSeq3(AbstractProject):
             logging.info("NGI report was generated successfully.")
         else:
             logging.error("Failed to generate the NGI report.")
-
-    def pre_process(self, doc):
-        """
-        Pre-process method placeholder.
-
-        Args:
-            doc (dict): Document to pre-process.
-        """
-        pass
 
     def create_slurm_job(self, sample):
         """

--- a/lib/realms/tenx/tenx_project.py
+++ b/lib/realms/tenx/tenx_project.py
@@ -397,12 +397,8 @@ class TenXProject(AbstractProject):
         run_samples = self.create_run_samples(grouped_lab_samples)
         return run_samples
 
-    def pre_process(self) -> None:
-        """Perform any pre-processing steps required before processing the project."""
-        pass
-
-    async def process(self):
-        """Process the TenX project by handling its samples."""
+    async def launch(self):
+        """Launch the TenX Realm to handle its samples."""
         logging.info(f"Processing TenX project {self.project_info['project_name']}")
         self.status = "processing"
 

--- a/ygg-mule.py
+++ b/ygg-mule.py
@@ -71,7 +71,7 @@ def process_document(doc_id):
             if RealmClass:
                 realm = RealmClass(document, ydm)
                 if realm.proceed:
-                    asyncio.run(realm.process())
+                    asyncio.run(realm.launch())
                     logging.info("Processing complete.")
                 else:
                     logging.info(

--- a/ygg_trunk.py
+++ b/ygg_trunk.py
@@ -56,13 +56,12 @@ async def process_couchdb_changes():
                         RealmClass = Ygg.load_realm_class(module_loc)
 
                         if RealmClass:
-                            # Call the module's process function
+                            # Call the module's launch function
                             realm = RealmClass(data, ydm)
                             if realm.proceed:
-                                task = asyncio.create_task(realm.process())
+                                task = asyncio.create_task(realm.launch())
                                 tasks.append(task)
                                 # print(f"Tasks ({realm.project_info['project_id']}): {tasks}")
-                                # module.process(data)
                             else:
                                 logging.info(
                                     f"Skipping task creation due to missing required information. {data.get('project_id')}"


### PR DESCRIPTION
This pull request focuses on renaming the `process` method to `launch` across different project classes and scripts. This renaming aims to reflect the method's purpose better, improve code clarity, and avoid confusion with the sample's class `process` method. Also, remove the `pre_process` methods since they have not been used and have fallen out of scope.

Method renaming:

* [`lib/base/abstract_project.py`](diffhunk://#diff-26e90429a1c5989fad504f0e49c123f619a69c29102aad2ee6a233782c67538eL36-R43): Renamed the `process` method to `launch` in the abstract base class and updated the docstring to reflect the new method name.
* [`lib/realms/smartseq3/smartseq3.py`](diffhunk://#diff-74e1b57a1c9ee04389b18767e3f5a56f84603ee3bf60db5a794ab51bf40a1016L154-R155): Renamed the `process` method to `launch` and updated the corresponding docstring. Removed the `pre_process` method as it was no longer needed. [[1]](diffhunk://#diff-74e1b57a1c9ee04389b18767e3f5a56f84603ee3bf60db5a794ab51bf40a1016L154-R155) [[2]](diffhunk://#diff-74e1b57a1c9ee04389b18767e3f5a56f84603ee3bf60db5a794ab51bf40a1016L215-L223)
* [`lib/realms/tenx/tenx_project.py`](diffhunk://#diff-dc3ac22d5b8fcf4f646c26032dca15be67d91928029577a61dcfc420f4498bb4L400-R401): Renamed the `process` method to `launch` and updated the corresponding docstring. Removed the `pre_process` method as it was no longer needed.

Script updates:

* [`ygg-mule.py`](diffhunk://#diff-18e475be20d5e65529ac9fb4f3aa3e0051b2bf209cfe4f0d57b8323af77320b6L74-R74): Updated the call from `realm.process()` to `realm.launch()` to align with the method renaming.
* [`ygg_trunk.py`](diffhunk://#diff-00061d6e27d23df7ae5e4695a31c863f6f646bdae8ad44c20240fe4ea123a3f8L59-L65): Updated the call from `realm.process()` to `realm.launch()` to align with the method renaming.