### PR TITLE
Move paths to SampleFileHandler

### DIFF
--- a/lib/realms/smartseq3/ss3_sample.py
+++ b/lib/realms/smartseq3/ss3_sample.py
@@ -25,8 +25,6 @@ class SS3Sample(AbstractSample):
         config (dict): Configuration settings.
         status (str): Current status of the sample.
         metadata (dict): Metadata for the sample.
-        project_dir (Path): Path to the parent project directory.
-        sample_dir (Path): Path to the sample directory.
         sjob_manager (SlurmJobManager): Manager for submitting and monitoring Slurm jobs.
         file_handler (SampleFileHandler): Handler for sample files.
     """
@@ -57,13 +55,6 @@ class SS3Sample(AbstractSample):
         # TODO: Currently not used much, but should be used if we write to a database
         self._status = "pending"  # other statuses: "processing", "completed", "failed"
         self.metadata = None
-
-        # Define the parent project directory
-        self.project_dir = self.project_info.get("project_dir")
-
-        # Define the sample directory
-        # NOTE: This directory is not created yet. To be verified in the post_process method.
-        self.sample_dir = self.project_dir / self.id
 
         if DEBUG:
             self.sjob_manager = MockSlurmJobManager()
@@ -209,8 +200,8 @@ class SS3Sample(AbstractSample):
                 "fastqs": {k: str(v) for k, v in fastqs.items() if v},
                 "read_setup": read_setup,
                 "ref": ref_paths,
-                "outdir": str(self.sample_dir),
-                "out_yaml": self.project_dir / f"{self.id}.yaml",
+                "outdir": str(self.file_handler.sample_dir),
+                "out_yaml": self.file_handler.project_dir / f"{self.id}.yaml",
             }
         except Exception as e:
             logging.error(f"Error constructing metadata for sample {self.id}: {e}")
@@ -259,10 +250,10 @@ class SS3Sample(AbstractSample):
         try:
             metadata = {
                 "project_name": self.project_info["project_name"],
-                "project_dir": self.project_dir,
+                "project_dir": self.file_handler.project_dir,
                 # 'sample_id': self.id, # Temporarily not used, but might be used when we name everything after ngi
                 "plate_id": self.id,  # self.sample_data.get('customer_name', ''),
-                "yaml_settings_path": self.project_dir / f"{self.id}.yaml",
+                "yaml_settings_path": self.file_handler.project_dir / f"{self.id}.yaml",
                 "zumis_path": self.config["zumis_path"],
             }
         except Exception as e:

--- a/lib/realms/smartseq3/utils/sample_file_handler.py
+++ b/lib/realms/smartseq3/utils/sample_file_handler.py
@@ -56,10 +56,8 @@ class SampleFileHandler:
         self.config = sample.config
 
         # Define sample folder structure
-        self.base_dir = (
-            Path(self.config["smartseq3_dir"]) / "projects" / self.project_name
-        )
-        self.sample_dir = self.base_dir / self.sample_id
+        self.project_dir = sample.project_info.get("project_dir", "")
+        self.sample_dir = self.project_dir / self.sample_id
         self.zumis_output_dir = self.sample_dir / "zUMIs_output"
         self.stats_dir = self.sample_dir / "zUMIs_output" / "stats"
         self.expression_dir = self.sample_dir / "zUMIs_output" / "expression"
@@ -90,7 +88,7 @@ class SampleFileHandler:
         self.features_plot_fpath = self.stats_dir / f"{self.plate}.features.pdf"
 
         # Files needed for processing
-        self.slurm_script_path = self.base_dir / f"{self.sample_id}_slurm_script.sh"
+        self.slurm_script_path = self.project_dir / f"{self.sample_id}_slurm_script.sh"
         self.barcode_fpath = (
             Path(self.config["smartseq3_dir"]) / "barcodes" / f"{self.barcode}.txt"
         )


### PR DESCRIPTION
This pull request focuses on refactoring the handling of directory paths in the `SS3Sample` class and related methods, moving the responsibility to the `SampleFileHandler` class. The most important changes include renaming `base_dir` to `project_dir`, removing the `project_dir` and `sample_dir` attributes from `SS3Sample` and updating methods to use `SampleFileHandler` for directory paths.

Refactoring directory path handling:

* [`lib/realms/smartseq3/ss3_sample.py`](diffhunk://#diff-4e7a80d2b2482b76b39abc2b02389372d35b10f12384a4840ea1d8d3fb951a27L28-L29): Removed `project_dir` and `sample_dir` attributes from `SS3Sample` and updated methods to use `SampleFileHandler` for directory paths. [[1]](diffhunk://#diff-4e7a80d2b2482b76b39abc2b02389372d35b10f12384a4840ea1d8d3fb951a27L28-L29) [[2]](diffhunk://#diff-4e7a80d2b2482b76b39abc2b02389372d35b10f12384a4840ea1d8d3fb951a27L61-L67) [[3]](diffhunk://#diff-4e7a80d2b2482b76b39abc2b02389372d35b10f12384a4840ea1d8d3fb951a27L212-R204) [[4]](diffhunk://#diff-4e7a80d2b2482b76b39abc2b02389372d35b10f12384a4840ea1d8d3fb951a27L262-R256)
* [`lib/realms/smartseq3/utils/sample_file_handler.py`](diffhunk://#diff-5ba933c43f51d317425c66c63acc203192e70ad4798c0e065ec7732e96c4ce8bL59-R60): Updated `SampleFileHandler` to initialize `project_dir` and `sample_dir` based on `sample.project_info` and refactored methods to use these attributes. [[1]](diffhunk://#diff-5ba933c43f51d317425c66c63acc203192e70ad4798c0e065ec7732e96c4ce8bL59-R60) [[2]](diffhunk://#diff-5ba933c43f51d317425c66c63acc203192e70ad4798c0e065ec7732e96c4ce8bL93-R91)