### PR TITLE
Fix rsync command to account for non-existed parent folders in dest

### DIFF
--- a/lib/module_utils/report_transfer.py
+++ b/lib/module_utils/report_transfer.py
@@ -23,19 +23,25 @@ def transfer_report(
         logging.warning("Report transfer will not be attempted. Handle manually...")
         return False
 
+    # Build the remote directory path
+    remote_dir = f"{destination_path}/{project_id}"
     if sample_id:
-        remote_path = f"{user}@{server}:{destination_path}/{project_id}/{sample_id}/"
-    else:
-        remote_path = f"{user}@{server}:{destination_path}/{project_id}/"
+        remote_dir = f"{remote_dir}/{sample_id}"
+
+    remote_path = f"{user}@{server}:{remote_dir}/"
 
     rsync_command = [
         "rsync",
         "-avz",
+        "--rsync-path",
+        f"mkdir -p '{remote_dir}' && rsync",
         "-e",
         f"ssh -i {ssh_key}" if ssh_key else "ssh",
         str(report_path),
         remote_path,
     ]
+
+    logging.debug(f"RSYNC command: {' '.join(rsync_command)}")
 
     try:
         # Execute the rsync command


### PR DESCRIPTION
This pull request includes changes to the `transfer_report` function in `lib/module_utils/report_transfer.py` to improve the handling of remote directory paths and enhance logging.

Improvements to remote directory handling:

* Refactored the construction of `remote_dir` to ensure it includes `sample_id` if provided.
* Modified the `rsync_command` to include a `--rsync-path` option that creates the remote directory if it does not exist.

Enhancements to logging:

* Added a debug log statement to output the constructed `rsync_command` for easier troubleshooting.