### PR TITLE
Add unittests

### DIFF
--- a/tests/test_slurm_utils.py
+++ b/tests/test_slurm_utils.py
@@ -232,12 +232,12 @@ class TestGenerateSlurmScript(unittest.TestCase):
     def test_generate_slurm_script_invalid_template_path_type(self):
         # Test with invalid type for template_fpath
         with self.assertRaises(TypeError):
-            generate_slurm_script(self.args_dict, None, self.output_fpath)
+            generate_slurm_script(self.args_dict, None, self.output_fpath)  # type: ignore
 
     def test_generate_slurm_script_invalid_output_path_type(self):
         # Test with invalid type for output_fpath
         with self.assertRaises(TypeError):
-            generate_slurm_script(self.args_dict, self.template_fpath, None)
+            generate_slurm_script(self.args_dict, self.template_fpath, None)  # type: ignore
 
     @patch("lib.module_utils.slurm_utils.Path")
     @patch("builtins.open", new_callable=mock_open)


### PR DESCRIPTION
This pull request includes several updates to the test suite, focusing on improving the robustness and coverage of the tests. The most important changes include adding new test cases, modifying existing test cases for better accuracy, and ensuring proper error handling.

### Enhancements to test cases:

* [`tests/test_common.py`](diffhunk://#diff-556812789bdf8b0b5fa491afe93530be33abb8fd41150bec1da8da6b7c43e064L62-L68): Modified `test_load_realm_class_attribute_error` to use a mock module with no attributes allowed, ensuring any attribute access raises `AttributeError`.
* [`tests/test_common.py`](diffhunk://#diff-556812789bdf8b0b5fa491afe93530be33abb8fd41150bec1da8da6b7c43e064R97-R112): Added `test_load_realm_class_caching` to verify that the `load_realm_class` function correctly caches the class after the first load, avoiding redundant imports.
* [`tests/test_common.py`](diffhunk://#diff-556812789bdf8b0b5fa491afe93530be33abb8fd41150bec1da8da6b7c43e064R236-R245): Added `test_get_path_resolve_error` to handle exceptions during the `Path.resolve` call, ensuring the function returns `None` when an error occurs.

### Improvements to error handling:

* [`tests/test_report_transfer.py`](diffhunk://#diff-ecf77d8d01727f274cc84acc445b1932a429752db2f864103df7366824b59673L134-R177): Added `test_transfer_report_general_exception_with_result` to simulate an error during logging after a successful subprocess run, ensuring the function handles the exception and logs the appropriate messages.

### Minor fixes:

* [`tests/test_config_loader.py`](diffhunk://#diff-70c0e06420ab3a9b3aef0a49e1e76b7d5b43e0cc62b764e3550d94fb5045e304L98-R98): Simplified the `test_config_immutable` by directly attempting to modify the `MappingProxyType` configuration, ensuring immutability.
* [`tests/test_config_loader.py`](diffhunk://#diff-70c0e06420ab3a9b3aef0a49e1e76b7d5b43e0cc62b764e3550d94fb5045e304L135-R149): Updated `test_configs_loaded` to patch the `load_config` method directly and ensure the `configs` attribute is correctly set.
* [`tests/test_slurm_utils.py`](diffhunk://#diff-15340a0e553d3fb5063a04b7715c0d5a9246bad9551710e2aef5d9edd758f27bL235-R240): Added `# type: ignore` comments to tests with invalid path types to suppress type checking errors.