### PR TITLE
Refactor/ss3

### DIFF
--- a/lib/base/abstract_project.py
+++ b/lib/base/abstract_project.py
@@ -71,7 +71,7 @@ class AbstractProject(ABC):
                 self.proceed = False
             else:
                 logging.info(
-                    f"Project with ID {self.project_id} is ongoing and will be processed."
+                    f"Project with ID {self.project_id} has status '{self.status}' and will be processed."
                 )
                 self.proceed = True
 

--- a/lib/realms/smartseq3/ss3_sample.py
+++ b/lib/realms/smartseq3/ss3_sample.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from lib.base.abstract_sample import AbstractSample
 from lib.core_utils.logging_utils import custom_logger
 from lib.module_utils.report_transfer import transfer_report
@@ -26,7 +28,7 @@ class SS3Sample(AbstractSample):
         config (dict): Configuration settings.
         status (str): Current status of the sample.
         metadata (dict): Metadata for the sample.
-        sjob_manager (SlurmJobManager): Manager for submitting and monitoring Slurm jobs.
+        sjob_manager (Union[SlurmJobManager, MockSlurmJobManager]): Manager for submitting and monitoring Slurm jobs.
         file_handler (SampleFileHandler): Handler for sample files.
     """
 
@@ -69,10 +71,9 @@ class SS3Sample(AbstractSample):
 
         self.metadata = None
 
-        if DEBUG:
-            self.sjob_manager = MockSlurmJobManager()
-        else:
-            self.sjob_manager = SlurmJobManager()
+        self.sjob_manager: Union[SlurmJobManager, MockSlurmJobManager] = (
+            MockSlurmJobManager() if DEBUG else SlurmJobManager()
+        )
 
         # Initialize SampleFileHandler
         self.file_handler = SampleFileHandler(self)

--- a/lib/realms/smartseq3/ss3_sample.py
+++ b/lib/realms/smartseq3/ss3_sample.py
@@ -31,7 +31,13 @@ class SS3Sample(AbstractSample):
     """
 
     def __init__(
-        self, sample_id, sample_data, project_info, config, yggdrasil_db_manager
+        self,
+        sample_id,
+        sample_data,
+        project_info,
+        config,
+        yggdrasil_db_manager,
+        aborted: bool = False,
     ):
         """
         Initialize a SmartSeq3 sample instance.
@@ -48,6 +54,12 @@ class SS3Sample(AbstractSample):
         self.project_info = project_info
         # TODO: ensure project_id is always available
         self.project_id = self.project_info.get("project_id", "")
+        self.config = config
+        self.ydm = yggdrasil_db_manager
+
+        if aborted:
+            self._status = "aborted"
+            return
 
         # Initialize barcode
         self.barcode = self.get_barcode()
@@ -55,12 +67,6 @@ class SS3Sample(AbstractSample):
         # Collect flowcell ID
         self.flowcell_id = self._get_latest_flowcell()
 
-        self.config = config
-        self.ydm = yggdrasil_db_manager
-        # self.job_id = None
-
-        # TODO: Currently not used much, but should be used if we write to a database
-        # self._status = "initialized"
         self.metadata = None
 
         if DEBUG:
@@ -71,7 +77,10 @@ class SS3Sample(AbstractSample):
         # Initialize SampleFileHandler
         self.file_handler = SampleFileHandler(self)
 
-        self._status = "initialized"
+        if self.flowcell_id:
+            self._status = "initialized"
+        else:
+            self._status = "unsequenced"
 
     @property
     def id(self):


### PR DESCRIPTION
This pull request includes several changes to improve the handling and processing of samples in the SmartSeq3 project. The most important changes include updating logging messages, adding type hints, and refining the sample extraction and selection logic.

Improvements to logging messages:

* [`lib/base/abstract_project.py`](diffhunk://#diff-26e90429a1c5989fad504f0e49c123f619a69c29102aad2ee6a233782c67538eL74-R74): Updated the logging message to include the project status.

Enhancements to type hints and imports:

* [`lib/realms/smartseq3/ss3_project.py`](diffhunk://#diff-23f3cc940120f80dbc0da4298f4623ee1ac32d2e7d5f7f3f23b45cae543b9e80R3): Added the `List` type hint from the `typing` module.

Refinements to sample extraction and selection:

* [`lib/realms/smartseq3/ss3_project.py`](diffhunk://#diff-23f3cc940120f80dbc0da4298f4623ee1ac32d2e7d5f7f3f23b45cae543b9e80R150-R166): Updated the `launch` method to include detailed steps for gathering, registering, filtering, pre-processing, and processing samples. [[1]](diffhunk://#diff-23f3cc940120f80dbc0da4298f4623ee1ac32d2e7d5f7f3f23b45cae543b9e80R150-R166) [[2]](diffhunk://#diff-23f3cc940120f80dbc0da4298f4623ee1ac32d2e7d5f7f3f23b45cae543b9e80L177-R187) [[3]](diffhunk://#diff-23f3cc940120f80dbc0da4298f4623ee1ac32d2e7d5f7f3f23b45cae543b9e80L193-R255)
* [`lib/realms/smartseq3/ss3_project.py`](diffhunk://#diff-23f3cc940120f80dbc0da4298f4623ee1ac32d2e7d5f7f3f23b45cae543b9e80L193-R255): Modified the `extract_samples` method to gather all samples, including aborted or unsequenced ones, and added a new method `select_samples_for_processing` to filter out non-processable samples.
* [`lib/realms/smartseq3/ss3_sample.py`](diffhunk://#diff-4e7a80d2b2482b76b39abc2b02389372d35b10f12384a4840ea1d8d3fb951a27L34-R40): Updated the `SS3Sample` class constructor to handle aborted samples and set the appropriate status based on the presence of a flowcell ID. [[1]](diffhunk://#diff-4e7a80d2b2482b76b39abc2b02389372d35b10f12384a4840ea1d8d3fb951a27L34-R40) [[2]](diffhunk://#diff-4e7a80d2b2482b76b39abc2b02389372d35b10f12384a4840ea1d8d3fb951a27R57-L63) [[3]](diffhunk://#diff-4e7a80d2b2482b76b39abc2b02389372d35b10f12384a4840ea1d8d3fb951a27R80-R83)