### PR TITLE
Revert sample extraction logic to exclude aborted samples and simplif…

### DIFF
--- a/lib/realms/smartseq3/ss3_sample.py
+++ b/lib/realms/smartseq3/ss3_sample.py
@@ -33,13 +33,7 @@ class SS3Sample(AbstractSample):
     """
 
     def __init__(
-        self,
-        sample_id,
-        sample_data,
-        project_info,
-        config,
-        yggdrasil_db_manager,
-        aborted: bool = False,
+        self, sample_id, sample_data, project_info, config, yggdrasil_db_manager
     ):
         """
         Initialize a SmartSeq3 sample instance.
@@ -58,10 +52,6 @@ class SS3Sample(AbstractSample):
         self.project_id = self.project_info.get("project_id", "")
         self.config = config
         self.ydm = yggdrasil_db_manager
-
-        if aborted:
-            self._status = "aborted"
-            return
 
         # Initialize barcode
         self.barcode = self.get_barcode()


### PR DESCRIPTION
This pull request includes changes to the `lib/realms/smartseq3` module to improve the handling of samples, specifically excluding aborted samples from processing. The most important changes are the removal of the aborted sample handling logic and the update to the sample extraction process.

### Improvements to sample handling:

* [`lib/realms/smartseq3/ss3_project.py`](diffhunk://#diff-23f3cc940120f80dbc0da4298f4623ee1ac32d2e7d5f7f3f23b45cae543b9e80L205-R223): Updated the `extract_samples` method to exclude aborted samples entirely from the list of `SS3Sample` instances. Added logging to indicate when a sample is skipped due to being aborted. [[1]](diffhunk://#diff-23f3cc940120f80dbc0da4298f4623ee1ac32d2e7d5f7f3f23b45cae543b9e80L205-R223) [[2]](diffhunk://#diff-23f3cc940120f80dbc0da4298f4623ee1ac32d2e7d5f7f3f23b45cae543b9e80L232)

### Code simplification:

* [`lib/realms/smartseq3/ss3_sample.py`](diffhunk://#diff-4e7a80d2b2482b76b39abc2b02389372d35b10f12384a4840ea1d8d3fb951a27L36-R36): Removed the `aborted` parameter from the `SS3Sample` constructor and the associated logic that set the sample status to "aborted". [[1]](diffhunk://#diff-4e7a80d2b2482b76b39abc2b02389372d35b10f12384a4840ea1d8d3fb951a27L36-R36) [[2]](diffhunk://#diff-4e7a80d2b2482b76b39abc2b02389372d35b10f12384a4840ea1d8d3fb951a27L62-L65)