### PR TITLE
Update report filename to include full SmartSeq3 designation

### DIFF
--- a/lib/realms/smartseq3/utils/sample_file_handler.py
+++ b/lib/realms/smartseq3/utils/sample_file_handler.py
@@ -98,7 +98,7 @@ class SampleFileHandler:
         self.umi_stats_fpath = self.stats_dir / f"{self.plate}.umi_stats.txt"
         self.well_barcodes_fpath = self.stats_dir / f"{self.plate}.well_barcodes.txt"
         # TODO: whether PDF or HTML should be decided by the report generator
-        self.report_fpath = self.zumis_output_dir / f"{self.plate}_SS3_report.pdf"
+        self.report_fpath = self.zumis_output_dir / f"{self.plate}_SmartSeq3_report.pdf"
 
     def ensure_barcode_file(self):
         """


### PR DESCRIPTION
This pull request includes a small change to the `lib/realms/smartseq3/utils/sample_file_handler.py` file. The change updates the naming convention for the report file generated by the `init_file_paths` method.

* [`lib/realms/smartseq3/utils/sample_file_handler.py`](diffhunk://#diff-5ba933c43f51d317425c66c63acc203192e70ad4798c0e065ec7732e96c4ce8bL101-R101): Modified the `report_fpath` to use "SmartSeq3" instead of "SS3" in the report file name.