### PR TITLE
Add optional destination filename parameter to transfer_report function

### DIFF
--- a/lib/module_utils/report_transfer.py
+++ b/lib/module_utils/report_transfer.py
@@ -9,7 +9,10 @@ logging = custom_logger(__name__.split(".")[-1])
 
 
 def transfer_report(
-    report_path: Path, project_id: str, sample_id: Optional[str] = None
+    report_path: Path,
+    project_id: str,
+    sample_id: Optional[str] = None,
+    destination_filename: Optional[str] = None,
 ) -> bool:
     try:
         report_transfer_config = configs["report_transfer"]
@@ -34,7 +37,10 @@ def transfer_report(
     if sample_id:
         remote_dir = f"{remote_dir}/{sample_id}"
 
-    remote_path = f"{user}@{server}:{remote_dir}/"
+    if destination_filename:
+        remote_path = f"{user}@{server}:{remote_dir}/{destination_filename}"
+    else:
+        remote_path = f"{user}@{server}:{remote_dir}/"
 
     rsync_command = [
         "rsync",


### PR DESCRIPTION
This pull request includes changes to the `transfer_report` function in the `lib/module_utils/report_transfer.py` file. The changes introduce a new parameter to allow specifying a custom destination filename for the report transfer.

Key changes:

* [`lib/module_utils/report_transfer.py`](diffhunk://#diff-a1b73ea99a33a00ef3d18fad53586c12b92cc18303a24a0b98e319f86d7f7dbfL12-R15): Added a new optional parameter `destination_filename` to the `transfer_report` function to allow specifying a custom destination filename.
* [`lib/module_utils/report_transfer.py`](diffhunk://#diff-a1b73ea99a33a00ef3d18fad53586c12b92cc18303a24a0b98e319f86d7f7dbfR40-R42): Updated the logic in the `transfer_report` function to use the `destination_filename` if provided, otherwise defaulting to the existing behavior.