### PR TITLE
Add destination filename for report transfer

### DIFF
--- a/lib/realms/tenx/run_sample.py
+++ b/lib/realms/tenx/run_sample.py
@@ -440,6 +440,7 @@ class TenXRunSample(AbstractSample):
             report_path=self.file_handler.report_path,
             project_id=self.project_info.get("project_id", ""),
             sample_id=self.id,
+            destination_filename=self.file_handler.dest_report_name,
         ):
             logging.info(f"[{self.id}] Report transferred successfully.")
         else:

--- a/lib/realms/tenx/utils/sample_file_handler.py
+++ b/lib/realms/tenx/utils/sample_file_handler.py
@@ -49,6 +49,9 @@ class SampleFileHandler:
 
         self.fastq_files: Dict[str, Any] = {}
 
+        # Define the name the report should have when transferred to ngi-interal
+        self.dest_report_name: str = f"{self.sample_id}_10x_report.html"
+
         # Define critical file paths
         self.init_file_paths()
 


### PR DESCRIPTION
This pull request includes changes to the `lib/realms/tenx` directory to enhance the handling of report filenames. The most important changes involve adding a new attribute for the destination report name and using this attribute in the report transfer process.

Enhancements to report filename handling:

* [`lib/realms/tenx/utils/sample_file_handler.py`](diffhunk://#diff-5c96d54f1355c9f886ea5c6b9b24206931f3b39baedb841e5cc4efb4bd4d3ba0R52-R54): Added a new attribute `dest_report_name` to define the name the report should have when transferred.
* [`lib/realms/tenx/run_sample.py`](diffhunk://#diff-752bedf2961fe47eb5b6cb7afe61078f3615f2d764c1b8ef58c5861e510b68e6R443): Updated the `post_process` method to use the `dest_report_name` attribute for the destination filename during report transfer.