### PR TITLE
Refactor/core dev - add dev mode

### DIFF
--- a/lib/base/abstract_project.py
+++ b/lib/base/abstract_project.py
@@ -3,9 +3,8 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 from lib.core_utils.logging_utils import custom_logger
-
-# from lib.module_utils.sjob_manager import SlurmJobManager
-from tests.mocks.mock_sjob_manager import MockSlurmJobManager
+from lib.core_utils.ygg_mode import YggMode
+from lib.module_utils.sjob_manager import SlurmManagerFactory
 
 logging = custom_logger(__name__.split(".")[-1])
 
@@ -34,8 +33,7 @@ class AbstractProject(ABC):
             doc (Any): The document representing the project (data to be processed).
             yggdrasil_db_manager (Any): The database manager for Yggdrasil-specific database operations.
         """
-        # self.sjob_manager: SlurmJobManager = SlurmJobManager()
-        self.sjob_manager: MockSlurmJobManager = MockSlurmJobManager()
+        self.sjob_manager: Any = SlurmManagerFactory.get_manager(YggMode.is_dev())
         self.doc: Any = doc
         self.ydm: Any = yggdrasil_db_manager
         self.project_id: str = self.doc.get("project_id")

--- a/lib/core_utils/config_loader.py
+++ b/lib/core_utils/config_loader.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any, Mapping, Optional
 
 from lib.core_utils.common import YggdrasilUtilities as Ygg
+from lib.core_utils.ygg_mode import YggMode
 
 # NOTE: To use custom_logger resolve circular import issue
 
@@ -60,48 +61,50 @@ class ConfigLoader:
         """
         return self._load_config(file_name, is_path=False)
 
-    def _load_config(self, file_name, is_path=False):
+    def _load_config(self, file_name: str, is_path: bool = False) -> Mapping[str, Any]:
         """
-        Load and validate the configuration from the JSON file.
-
-        Args:
-            file_name (str): The name or path of the configuration JSON file.
-            is_path (bool): True if file_name is a path, False if it's a filename.
-
-        Returns:
-            Mapping[str, Any]: The loaded configuration data.
+        Unified method that respects dev mode for both is_path=True/False.
         """
-        config_file = Path(file_name) if is_path else Ygg.get_path(file_name)
+        # 1) Build the 'base_file' (path to config.json)
+        base_file = Path(file_name) if is_path else Ygg.get_path(file_name)
 
-        if config_file is None:
-            # Return an empty mapping if the file is not found
+        if base_file is None:
             self._config = types.MappingProxyType({})
             return self._config
 
+        # 2) If dev mode is on, try the dev counterpart (dev_myfile.suffix) in the same directory
+        if YggMode.is_dev():
+            dev_file = base_file.with_name(f"dev_{base_file.name}")
+            if dev_file.is_file():
+                logging.info(
+                    f"Dev mode ON. Loading dev config '{dev_file.name}' instead of '{base_file.name}'."
+                )
+                base_file = dev_file
+            else:
+                logging.info(
+                    f"Dev mode ON but no dev config found for '{base_file.name}'. "
+                    f"Using the original file."
+                )
+
+        # 3) Now actually load from whatever base_file points to (the dev version if it existed)
         try:
-            with open(config_file) as f:
+            with open(base_file) as f:
                 config = json.load(f)
-                # TODO: Perform validation and error checking on the loaded data if needed.
                 self._config = types.MappingProxyType(config)
         except json.JSONDecodeError as e:
             # Set config to empty immutable mapping before raising
             self._config = types.MappingProxyType({})
             raise json.JSONDecodeError(
-                f"Error parsing config file '{config_file}': {e}", e.doc, e.pos
+                f"Error parsing config file '{base_file}': {e}", e.doc, e.pos
             )
         except TypeError as e:
             # Set config to empty immutable mapping before raising
             self._config = types.MappingProxyType({})
-            raise TypeError(f"Error parsing config file '{config_file}': {e}")
+            raise TypeError(f"Error parsing config file '{base_file}': {e}")
         except Exception as e:
-            logging.error(f"Unexpected error loading config file '{config_file}': {e}")
+            logging.error(f"Unexpected error loading config file '{base_file}': {e}")
             # Set config to empty immutable mapping before raising
             self._config = types.MappingProxyType({})
             raise
 
         return self._config
-
-
-# Instantiate ConfigLoader when the module is imported
-config_manager = ConfigLoader()
-configs = config_manager.load_config("config.json")

--- a/lib/core_utils/ygg_mode.py
+++ b/lib/core_utils/ygg_mode.py
@@ -1,0 +1,30 @@
+class YggMode:
+    """
+    Manages the development mode for the application.
+
+    This class maintains and provides read-only access to whether the application
+    should run in development mode. Once set, the development mode cannot be
+    changed mid-run.
+    """
+
+    __dev_mode = False  # Development mode flag
+    __already_set = False  # Flag to prevent changing the mode mid-run
+
+    @classmethod
+    def init(cls, dev: bool):
+        """
+        Sets the development mode if it has not been set before.
+        Raises a RuntimeError when the mode is already set.
+        """
+        if cls.__already_set:
+            # raise an exception or ignore repeated calls
+            raise RuntimeError("YggMode already set. Cannot change mid-run.")
+        cls.__dev_mode = dev
+        cls.__already_set = True
+
+    @classmethod
+    def is_dev(cls) -> bool:
+        """
+        Returns True if the application is in development mode, otherwise False.
+        """
+        return cls.__dev_mode

--- a/lib/module_utils/ngi_report_generator.py
+++ b/lib/module_utils/ngi_report_generator.py
@@ -1,10 +1,12 @@
 import subprocess
-from typing import List
+from typing import Any, List, Mapping
 
-from lib.core_utils.config_loader import configs
+# from lib.core_utils.config_loader import configs
+from lib.core_utils.config_loader import ConfigLoader
 from lib.core_utils.logging_utils import custom_logger
 
 logging = custom_logger(__name__)
+configs: Mapping[str, Any] = ConfigLoader().load_config("config.json")
 
 
 def generate_ngi_report(

--- a/lib/module_utils/report_transfer.py
+++ b/lib/module_utils/report_transfer.py
@@ -1,11 +1,13 @@
 import subprocess
 from pathlib import Path
-from typing import Optional
+from typing import Any, Mapping, Optional
 
-from lib.core_utils.config_loader import configs
+# from lib.core_utils.config_loader import configs
+from lib.core_utils.config_loader import ConfigLoader
 from lib.core_utils.logging_utils import custom_logger
 
 logging = custom_logger(__name__.split(".")[-1])
+configs: Mapping[str, Any] = ConfigLoader().load_config("config.json")
 
 
 def transfer_report(

--- a/lib/module_utils/sjob_manager.py
+++ b/lib/module_utils/sjob_manager.py
@@ -4,11 +4,21 @@ import subprocess
 from pathlib import Path
 from typing import Any, Mapping, Optional, Union
 
-# from lib.core_utils.config_loader import configs
 from lib.core_utils.config_loader import ConfigLoader
 from lib.core_utils.logging_utils import custom_logger
+from tests.mocks.mock_sjob_manager import MockSlurmJobManager
 
 logging = custom_logger(__name__.split(".")[-1])
+
+
+class SlurmManagerFactory:
+    @staticmethod
+    def get_manager(is_dev: bool):
+        if is_dev:
+            return MockSlurmJobManager()
+        else:
+            return SlurmJobManager()
+
 
 #################################################################################################
 ######### CLASS BELOW ASSUMES ACCESS TO THE HOST SYSTEM TO SUBMIT SLURM JOBS ####################

--- a/lib/module_utils/sjob_manager.py
+++ b/lib/module_utils/sjob_manager.py
@@ -2,9 +2,10 @@ import asyncio
 import re
 import subprocess
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Mapping, Optional, Union
 
-from lib.core_utils.config_loader import configs
+# from lib.core_utils.config_loader import configs
+from lib.core_utils.config_loader import ConfigLoader
 from lib.core_utils.logging_utils import custom_logger
 
 logging = custom_logger(__name__.split(".")[-1])
@@ -31,6 +32,8 @@ class SlurmJobManager:
         "OUT_OF_ME+",
     ]
 
+    configs: Mapping[str, Any] = ConfigLoader().load_config("config.json")
+
     def __init__(
         self, polling_interval: float = 10.0, command_timeout: float = 8.0
     ) -> None:
@@ -42,7 +45,7 @@ class SlurmJobManager:
             command_timeout (float, optional): Timeout for Slurm commands in seconds.
                 Defaults to 8.0 seconds.
         """
-        self.polling_interval: float = configs.get(
+        self.polling_interval: float = self.configs.get(
             "job_monitor_poll_interval", polling_interval
         )
         self.command_timeout: float = command_timeout

--- a/lib/realms/smartseq3/ss3_project.py
+++ b/lib/realms/smartseq3/ss3_project.py
@@ -5,8 +5,6 @@ from typing import List
 from lib.base.abstract_project import AbstractProject
 from lib.core_utils.config_loader import ConfigLoader
 from lib.core_utils.logging_utils import custom_logger
-
-# from datetime import datetime
 from lib.module_utils.ngi_report_generator import generate_ngi_report
 from lib.realms.smartseq3.ss3_sample import SS3Sample
 

--- a/lib/realms/tenx/run_sample.py
+++ b/lib/realms/tenx/run_sample.py
@@ -4,8 +4,6 @@ from typing import Any, Dict, List, Mapping, Optional
 from lib.base.abstract_sample import AbstractSample
 from lib.core_utils.logging_utils import custom_logger
 from lib.module_utils.report_transfer import transfer_report
-
-# from lib.module_utils.sjob_manager import SlurmJobManager
 from lib.module_utils.slurm_utils import generate_slurm_script
 from lib.realms.tenx.utils.sample_file_handler import SampleFileHandler
 from lib.realms.tenx.utils.tenx_utils import TenXUtils
@@ -60,14 +58,6 @@ class TenXRunSample(AbstractSample):
         self.reference_genomes: Dict[str, str] = (
             self.collect_reference_genomes()
         ) or {}
-
-        # if DEBUG:
-        #     # Use a mock SlurmJobManager for debugging purposes
-        #     from tests.mocks.mock_sjob_manager import MockSlurmJobManager
-
-        #     self.sjob_manager: SlurmJobManager = MockSlurmJobManager()
-        # else:
-        #     self.sjob_manager = SlurmJobManager()
 
         self.file_handler: SampleFileHandler = SampleFileHandler(self)
 

--- a/tests/mocks/mock_sjob_manager.py
+++ b/tests/mocks/mock_sjob_manager.py
@@ -3,12 +3,11 @@ import random
 import string
 
 from lib.core_utils.logging_utils import custom_logger
-from lib.module_utils.sjob_manager import SlurmJobManager
 
 logging = custom_logger(__name__.split(".")[-1])
 
 
-class MockSlurmJobManager(SlurmJobManager):
+class MockSlurmJobManager:
 
     slurm_end_states = [
         "COMPLETED",

--- a/ygg-mule.py
+++ b/ygg-mule.py
@@ -152,6 +152,8 @@ def main():
         help="Indicate if this is a delivery document in Yggdrasil DB.",
     )
 
+    parser.add_argument("--dev", action="store_true", help="Enable development mode")
+
     # Parse arguments
     args = parser.parse_args()
 

--- a/ygg-mule.py
+++ b/ygg-mule.py
@@ -6,6 +6,7 @@ import asyncio
 from lib.core_utils.common import YggdrasilUtilities as Ygg
 from lib.core_utils.config_loader import ConfigLoader
 from lib.core_utils.logging_utils import configure_logging, custom_logger
+from lib.core_utils.ygg_mode import YggMode
 from lib.couchdb.project_db_manager import ProjectDBManager
 from lib.couchdb.yggdrasil_db_manager import YggdrasilDBManager
 from lib.realms.delivery.deliver import DeliveryManager
@@ -156,6 +157,9 @@ def main():
 
     # Parse arguments
     args = parser.parse_args()
+
+    # Set dev mode (if enabled)
+    YggMode.init(args.dev)
 
     # Process the document
     if args.delivery:

--- a/ygg_trunk.py
+++ b/ygg_trunk.py
@@ -1,15 +1,20 @@
 #!/usr/bin/env python
 import asyncio
 import logging
+from typing import Any, Mapping
 
 from lib.core_utils.common import YggdrasilUtilities as Ygg
-from lib.core_utils.config_loader import configs as ygg_configs
+
+# from lib.core_utils.config_loader import configs as ygg_configs
+from lib.core_utils.config_loader import ConfigLoader
 from lib.core_utils.logging_utils import configure_logging
 from lib.couchdb.project_db_manager import ProjectDBManager
 from lib.couchdb.yggdrasil_db_manager import YggdrasilDBManager
 
 # Call configure_logging to set up the logging environment
 configure_logging(debug=True)
+
+ygg_configs: Mapping[str, Any] = ConfigLoader().load_config("config.json")
 
 
 # Define asynchronous functions for task handling


### PR DESCRIPTION
This pull request introduces several changes to the codebase, focusing on the implementation of a development mode, refactoring for better configuration management, and the creation of a factory for managing Slurm jobs. Below are the most important changes:

### Development Mode Implementation:

* Added a new `YggMode` class to manage the development mode for the application, allowing the mode to be set once and preventing changes mid-run. (`lib/core_utils/ygg_mode.py`)
* Updated `ygg-mule.py` to include a command-line argument for enabling development mode and set the mode accordingly. (`ygg-mule.py`)

### Configuration Management:

* Refactored `ConfigLoader` to load different configurations based on the development mode, including loading development-specific configuration files if available. (`lib/core_utils/config_loader.py`)
* Updated various modules to use `ConfigLoader` directly instead of importing a preloaded configuration. (`lib/module_utils/ngi_report_generator.py`, `lib/module_utils/report_transfer.py`, `lib/module_utils/sjob_manager.py`, `ygg_trunk.py`) [[1]](diffhunk://#diff-aff1f85a57bc1ab53c8d696545aa6adc154761c006cc24f984223a312d0d6c5cL2-R9) [[2]](diffhunk://#diff-a1b73ea99a33a00ef3d18fad53586c12b92cc18303a24a0b98e319f86d7f7dbfL3-R10) [[3]](diffhunk://#diff-a58f474e3dbad5a4fa18d2c5d4e86955073ddd1a97b4ffab7235183870d2ae7dL5-R22) [[4]](diffhunk://#diff-00061d6e27d23df7ae5e4695a31c863f6f646bdae8ad44c20240fe4ea123a3f8R4-R18)

### Slurm Job Management:

* Introduced `SlurmManagerFactory` to dynamically provide the appropriate Slurm job manager based on the development mode. (`lib/module_utils/sjob_manager.py`)
* Refactored `MockSlurmJobManager` to no longer inherit from `SlurmJobManager`, aligning with the new factory pattern. (`tests/mocks/mock_sjob_manager.py`)

### Code Cleanup:

* Removed commented-out code and unused imports across various files to improve code readability and maintainability. (`lib/base/abstract_project.py`, `lib/realms/smartseq3/ss3_project.py`, `lib/realms/tenx/run_sample.py`) [[1]](diffhunk://#diff-26e90429a1c5989fad504f0e49c123f619a69c29102aad2ee6a233782c67538eL6-R7) [[2]](diffhunk://#diff-23f3cc940120f80dbc0da4298f4623ee1ac32d2e7d5f7f3f23b45cae543b9e80L8-L9) [[3]](diffhunk://#diff-752bedf2961fe47eb5b6cb7afe61078f3615f2d764c1b8ef58c5861e510b68e6L7-L8)