### PR TITLE
Add handling for empty project status in AbstractProject (for new inc…

### DIFF
--- a/lib/base/abstract_project.py
+++ b/lib/base/abstract_project.py
@@ -356,6 +356,8 @@ class AbstractProject(ABC):
         #     return
 
         match self.project_status:
+            case "":
+                await self._handle_main_flow()
             case "pending":
                 await self._handle_main_flow()
             case "manually_submitted_samples":


### PR DESCRIPTION
This pull request includes a change to the `launch_template` method in the `lib/base/abstract_project.py` file. The change introduces a new case in the match statement to handle an empty string status by calling the `_handle_main_flow` method.

Change details:

* [`lib/base/abstract_project.py`](diffhunk://#diff-26e90429a1c5989fad504f0e49c123f619a69c29102aad2ee6a233782c67538eR359-R360): Added a new case in the match statement to handle an empty string status in the `launch_template` method.