### PR TITLE
Fix ibm-cloudant SDK _change fetching issues by replacing it with raw GET requests

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -38,6 +38,31 @@ Yggdrasil is an event-driven orchestration framework. It watches external system
 - Evaluates `filter_expr` (JSON Logic) on each raw event to decide whether to forward it
 - Calls `build_scope()` and `build_payload()` to construct a `YggdrasilEvent` and route it to core
 
+### CouchDB backend behavior
+
+`lib/watchers/backends/couchdb.py`
+
+The CouchDB backend polls the `_changes` feed using a raw HTTP GET request (not the IBM CloudantV1 SDK).
+
+**Feed mode** — the backend starts in `feed=normal`. Once a batch is fully caught up (`pending == 0`), it switches to `feed=longpoll` to reduce polling overhead. It reverts to `feed=normal` whenever `pending > 0`.
+
+**Internal document filtering** — `_design/*` and `_local/*` documents are silently skipped. No event is emitted; the checkpoint still advances past them.
+
+**Checkpoint timing** — checkpoints advance per-row, immediately after each row is processed or intentionally skipped. On an abrupt restart, at most one event (the last emitted before shutdown) may be replayed. Downstream handlers are expected to be idempotent.
+
+**404 on a non-deleted row** — treated as a recoverable skip: no event is emitted, a `WARNING` is logged, and the checkpoint advances. The row is not retried.
+
+**Retry configuration** — transient document fetch failures (5xx, 429, network errors) are retried. The defaults can be overridden in `main.json`:
+
+```json
+"watchers": {
+  "max_observation_retries": 3,
+  "observation_retry_delay_s": 1.0
+}
+```
+
+If this block is absent, defaults are `max_observation_retries=3` and `observation_retry_delay_s=1.0`. `_changes` poll failures are retried indefinitely (no cap) to keep the daemon alive when CouchDB is temporarily unavailable.
+
 ### YggdrasilCore
 
 `lib/core_utils/yggdrasil_core.py`
@@ -73,7 +98,23 @@ Executes a `Plan` (list of `StepSpec`):
 
 ### PlanWatcher
 
+`lib/watchers/plan_watcher.py`
+
 Monitors the `yggdrasil_plans` database. When a plan document transitions to `status="approved"` and `run_token > executed_run_token`, the PlanWatcher picks it up and dispatches it to the Engine.
+
+PlanWatcher uses `ChangesFetcher` for continuous polling with `include_docs=True`, which triggers a separate `fetch_document_by_id()` call per change row so eligibility checks have the full document body available.
+
+### ChangesFetcher
+
+`lib/couchdb/changes_fetcher.py`
+
+Continuous `_changes` feed poller used by PlanWatcher. Key behaviours:
+
+- Polls via raw HTTP GET (`fetch_changes_raw`) — **not** the IBM CloudantV1 SDK — matching the proven `CouchDBBackend` transport
+- Switches between `feed=normal` (catching up, `pending > 0`) and `feed=longpoll` (caught up, `pending == 0`) to reduce overhead once current
+- Fetches full document bodies separately via `fetch_document_by_id()` when `include_docs=True`
+- Filters `_design/*` and `_local/*` documents before yielding
+- Handles transient network and server errors with exponential backoff; never permanently aborts on connection resets
 
 ---
 
@@ -141,7 +182,7 @@ Trigger events control *which handler runs*. Step events record *what happened d
 | `yggdrasil/core/` | Engine, `RealmDescriptor`, core registry |
 | `lib/core_utils/` | `YggdrasilCore`, `YggSession`, config loader, logging |
 | `lib/watchers/` | `WatcherManager`, `WatchSpec`, backends (CouchDB, filesystem) |
-| `lib/couchdb/` | Low-level CouchDB connection, document managers |
+| `lib/couchdb/` | CouchDB connection handler, document managers, `ChangesFetcher` (continuous poller), typed models (`couchdb_models.py`) |
 | `lib/realms/` | Internal realm implementations and `test_realm` (dev-only) |
 | `tests/` | Full test suite (1700+ tests) |
 

--- a/lib/couchdb/changes_fetcher.py
+++ b/lib/couchdb/changes_fetcher.py
@@ -21,6 +21,7 @@ from urllib3.exceptions import HTTPError as Urllib3HTTPError
 from urllib3.exceptions import ProtocolError
 
 from lib.core_utils.logging_utils import custom_logger
+from lib.couchdb.couchdb_models import ChangesBatch
 
 
 class ChangesFetcher:
@@ -44,6 +45,7 @@ class ChangesFetcher:
         include_docs: bool = True,
         retry_delay_sec: float = 2.0,
         max_retries: int = 3,
+        longpoll_timeout_ms: int = 60_000,
         logger: logging.Logger | None = None,
     ):
         """
@@ -54,14 +56,17 @@ class ChangesFetcher:
             include_docs: Include full documents in _changes feed (default True)
             retry_delay_sec: Delay in seconds before retrying (default 2.0)
             max_retries: Max retry attempts on transient errors (default 3)
+            longpoll_timeout_ms: CouchDB longpoll timeout in ms (default 60000)
             logger: Optional logger instance; uses module logger if None
         """
         self.db_handler = db_handler
         self.include_docs = include_docs
         self.retry_delay_sec = retry_delay_sec
         self.max_retries = max_retries
+        self.longpoll_timeout_ms = longpoll_timeout_ms
         self._logger = logger or custom_logger(f"{__name__}.{type(self).__name__}")
         self._last_seq: str | None = None
+        self._last_pending: int = 0
 
     @property
     def last_seq(self) -> str | None:
@@ -71,6 +76,8 @@ class ChangesFetcher:
     async def fetch_changes(
         self,
         since: str | None = None,
+        feed: str = "normal",
+        timeout_ms: int | None = None,
     ) -> AsyncGenerator[dict[str, Any], None]:
         """
         Fetch changes from the _changes feed, starting from 'since' seq.
@@ -80,30 +87,46 @@ class ChangesFetcher:
 
         Args:
             since: CouchDB sequence number to start from (None = start from beginning)
+            feed: CouchDB feed mode — "normal" or "longpoll" (default "normal")
+            timeout_ms: CouchDB longpoll timeout in ms; only relevant for longpoll feed
 
         Yields:
             Dict containing change entry: {"id": doc_id, "seq": seq, "doc": doc_dict, ...}
 
         Raises:
-            ApiException: On connection failures (caller handles retry logic)
+            requests.exceptions.RequestException: On poll failures from the _changes feed
+                (raised by fetch_changes_raw; caller handles retry logic)
+            ApiException: On non-404 server errors from fetch_document_by_id
+                (only when include_docs=True and the document fetch fails)
         """
         if since is None:
             since = "0"
 
-        # Single-pass batch from handler wrapper.
-        # No retry logic here; exceptions propagate to caller (stream_changes_continuously)
-        # for centralized retry/backoff handling.
-        results, last_seq = await asyncio.to_thread(
-            self.db_handler.fetch_changes_batch,
+        batch: ChangesBatch = await asyncio.to_thread(
+            self.db_handler.fetch_changes_raw,
             since=since,
-            include_docs=self.include_docs,
-            feed="normal",
+            feed=feed,
+            **({"timeout_ms": timeout_ms} if timeout_ms is not None else {}),
         )
-        self._last_seq = last_seq
+        self._last_seq = str(batch.last_seq) if batch.last_seq is not None else None
+        self._last_pending = batch.pending
 
-        for change in results:
-            if "id" in change and "seq" in change:
-                yield change
+        for row in batch.rows:
+            if row.id.startswith(("_design/", "_local/")):
+                continue
+            change: dict[str, Any] = {
+                "id": row.id,
+                "seq": row.seq,
+                "deleted": row.deleted,
+            }
+            if self.include_docs and not row.deleted:
+                doc = await asyncio.to_thread(
+                    self.db_handler.fetch_document_by_id, row.id
+                )
+                change["doc"] = (
+                    doc  # None if 404; PlanWatcher._evaluate_change handles this
+                )
+            yield change
 
     async def stream_changes_continuously(
         self,
@@ -129,17 +152,26 @@ class ChangesFetcher:
 
         current_seq = since
         retry_count = 0
+        feed_mode = "normal"
 
         while True:
             try:
                 self._logger.debug(
-                    "Polling changes from db='%s' since='%s'",
+                    "Polling changes from db='%s' since='%s' feed=%s",
                     self.db_handler.db_name,
                     current_seq,
+                    feed_mode,
                 )
 
-                # Fetch next batch
-                async for change in self.fetch_changes(since=current_seq):
+                # Fetch next batch; pass longpoll timeout when in longpoll mode
+                timeout_ms = (
+                    self.longpoll_timeout_ms if feed_mode == "longpoll" else None
+                )
+                async for change in self.fetch_changes(
+                    since=current_seq,
+                    feed=feed_mode,
+                    timeout_ms=timeout_ms,
+                ):
                     if "seq" in change:
                         current_seq = change["seq"]
                     yield change
@@ -151,31 +183,41 @@ class ChangesFetcher:
 
                 if retry_count > 0:
                     self._logger.debug(
-                        "Recovered after retries; sleeping %.1fs before next poll",
-                        poll_interval_sec,
+                        "Recovered after retries; resuming with feed=%s",
+                        feed_mode,
                     )
                 retry_count = 0
 
-            except ApiException as e:
-                if e.code == 404:
-                    # DB doesn't exist or was deleted
-                    self._logger.error(
-                        "Database '%s' not found (404)", self.db_handler.db_name
+                # Switch feed mode based on pending changes
+                new_mode = "normal" if self._last_pending > 0 else "longpoll"
+                if new_mode != feed_mode:
+                    self._logger.debug(
+                        "Feed mode: %s → %s (pending=%d)",
+                        feed_mode,
+                        new_mode,
+                        self._last_pending,
                     )
-                    raise
-                elif e.code in (500, 503):
+                    feed_mode = new_mode
+
+            except ApiException as e:
+                # ApiException can only reach here from fetch_document_by_id()
+                # (fetch_changes_raw uses requests, not the IBM SDK).
+                # fetch_document_by_id returns None for 404 and never raises it.
+                if e.status_code in (500, 503):
                     # Transient server error
                     retry_count += 1
                     if retry_count > self.max_retries:
                         self._logger.error(
-                            "Max retries (%d) exceeded; aborting continuous stream",
+                            "Max retries (%d) exceeded; backing off 60s before resuming",
                             self.max_retries,
                         )
-                        raise
+                        await asyncio.sleep(60.0)
+                        retry_count = 0
+                        continue
                     backoff = self.retry_delay_sec * (2 ** (retry_count - 1))
                     self._logger.warning(
-                        "Transient error (code=%d); retry %d/%d after %.1fs",
-                        e.code,
+                        "Transient error (status=%d); retry %d/%d after %.1fs",
+                        e.status_code,
                         retry_count,
                         self.max_retries,
                         backoff,
@@ -197,10 +239,12 @@ class ChangesFetcher:
                 retry_count += 1
                 if retry_count > self.max_retries:
                     self._logger.error(
-                        "Max retries (%d) exceeded after transient connection errors; aborting continuous stream",
+                        "Max retries (%d) exceeded; backing off 60s before resuming",
                         self.max_retries,
                     )
-                    raise
+                    await asyncio.sleep(60.0)
+                    retry_count = 0
+                    continue
                 backoff = self.retry_delay_sec * (2 ** (retry_count - 1))
                 self._logger.warning(
                     "Transient connection error; retry %d/%d after %.1fs: %s",
@@ -215,5 +259,6 @@ class ChangesFetcher:
                 self._logger.exception("Unexpected error in continuous stream: %s", e)
                 raise
 
-            # Sleep before next poll
-            await asyncio.sleep(poll_interval_sec)
+            # Only sleep between polls in normal mode; longpoll already blocks in CouchDB
+            if feed_mode == "normal":
+                await asyncio.sleep(poll_interval_sec)

--- a/lib/couchdb/couchdb_connection.py
+++ b/lib/couchdb/couchdb_connection.py
@@ -18,10 +18,12 @@ import os
 import threading
 from typing import Any
 
+import requests
 from ibm_cloud_sdk_core.api_exception import ApiException
 from ibmcloudant import CouchDbSessionAuthenticator, cloudant_v1
 
 from lib.core_utils.logging_utils import custom_logger
+from lib.couchdb.couchdb_models import ChangesBatch, ChangesRow
 
 logger = custom_logger(__name__)
 
@@ -94,6 +96,7 @@ class CouchDBClientFactory:
                 authenticator=CouchDbSessionAuthenticator(user, password)
             )
             client.set_service_url(url)
+            client.enable_retries(max_retries=3, retry_interval=5.0)
 
             # Verify connection (fail fast)
             if verify_connection:
@@ -178,11 +181,18 @@ class CouchDBHandler:
             pass_env=pass_env,
         )
 
+        # Store URL and credentials for raw HTTP requests (validated by factory above)
+        self._url: str = url.rstrip("/")
+        self._auth: tuple[str, str] = (
+            os.environ[user_env],
+            os.environ[pass_env],
+        )
+
         # Verify database exists (fail fast)
         try:
             self.server.get_database_information(db=db_name)
         except ApiException as e:
-            if e.code == 404:
+            if e.status_code == 404:
                 raise ConnectionError(f"Database {db_name} does not exist") from e
             raise
 
@@ -207,7 +217,7 @@ class CouchDBHandler:
             )
             return None
         except ApiException as e:
-            if e.code == 404:
+            if e.status_code == 404:
                 self._logger.debug(
                     "Document '%s' not found in database '%s'",
                     doc_id,
@@ -218,7 +228,7 @@ class CouchDBHandler:
                 "Cloudant API error fetching '%s' from %s: %s %s",
                 doc_id,
                 self.db_name,
-                e.code,
+                e.status_code,
                 e.message,
             )
             raise
@@ -266,7 +276,7 @@ class CouchDBHandler:
             self._logger.error(
                 "Cloudant API error in find_documents on '%s': %s %s",
                 self.db_name,
-                e.code,
+                e.status_code,
                 e.message,
             )
             raise
@@ -276,92 +286,122 @@ class CouchDBHandler:
             )
             raise
 
-    def post_changes(
+    def fetch_changes_raw(
         self,
         *,
         since: str | int | None = None,
-        include_docs: bool = True,
-        limit: int = 100,
-        feed: str | None = None,
-        timeout_ms: int | None = None,
-    ) -> dict[str, Any]:
-        """
-        Fetch changes from the database's _changes feed.
+        feed: str = "normal",
+        limit: int | None = None,
+        timeout_ms: int = 30_000,
+    ) -> ChangesBatch:
+        """Fetch one ``_changes`` batch via a raw HTTP GET request.
 
-        This is a wrapper around the CloudantV1 post_changes API,
-        providing a simpler interface for watcher backends.
+        Uses ``requests`` directly (not the IBM SDK) so that exception types are
+        predictable and classifiable by :func:`is_transient_poll_error`.
 
         Args:
-            since: Sequence token to start from (default: "0" for all changes)
-                   Accepts int for convenience; normalized to str for SDK.
-            include_docs: Include full documents in response (default: True)
-            limit: Maximum number of changes to return (default: 100)
-            feed: CouchDB feed mode (e.g. "normal", "longpoll", "continuous")
-            timeout_ms: Optional request timeout in milliseconds
+            since:      Resume token.  ``None`` is sent as ``"0"`` (from the start).
+            feed:       CouchDB feed mode — ``"normal"`` or ``"longpoll"``.
+            limit:      Maximum rows to return.  ``None`` omits the parameter.
+            timeout_ms: CouchDB-internal timeout for longpoll.  A socket-level timeout
+                        of ``timeout_ms / 1000 + 5`` is applied to the HTTP request,
+                        giving CouchDB time to respond before the socket closes.
 
         Returns:
-            Dict with 'results' (list of changes) and 'last_seq' (checkpoint)
+            Parsed :class:`ChangesBatch`.
 
         Raises:
-            ApiException: If the CouchDB API call fails
-            TypeError: If response is not a dict (unexpected SDK behavior)
+            requests.exceptions.Timeout:         Socket/read timeout.
+            requests.exceptions.ConnectionError: Network-level failure.
+            requests.exceptions.HTTPError:       Non-2xx HTTP response (after
+                                                 ``raise_for_status()``).
+            ValueError / KeyError:               Malformed JSON response.
         """
-        # Normalize since to str (SDK expects str | None)
-        if since is None:
-            since_str: str | None = None  # Let SDK use default
-        else:
-            since_str = str(since)
-
-        request: dict[str, Any] = {
-            "db": self.db_name,
-            "since": since_str,
-            "include_docs": include_docs,
-            "limit": limit,
+        url = f"{self._url}/{self.db_name}/_changes"
+        params: dict[str, Any] = {
+            "feed": feed,
+            "since": since if since is not None else "0",
+            "include_docs": "false",
         }
-        if feed is not None:
-            request["feed"] = feed
-        if timeout_ms is not None:
-            request["timeout"] = timeout_ms
+        if limit is not None:
+            params["limit"] = limit
+        if feed == "longpoll":
+            # Pass CouchDB's own timeout so it returns before the socket closes
+            params["timeout"] = timeout_ms
 
-        response = self.server.post_changes(**request)
-        result = response.get_result()
-        if isinstance(result, dict):
-            return result
-        # Unexpected SDK response - fail explicitly
-        raise TypeError(
-            f"post_changes returned non-dict result: {type(result).__name__}"
+        socket_timeout = timeout_ms / 1000 + 5  # 5 s margin beyond CouchDB timeout
+        response = requests.get(
+            url,
+            params=params,
+            auth=self._auth,
+            timeout=socket_timeout,
+        )
+        response.raise_for_status()
+
+        data: dict[str, Any] = response.json()
+        rows: list[ChangesRow] = []
+        for r in data.get("results", []):
+            changes_list = r.get("changes")
+            rev = changes_list[0]["rev"] if changes_list else None
+            rows.append(
+                ChangesRow(
+                    id=r["id"],
+                    seq=r["seq"],
+                    deleted=r.get("deleted", False),
+                    rev=rev,
+                )
+            )
+        return ChangesBatch(
+            rows=rows,
+            last_seq=data.get("last_seq"),
+            pending=int(data.get("pending", 0)),
         )
 
-    def fetch_changes_batch(
-        self,
-        *,
-        since: str | None = None,
-        include_docs: bool = True,
-        limit: int = 100,
-        feed: str = "normal",
-        timeout_ms: int | None = None,
-    ) -> tuple[list[dict[str, Any]], str | None]:
-        """Fetch one _changes batch and return ``(results, last_seq)``.
 
-        This is intentionally a single-request helper. It performs no polling,
-        retries, sleeping, or checkpointing.
-        """
-        result = self.post_changes(
-            since=since,
-            include_docs=include_docs,
-            limit=limit,
-            feed=feed,
-            timeout_ms=timeout_ms,
-        )
+def is_transient_poll_error(exc: Exception) -> bool:
+    """Return True for transient ``_changes`` polling failures (requests-based).
 
-        raw_results = result.get("results", []) if isinstance(result, dict) else []
-        if isinstance(raw_results, list):
-            results: list[dict[str, Any]] = [
-                item for item in raw_results if isinstance(item, dict)
-            ]
-        else:
-            results = []
+    Used **only** for errors raised by :meth:`CouchDBHandler.fetch_changes_raw`,
+    which uses the ``requests`` library directly.
 
-        last_seq = result.get("last_seq") if isinstance(result, dict) else None
-        last_seq_str = str(last_seq) if last_seq is not None else None
-        return results, last_seq_str
+    Classification:
+    - ``requests.Timeout`` / ``ConnectionError`` → transient (network)
+    - HTTP 5xx → transient (server-side)
+    - HTTP 4xx (other), parse errors → permanent
+    """
+    if isinstance(
+        exc, requests.exceptions.Timeout | requests.exceptions.ConnectionError
+    ):
+        return True
+    if isinstance(exc, requests.exceptions.HTTPError):
+        status = exc.response.status_code if exc.response is not None else None
+        return status is not None and status >= 500
+    return False
+
+
+def is_transient_doc_fetch_error(exc: Exception) -> bool:
+    """Return True for transient document fetch failures (IBM SDK-based).
+
+    Used **only** for errors raised by :meth:`CouchDBHandler.fetch_document_by_id`,
+    which uses the IBM CloudantV1 SDK.
+
+    Note: 404 is *not* raised by ``fetch_document_by_id`` — it returns ``None`` instead.
+    So this function will never be called for a 404.
+
+    Classification:
+    - ``ApiException`` with 5xx or 429 → transient
+    - ``ApiException`` with 4xx other → permanent
+    - ``requests.Timeout`` / ``ConnectionError`` → transient (defensive; SDK may surface these)
+    - Other exceptions → permanent
+    """
+    # Duck-type check: any exception with an integer status_code is treated as
+    # an API-style error (covers real ApiException and test mocks alike).
+    status = getattr(exc, "status_code", None)
+    if isinstance(status, int):
+        return status >= 500 or status == 429
+    # Defensive: IBM SDK may surface network failures as requests exceptions in some versions
+    if isinstance(
+        exc, requests.exceptions.Timeout | requests.exceptions.ConnectionError
+    ):
+        return True
+    return False

--- a/lib/couchdb/couchdb_models.py
+++ b/lib/couchdb/couchdb_models.py
@@ -1,0 +1,58 @@
+"""
+Typed structures for CouchDB _changes feed consumption.
+
+Kept in lib/couchdb/ alongside couchdb_connection.py because these types
+are CouchDB-specific and used by both the connection layer and the backend.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+
+
+class FeedMode(str, enum.Enum):
+    """CouchDB _changes feed mode.
+
+    String values match the ``feed=`` query-parameter values accepted by CouchDB.
+    The ``str`` mixin lets instances be passed directly as parameter values without
+    calling ``.value``.
+    """
+
+    NORMAL = "normal"
+    LONGPOLL = "longpoll"
+
+
+@dataclasses.dataclass(frozen=True)
+class ChangesRow:
+    """One row from a CouchDB _changes response.
+
+    Attributes:
+        id:      Document ID.
+        seq:     CouchDB sequence token for this change.
+        deleted: True if the document was deleted.
+        rev:     First revision token from ``changes[0].rev``.  Informational
+                 only — not used in checkpoint or dispatch logic.
+    """
+
+    id: str
+    seq: str | int
+    deleted: bool = False
+    rev: str | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class ChangesBatch:
+    """Parsed result of one CouchDB _changes HTTP response.
+
+    Attributes:
+        rows:     Parsed change rows.
+        last_seq: CouchDB sequence token representing the end of this response.
+                  Use as ``since=`` on the next poll.
+        pending:  Number of changes still waiting to be fetched.
+                  ``0`` means the feed is caught up.
+    """
+
+    rows: list[ChangesRow]
+    last_seq: str | int | None
+    pending: int

--- a/lib/watchers/backends/couchdb.py
+++ b/lib/watchers/backends/couchdb.py
@@ -5,28 +5,37 @@ This backend watches a CouchDB database's _changes feed and emits
 RawWatchEvent objects for each change.
 
 Features:
-- Polls _changes feed with configurable interval
-- Checkpoint-based resume (saves after each poll batch)
-- Delegates polling retry/backoff to ChangesFetcher
+- Polls _changes feed with raw HTTP GET (feed=normal until caught up, then longpoll)
+- Per-row checkpointing after each successfully processed or intentionally skipped row
+- Internal docs (_design/*, _local/*) silently skipped
+- 404 on non-deleted row: skip, log WARNING, advance checkpoint (no event)
+- Transient doc fetch errors retried up to max_observation_retries times
+- Non-retriable fetch errors: skip, log ERROR, advance checkpoint (no event)
 - Graceful shutdown on stop()
-- Uses existing CouchDBHandler infrastructure for connection management
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import AsyncIterator
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any
 
 from lib.core_utils.logging_utils import custom_logger
-from lib.couchdb.changes_fetcher import ChangesFetcher
-from lib.couchdb.couchdb_connection import CouchDBHandler
+from lib.couchdb.couchdb_connection import (
+    CouchDBHandler,
+    is_transient_doc_fetch_error,
+    is_transient_poll_error,
+)
+from lib.couchdb.couchdb_models import ChangesBatch, ChangesRow, FeedMode
 from lib.watchers.backends.base import CheckpointStore, RawWatchEvent, WatcherBackend
 
-if TYPE_CHECKING:
-    pass
+_INTERNAL_PREFIXES = ("_design/", "_local/")
 
-# logger = custom_logger(__name__)
+
+def _is_internal_doc(doc_id: str) -> bool:
+    """Return True if the document ID belongs to a CouchDB-internal namespace."""
+    return doc_id.startswith(_INTERNAL_PREFIXES)
 
 
 class CouchDBBackend(WatcherBackend):
@@ -38,26 +47,30 @@ class CouchDBBackend(WatcherBackend):
 
     Config schema (after resolution by WatcherManager):
         {
-            "url": str,              # CouchDB server URL (normalized with scheme)
-            "db": str,               # Database name
-            "user_env": str,         # Env var name for username
-            "pass_env": str,         # Env var name for password
-            "backend": str,          # Optional, used for validation only
-            "include_docs": bool,    # Include full doc in changes (default True)
-            "poll_interval": float,  # Seconds between polls (default 1.0)
-            "start_seq": str,        # Starting seq if no checkpoint (default "0")
-            "limit": int,            # Max changes per poll (default 100)
+            "url": str,                      # CouchDB server URL (with scheme)
+            "db": str,                       # Database name
+            "user_env": str,                 # Env var name for username
+            "pass_env": str,                 # Env var name for password
+            "backend": str,                  # Optional, used for validation only
+            "poll_interval": float,          # Seconds between normal polls (default 5.0)
+            "start_seq": str,                # Starting seq if no checkpoint (default "0")
+            "limit": int | None,             # Max changes per poll (default None)
+            "longpoll_timeout_ms": int,      # CouchDB longpoll timeout (default 60000)
+            "max_observation_retries": int,  # Doc fetch retries (default 3, from global policy)
+            "observation_retry_delay_s": float,  # Delay between retries (default 1.0)
         }
 
     Required keys: db, url, user_env, pass_env
 
     Checkpoint strategy:
-        - Checkpoints are saved after each poll batch using last_seq
-        - This is more efficient than per-event checkpointing
-        - On restart, at most one batch may be replayed (idempotency assumed)
+        Checkpoints are saved per-row, immediately after each successfully
+        processed or intentionally skipped row. On restart, at most one event
+        (the last yielded before shutdown) may be replayed; downstream handling
+        is assumed idempotent.
 
-    Retry strategy:
-        - Delegated to ChangesFetcher.stream_changes_continuously()
+    Feed mode:
+        Starts in NORMAL mode. Transitions to LONGPOLL when batch.pending == 0
+        (feed is caught up). Returns to NORMAL when pending > 0 again.
 
     Example:
         backend = CouchDBBackend(
@@ -78,13 +91,12 @@ class CouchDBBackend(WatcherBackend):
         await backend.stop()
     """
 
-    # Default configuration values
-    DEFAULT_POLL_INTERVAL = 1.0
-    DEFAULT_START_SEQ = "0"  # CouchDB _changes feed can start from "0" (from start) or "now" to only get new changes
-    DEFAULT_INCLUDE_DOCS = True
-    DEFAULT_LIMIT = 100  # Max changes to fetch per poll
-    DEFAULT_FEED = "normal"
-    DEFAULT_LONGPOLL_TIMEOUT_MS = 5000
+    DEFAULT_POLL_INTERVAL = 5.0
+    DEFAULT_START_SEQ = "0"
+    DEFAULT_LIMIT = None
+    DEFAULT_LONGPOLL_TIMEOUT_MS = 60_000
+    DEFAULT_MAX_RETRIES = 3
+    DEFAULT_RETRY_DELAY = 1.0
 
     def __init__(
         self,
@@ -99,13 +111,14 @@ class CouchDBBackend(WatcherBackend):
 
         Args:
             backend_key: Unique identifier (format: "couchdb:{connection}")
-            config: Resolved configuration with url, db, credentials
+            config: Resolved configuration with url, db, credentials, and policy keys
             checkpoint_store: Storage for checkpoint persistence
             queue_maxsize: Maximum size of internal event queue
             logger: Optional logger instance
 
         Raises:
             KeyError: If required config keys (url, db, user_env, pass_env) are missing
+            ValueError: If required config values are empty
         """
         super().__init__(
             backend_key=backend_key,
@@ -115,7 +128,6 @@ class CouchDBBackend(WatcherBackend):
             logger=logger or custom_logger(f"{__name__}.CouchDBBackend"),
         )
 
-        # Validate required config keys (must be present AND non-empty)
         required_keys = ["db", "url", "user_env", "pass_env"]
         missing = [k for k in required_keys if k not in config]
         if missing:
@@ -128,24 +140,25 @@ class CouchDBBackend(WatcherBackend):
                 f"Empty values for required config keys {empty} for backend {backend_key}"
             )
 
-        # Extract config with defaults
         self._db_name = config["db"]
         self._url = config["url"]
         self._user_env = config["user_env"]
         self._pass_env = config["pass_env"]
 
-        self._include_docs = config.get("include_docs", self.DEFAULT_INCLUDE_DOCS)
-        self._poll_interval = config.get("poll_interval", self.DEFAULT_POLL_INTERVAL)
-        self._start_seq = config.get("start_seq", self.DEFAULT_START_SEQ)
-        self._limit = config.get("limit", self.DEFAULT_LIMIT)
-        self._feed = str(config.get("feed", self.DEFAULT_FEED)).lower()
+        self._poll_interval = float(
+            config.get("poll_interval", self.DEFAULT_POLL_INTERVAL)
+        )
+        self._start_seq = str(config.get("start_seq", self.DEFAULT_START_SEQ))
+        self._limit: int | None = config.get("limit", self.DEFAULT_LIMIT)
         self._longpoll_timeout_ms = int(
             config.get("longpoll_timeout_ms", self.DEFAULT_LONGPOLL_TIMEOUT_MS)
         )
-
-        # Handler and fetcher initialized lazily in stream()
-        self._handler: CouchDBHandler | None = None
-        self._fetcher: ChangesFetcher | None = None
+        self._max_retries = int(
+            config.get("max_observation_retries", self.DEFAULT_MAX_RETRIES)
+        )
+        self._retry_delay = float(
+            config.get("observation_retry_delay_s", self.DEFAULT_RETRY_DELAY)
+        )
 
     def _create_handler(self) -> CouchDBHandler:
         """
@@ -162,118 +175,218 @@ class CouchDBBackend(WatcherBackend):
             RuntimeError: If required env var is missing
             ValueError: If URL is missing scheme
         """
-        handler_ctor = cast(Any, CouchDBHandler)
-        return handler_ctor(
+        return CouchDBHandler(
             db_name=self._db_name,
             url=self._url,
             user_env=self._user_env,
             pass_env=self._pass_env,
         )
 
-    def stream(self) -> AsyncIterator[RawWatchEvent]:
+    def _load_checkpoint_value(self) -> str | None:
+        """Return the persisted checkpoint seq, or None if no checkpoint exists."""
+        checkpoint = self.load_checkpoint()
+        if checkpoint is not None and checkpoint.value is not None:
+            return str(checkpoint.value)
+        return None
+
+    async def stream(self) -> AsyncIterator[RawWatchEvent]:  # type: ignore[override]
         """
         Yield CouchDB changes as RawWatchEvent objects.
 
-        Checkpoint strategy:
-            - Load checkpoint once at startup
-            - Save checkpoint when emitted event seq advances
+        Connects to CouchDB, then enters a polling loop:
+        - Uses NORMAL feed until caught up (pending == 0), then LONGPOLL
+        - Filters internal docs (_design/*, _local/*)
+        - Emits events for deleted rows immediately
+        - Fetches doc for non-deleted rows with retry
+        - Checkpoints after each row (processed or skipped)
+        - Retries _changes poll indefinitely on transient failures
 
-        Error handling:
-            - Handled by ChangesFetcher policy layer
-
-        No direct post_changes calls or backend-local polling loops.
+        Stops when self._running becomes False.
         """
+        self._logger.info(
+            "Starting CouchDB stream for %s (db=%s, poll_interval=%.1fs)",
+            self.backend_key,
+            self._db_name,
+            self._poll_interval,
+        )
 
-        async def _gen() -> AsyncIterator[RawWatchEvent]:
-            self._logger.info(
-                "Starting CouchDB stream for %s (db=%s, feed=%s, interval=%.1fs)",
+        try:
+            handler = self._create_handler()
+        except Exception as e:
+            self._logger.error(
+                "Failed to create CouchDB handler for %s: %s",
                 self.backend_key,
-                self._db_name,
-                self._feed,
-                self._poll_interval,
+                e,
+                exc_info=True,
             )
+            return
 
-            # Initialize handler using shared infrastructure
+        # Load checkpoint or fall back to start_seq
+        since: str | None = self._load_checkpoint_value()
+        if since is not None:
+            self._logger.info("Resuming from checkpoint seq='%s'", since)
+        else:
+            since = self._start_seq
+            self._logger.info("No checkpoint found, starting from seq='%s'", since)
+
+        feed_mode = FeedMode.NORMAL
+
+        while self._running:
+
+            # ── Poll _changes ─────────────────────────────────────────────────
             try:
-                self._handler = self._create_handler()
-            except Exception as e:
-                self._logger.error(
-                    "Failed to create CouchDB handler for %s: %s",
-                    self.backend_key,
-                    e,
-                    exc_info=True,
+                batch: ChangesBatch = await asyncio.to_thread(
+                    handler.fetch_changes_raw,
+                    since=since,
+                    feed=feed_mode.value,
+                    limit=self._limit,
+                    timeout_ms=self._longpoll_timeout_ms,
                 )
-                return
+            except Exception as exc:
+                if is_transient_poll_error(exc):
+                    self._logger.warning(
+                        "_changes poll failed (transient) for %s: %s",
+                        self.backend_key,
+                        exc,
+                    )
+                else:
+                    self._logger.error(
+                        "_changes poll failed (permanent) for %s: %s",
+                        self.backend_key,
+                        exc,
+                    )
+                await asyncio.sleep(self._retry_delay)
+                continue
 
-            self._fetcher = ChangesFetcher(
-                db_handler=self._handler,
-                include_docs=self._include_docs,
-                logger=self._logger,
-            )
-
-            # Load checkpoint or use start_seq
-            checkpoint = self.load_checkpoint()
-            # Handle None checkpoint value explicitly
-            if checkpoint and checkpoint.value is not None:
-                current_seq = str(checkpoint.value)
-                self._logger.info(
-                    "Resuming from checkpoint ='%s' (updated %s)",
-                    current_seq,
-                    checkpoint.updated_at,
+            # ── Feed mode transition ──────────────────────────────────────────
+            new_mode = FeedMode.LONGPOLL if batch.pending == 0 else FeedMode.NORMAL
+            if new_mode != feed_mode:
+                self._logger.debug(
+                    "Feed mode: %s → %s (pending=%d)",
+                    feed_mode.value,
+                    new_mode.value,
+                    batch.pending,
                 )
-            else:
-                current_seq = str(self._start_seq)
-                self._logger.info(
-                    "No checkpoint found, starting from ='%s'", current_seq
-                )
+                feed_mode = new_mode
 
-            fetcher = cast(ChangesFetcher, self._fetcher)
-
-            async for change in fetcher.stream_changes_continuously(
-                since=current_seq,
-                poll_interval_sec=self._poll_interval,
-            ):
+            # ── Process rows ──────────────────────────────────────────────────
+            for row in batch.rows:
                 if not self._running:
                     break
 
-                event = self._change_to_event(change)
+                # 1. Internal doc filter
+                if _is_internal_doc(row.id):
+                    self._logger.debug("Skipping internal doc: %s", row.id)
+                    self.save_checkpoint(row.seq)
+                    continue
+
+                # 2. Deleted row — emit without fetching doc
+                if row.deleted:
+                    event = self._change_to_event(row, doc=None)
+                    yield event
+                    self.save_checkpoint(row.seq)
+                    continue
+
+                # 3. Non-deleted row — fetch with retry
+                doc, skip = await self._fetch_doc_with_retry(
+                    handler, row, self._max_retries, self._retry_delay
+                )
+
+                if skip:
+                    # 404 or permanent error: already logged; advance checkpoint
+                    self.save_checkpoint(row.seq)
+                    continue
+
+                event = self._change_to_event(row, doc=doc)
                 yield event
+                self.save_checkpoint(row.seq)
 
-                seq = change.get("seq")
-                if seq is not None:
-                    seq_str = str(seq)
-                    if seq_str != current_seq:
-                        current_seq = seq_str
-                        self.save_checkpoint(current_seq)
+            # ── Advance since ─────────────────────────────────────────────────
+            if batch.last_seq is not None:
+                since = str(batch.last_seq)
 
-        return _gen()
+            # ── Avoid busy-loop in normal mode with no rows ───────────────────
+            if feed_mode == FeedMode.NORMAL and not batch.rows:
+                await asyncio.sleep(self._poll_interval)
 
-    def _change_to_event(self, change: dict[str, Any]) -> RawWatchEvent:
+    async def _fetch_doc_with_retry(
+        self,
+        handler: CouchDBHandler,
+        row: ChangesRow,
+        max_retries: int,
+        retry_delay: float,
+    ) -> tuple[dict[str, Any] | None, bool]:
         """
-        Convert a CouchDB _changes entry to a RawWatchEvent.
-
-        Args:
-            change: A single entry from the _changes results array
+        Fetch a document with retry logic.
 
         Returns:
-            RawWatchEvent with id, doc, seq, deleted, and meta fields
+            (doc, skip) tuple.
+            skip=False means a doc was fetched successfully.
+            skip=True means the row should be skipped (404, non-retriable, or exhausted).
         """
-        doc_id = change.get("id", "")
-        deleted = change.get("deleted", False)
-        seq = change.get("seq")
+        last_exc: Exception | None = None
 
-        # Don't include doc for deletions (it would be None anyway)
-        doc = change.get("doc") if not deleted else None
+        for attempt in range(max_retries + 1):  # 0..max_retries inclusive
+            try:
+                doc = await asyncio.to_thread(handler.fetch_document_by_id, row.id)
+                if doc is None:
+                    # 404: non-fatal, no retry
+                    self._logger.warning(
+                        "Doc %s not found (404) for non-deleted _changes row (seq=%s)",
+                        row.id,
+                        row.seq,
+                    )
+                    return None, True  # skip
+                return doc, False  # success
 
-        # Preserve additional CouchDB-specific info in meta
-        meta: dict[str, Any] = {}
-        if "changes" in change:
-            meta["changes"] = change["changes"]
+            except Exception as exc:
+                if not is_transient_doc_fetch_error(exc):
+                    # Permanent error — no retry
+                    self._logger.error(
+                        "Permanent error fetching doc %s (seq=%s): %s",
+                        row.id,
+                        row.seq,
+                        exc,
+                    )
+                    return None, True  # skip
 
+                last_exc = exc
+                if attempt < max_retries:
+                    self._logger.warning(
+                        "Transient error fetching doc %s (attempt %d/%d): %s",
+                        row.id,
+                        attempt + 1,
+                        max_retries,
+                        exc,
+                    )
+                    await asyncio.sleep(retry_delay)
+
+        # Exhausted retries
+        self._logger.error(
+            "Doc fetch for %s failed after %d retries (seq=%s): %s",
+            row.id,
+            max_retries,
+            row.seq,
+            last_exc,
+        )
+        return None, True  # skip
+
+    def _change_to_event(
+        self, row: ChangesRow, doc: dict[str, Any] | None
+    ) -> RawWatchEvent:
+        """
+        Convert a parsed ChangesRow and fetched doc to a RawWatchEvent.
+
+        Args:
+            row: Parsed change row from _changes feed
+            doc: Fetched document dict, or None for deleted rows
+
+        Returns:
+            RawWatchEvent with id, seq, deleted, and doc fields
+        """
         return RawWatchEvent(
-            id=doc_id,
+            id=row.id,
+            seq=row.seq,
+            deleted=row.deleted,
             doc=doc,
-            seq=seq,
-            deleted=deleted,
-            meta=meta,
         )

--- a/lib/watchers/manager.py
+++ b/lib/watchers/manager.py
@@ -121,6 +121,7 @@ class WatcherManager:
         on_event: Callable[[YggdrasilEvent], None] | None = None,
         checkpoint_store: CheckpointStore | None = None,
         logger: logging.Logger | None = None,
+        watcher_policy: dict[str, Any] | None = None,
     ):
         """
         Initialize the WatcherManager.
@@ -161,6 +162,7 @@ class WatcherManager:
         self._on_event = on_event
         self.checkpoint_store = checkpoint_store or CouchDBCheckpointStore()
         self._logger = logger or custom_logger(f"{__name__}.{type(self).__name__}")
+        self._watcher_policy_override = watcher_policy
 
         self._watcher_groups: dict[tuple[str, str], WatcherBackendGroup] = {}
         # BoundWatchSpecs grouped by backend group key
@@ -375,6 +377,35 @@ class WatcherManager:
     # Backend Instantiation
     # -------------------------------------------------------------------------
 
+    def _resolve_watcher_policy(self) -> dict[str, Any]:
+        """Load global watcher retry policy from ``main.json["watchers"]``.
+
+        Reads the optional top-level ``watchers`` key from the full main.json
+        config and returns a dict with defaults applied for any missing keys.
+        Falls back to all defaults if the config cannot be loaded (e.g. in tests).
+
+        Returns:
+            Dict with keys:
+            - ``max_observation_retries`` (int, default 3)
+            - ``observation_retry_delay_s`` (float, default 1.0)
+        """
+        if self._watcher_policy_override is not None:
+            raw: dict[str, Any] = self._watcher_policy_override
+        else:
+            try:
+                from lib.core_utils.config_loader import ConfigLoader
+
+                raw = ConfigLoader().load_config("main.json").get("watchers", {}) or {}
+            except Exception:
+                raw = {}
+
+        return {
+            "max_observation_retries": int(raw.get("max_observation_retries", 3)),
+            "observation_retry_delay_s": float(
+                raw.get("observation_retry_delay_s", 1.0)
+            ),
+        }
+
     def _instantiate_watcher_backends(self) -> None:
         """
         Instantiate WatcherBackend for each group.
@@ -387,6 +418,8 @@ class WatcherManager:
             KeyError: If connection config is invalid
             RuntimeError: If env var resolution fails
         """
+        policy = self._resolve_watcher_policy()
+
         for key, group in self._watcher_groups.items():
             if group.backend_instance is not None:
                 continue
@@ -409,6 +442,19 @@ class WatcherManager:
                     f"endpoint says '{endpoint_backend}'"
                 )
 
+            # Merge global watcher policy on top of connection config.
+            # Policy keys are unlikely to collide with connection-specific keys;
+            # warn if they do to surface misconfiguration early.
+            for policy_key in policy:
+                if policy_key in config:
+                    self._logger.warning(
+                        "Watcher policy key '%s' shadows a connection config key "
+                        "for connection '%s'; policy value wins.",
+                        policy_key,
+                        group.connection,
+                    )
+            config = {**config, **policy}
+
             # Stable backend_key: {backend}:{connection}
             backend_key = f"{group.backend_type}:{group.connection}"
 
@@ -428,8 +474,8 @@ class WatcherManager:
         """
         Start all registered watcher backends.
 
-        Phase 1: Starts backends only (no consumption).
-        Phase 2 will add event consumption tasks.
+        Instantiates backends (if not already done), starts them concurrently,
+        then spawns one consumer task per registered backend group.
 
         Contract:
         - Instantiates backends if not already done

--- a/lib/watchers/plan_watcher.py
+++ b/lib/watchers/plan_watcher.py
@@ -191,11 +191,6 @@ class PlanWatcher(AbstractWatcher):
         doc_id = change.get("id", "")
         doc = change.get("doc")
 
-        # Skip design documents
-        if doc_id.startswith("_design/"):
-            self._logger.debug("Skipping design document: %s", doc_id)
-            return
-
         # Skip deleted documents
         if change.get("deleted"):
             self._logger.debug("Skipping deleted document: %s", doc_id)
@@ -337,9 +332,4 @@ class PlanWatcher(AbstractWatcher):
             }
             await self.emit(payload, source="PlanWatcher:recovery")
 
-        return filtered_plans
-        return filtered_plans
-        return filtered_plans
-        return filtered_plans
-        return filtered_plans
         return filtered_plans

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "numpy>=2.0,<3.0",
     "pandas==2.3.1",
     "panzi_json_logic==1.0.1",
+    "requests>=2.31.0",
     "pdf2image==1.17.0",
     "Pillow==11.3.0",
     "reportlab==4.0.9",

--- a/requirements/lock.txt
+++ b/requirements/lock.txt
@@ -95,6 +95,7 @@ requests==2.32.5
     # via
     #   ibm-cloud-sdk-core
     #   ibmcloudant
+    #   yggdrasil (pyproject.toml)
 rich==14.0.0
     # via yggdrasil (pyproject.toml)
 ruamel-yaml==0.17.32

--- a/tests/test_changes_fetcher.py
+++ b/tests/test_changes_fetcher.py
@@ -9,16 +9,27 @@ import asyncio
 import unittest
 from unittest.mock import Mock, patch
 
+from requests.exceptions import ConnectionError as RequestsConnectionError
+
 from lib.couchdb.changes_fetcher import ChangesFetcher
+from lib.couchdb.couchdb_models import ChangesBatch, ChangesRow
 
 
 class MockApiException(Exception):
-    """Mock ApiException for testing."""
+    """Stand-in for ibm_cloud_sdk_core.api_exception.ApiException in tests."""
 
-    def __init__(self, code, message="Test error"):
+    def __init__(self, message="", status_code=None):
         super().__init__(message)
-        self.code = code
+        self.status_code = status_code
         self.message = message
+
+
+def make_batch(rows=None, last_seq="1-abc", pending=0):
+    return ChangesBatch(rows=rows or [], last_seq=last_seq, pending=pending)
+
+
+def make_row(doc_id, seq="1-abc", deleted=False):
+    return ChangesRow(id=doc_id, seq=seq, deleted=deleted)
 
 
 class TestChangesFetcher(unittest.TestCase):
@@ -28,8 +39,8 @@ class TestChangesFetcher(unittest.TestCase):
         """Set up test fixtures."""
         self.mock_db_handler = Mock()
         self.mock_db_handler.db_name = "test_db"
-        self.mock_db_handler.server = Mock()
-        self.mock_db_handler.fetch_changes_batch = Mock()
+        self.mock_db_handler.fetch_changes_raw = Mock(return_value=make_batch())
+        self.mock_db_handler.fetch_document_by_id = Mock(return_value=None)
 
     def test_checkpoint_doc_id(self):
         """Test canonical checkpoint doc ID construction."""
@@ -43,6 +54,7 @@ class TestChangesFetcher(unittest.TestCase):
         self.assertTrue(fetcher.include_docs)
         self.assertEqual(fetcher.retry_delay_sec, 2.0)
         self.assertEqual(fetcher.max_retries, 3)
+        self.assertEqual(fetcher.longpoll_timeout_ms, 60_000)
 
     def test_init_custom_params(self):
         """Test fetcher initialization with custom parameters."""
@@ -51,25 +63,26 @@ class TestChangesFetcher(unittest.TestCase):
             include_docs=False,
             retry_delay_sec=5.0,
             max_retries=5,
+            longpoll_timeout_ms=30_000,
         )
         self.assertFalse(fetcher.include_docs)
         self.assertEqual(fetcher.retry_delay_sec, 5.0)
         self.assertEqual(fetcher.max_retries, 5)
+        self.assertEqual(fetcher.longpoll_timeout_ms, 30_000)
 
     @patch("asyncio.sleep")
     def test_fetch_changes_basic(self, mock_sleep):
-        """Test basic _changes fetch without errors."""
-        # Mock response dict (feed="normal")
-        mock_results = [
-            {"id": "doc1", "seq": "1-abc", "doc": {"_id": "doc1"}},
-            {"id": "doc2", "seq": "2-def", "doc": {"_id": "doc2"}},
-        ]
+        """Test basic _changes fetch: rows yielded, docs fetched, change shape correct."""
+        doc1 = {"_id": "doc1", "data": "x"}
+        doc2 = {"_id": "doc2", "data": "y"}
+        self.mock_db_handler.fetch_changes_raw.return_value = make_batch(
+            rows=[make_row("doc1", "1-abc"), make_row("doc2", "2-def")],
+            last_seq="2-def",
+        )
+        self.mock_db_handler.fetch_document_by_id.side_effect = [doc1, doc2]
 
-        self.mock_db_handler.fetch_changes_batch.return_value = (mock_results, "2-def")
+        fetcher = ChangesFetcher(self.mock_db_handler, include_docs=True)
 
-        fetcher = ChangesFetcher(self.mock_db_handler)
-
-        # Run async test
         loop = asyncio.new_event_loop()
         try:
             changes = []
@@ -80,24 +93,28 @@ class TestChangesFetcher(unittest.TestCase):
 
             loop.run_until_complete(collect())
 
-            # Verify results
             self.assertEqual(len(changes), 2)
-            self.assertEqual(changes[0]["id"], "doc1")
-            self.assertEqual(changes[1]["id"], "doc2")
-
-            # Verify API was called correctly
-            self.mock_db_handler.fetch_changes_batch.assert_called_once()
-            call_kwargs = self.mock_db_handler.fetch_changes_batch.call_args[1]
-            self.assertEqual(call_kwargs["feed"], "normal")
-            self.assertEqual(call_kwargs["since"], "0")
-            self.assertTrue(call_kwargs["include_docs"])
+            self.assertEqual(
+                changes[0],
+                {"id": "doc1", "seq": "1-abc", "deleted": False, "doc": doc1},
+            )
+            self.assertEqual(
+                changes[1],
+                {"id": "doc2", "seq": "2-def", "deleted": False, "doc": doc2},
+            )
+            self.mock_db_handler.fetch_changes_raw.assert_called_once_with(
+                since="0", feed="normal"
+            )
+            self.assertEqual(self.mock_db_handler.fetch_document_by_id.call_count, 2)
         finally:
             loop.close()
 
     @patch("asyncio.sleep")
     def test_fetch_changes_empty(self, mock_sleep):
         """Test _changes fetch with no changes."""
-        self.mock_db_handler.fetch_changes_batch.return_value = ([], "100")
+        self.mock_db_handler.fetch_changes_raw.return_value = make_batch(
+            rows=[], last_seq="100"
+        )
 
         fetcher = ChangesFetcher(self.mock_db_handler)
 
@@ -111,21 +128,24 @@ class TestChangesFetcher(unittest.TestCase):
 
             loop.run_until_complete(collect())
             self.assertEqual(len(changes), 0)
+            self.mock_db_handler.fetch_document_by_id.assert_not_called()
         finally:
             loop.close()
 
     @patch("asyncio.sleep")
-    def test_fetch_changes_skips_invalid_json(self, mock_sleep):
-        """Test that invalid entries (missing id/seq) are skipped."""
-        mock_results = [
-            {"id": "doc1", "seq": "1-abc", "doc": {}},
-            {"seq": "2-def", "doc": {}},
-            {"id": "doc2", "seq": "3-ghi", "doc": {}},
-            {"id": "doc3"},
-        ]
-        self.mock_db_handler.fetch_changes_batch.return_value = (mock_results, "3-ghi")
+    def test_fetch_changes_filters_internal_docs(self, mock_sleep):
+        """Test that _design/ and _local/ rows are filtered before yielding."""
+        self.mock_db_handler.fetch_changes_raw.return_value = make_batch(
+            rows=[
+                make_row("_design/views", "1-abc"),
+                make_row("_local/checkpoint", "2-def"),
+                make_row("real-doc", "3-ghi"),
+            ],
+            last_seq="3-ghi",
+        )
+        self.mock_db_handler.fetch_document_by_id.return_value = {"_id": "real-doc"}
 
-        fetcher = ChangesFetcher(self.mock_db_handler)
+        fetcher = ChangesFetcher(self.mock_db_handler, include_docs=True)
 
         loop = asyncio.new_event_loop()
         try:
@@ -136,23 +156,27 @@ class TestChangesFetcher(unittest.TestCase):
                     changes.append(change)
 
             loop.run_until_complete(collect())
-            # Should only get valid changes (missing id/seq skipped)
-            self.assertEqual(len(changes), 2)
+            self.assertEqual(len(changes), 1)
+            self.assertEqual(changes[0]["id"], "real-doc")
+            self.mock_db_handler.fetch_document_by_id.assert_called_once_with(
+                "real-doc"
+            )
         finally:
             loop.close()
 
     @patch("asyncio.sleep")
-    def test_fetch_changes_skips_empty_lines(self, mock_sleep):
-        """Test that entries missing id/seq are skipped."""
-        mock_results = [
-            {"id": "doc1", "seq": "1-abc"},
-            {},
-            {"seq": "2-def"},
-            {"id": "doc2", "seq": "3-ghi"},
-        ]
-        self.mock_db_handler.fetch_changes_batch.return_value = (mock_results, "3-ghi")
+    def test_fetch_changes_deleted_skips_doc_fetch(self, mock_sleep):
+        """Test that deleted rows are yielded without fetching the document."""
+        self.mock_db_handler.fetch_changes_raw.return_value = make_batch(
+            rows=[
+                make_row("doc-alive", "1-abc", deleted=False),
+                make_row("doc-dead", "2-def", deleted=True),
+            ],
+            last_seq="2-def",
+        )
+        self.mock_db_handler.fetch_document_by_id.return_value = {"_id": "doc-alive"}
 
-        fetcher = ChangesFetcher(self.mock_db_handler)
+        fetcher = ChangesFetcher(self.mock_db_handler, include_docs=True)
 
         loop = asyncio.new_event_loop()
         try:
@@ -164,15 +188,20 @@ class TestChangesFetcher(unittest.TestCase):
 
             loop.run_until_complete(collect())
             self.assertEqual(len(changes), 2)
+            self.assertTrue(changes[1]["deleted"])
+            self.assertNotIn("doc", changes[1])
+            # fetch_document_by_id called only for the non-deleted row
+            self.mock_db_handler.fetch_document_by_id.assert_called_once_with(
+                "doc-alive"
+            )
         finally:
             loop.close()
 
-    @patch("lib.couchdb.changes_fetcher.ApiException", MockApiException)
     @patch("asyncio.sleep")
-    def test_fetch_changes_api_exception(self, mock_sleep):
-        """Test that API exceptions are re-raised."""
-        self.mock_db_handler.fetch_changes_batch.side_effect = MockApiException(
-            500, "Server error"
+    def test_fetch_changes_connection_error_propagates(self, mock_sleep):
+        """Test that connection errors from fetch_changes_raw propagate to caller."""
+        self.mock_db_handler.fetch_changes_raw.side_effect = RequestsConnectionError(
+            "Connection refused"
         )
 
         fetcher = ChangesFetcher(self.mock_db_handler)
@@ -184,7 +213,7 @@ class TestChangesFetcher(unittest.TestCase):
                 async for _ in fetcher.fetch_changes():
                     pass
 
-            with self.assertRaises(MockApiException):
+            with self.assertRaises(RequestsConnectionError):
                 loop.run_until_complete(collect())
         finally:
             loop.close()
@@ -192,14 +221,13 @@ class TestChangesFetcher(unittest.TestCase):
     @patch("asyncio.sleep")
     def test_stream_changes_continuously_single_batch(self, mock_sleep):
         """Test continuous streaming with single batch of changes."""
-        mock_results = [
-            {"id": "doc1", "seq": "1-abc"},
-            {"id": "doc2", "seq": "2-def"},
-        ]
+        self.mock_db_handler.fetch_changes_raw.return_value = make_batch(
+            rows=[make_row("doc1", "1-abc"), make_row("doc2", "2-def")],
+            last_seq="2-def",
+        )
+        self.mock_db_handler.fetch_document_by_id.return_value = {"_id": "doc"}
 
-        self.mock_db_handler.fetch_changes_batch.return_value = (mock_results, "2-def")
-
-        fetcher = ChangesFetcher(self.mock_db_handler)
+        fetcher = ChangesFetcher(self.mock_db_handler, include_docs=False)
 
         loop = asyncio.new_event_loop()
         try:
@@ -220,90 +248,392 @@ class TestChangesFetcher(unittest.TestCase):
         finally:
             loop.close()
 
-    @patch("lib.couchdb.changes_fetcher.ApiException", MockApiException)
     @patch("asyncio.sleep")
-    def test_stream_continuous_transient_error_retry(self, mock_sleep):
-        """Test retry logic on transient 500 error."""
-        # Second call succeeds
-        # Alternate between fail and success
-        self.mock_db_handler.fetch_changes_batch.side_effect = [
-            MockApiException(500, "Server error"),
-            ([{"id": "doc1", "seq": "1-abc"}], "1-abc"),
-        ]
+    def test_stream_continuous_connection_error_retries(self, mock_sleep):
+        """Test that connection errors are retried with backoff before succeeding."""
+        call_count = [0]
 
-        fetcher = ChangesFetcher(self.mock_db_handler, max_retries=3)
+        def raw_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] < 3:
+                raise RequestsConnectionError("Connection reset")
+            return make_batch(rows=[make_row("doc1", "1-abc")], last_seq="1-abc")
+
+        self.mock_db_handler.fetch_changes_raw.side_effect = raw_side_effect
+
+        fetcher = ChangesFetcher(
+            self.mock_db_handler, max_retries=3, include_docs=False
+        )
 
         loop = asyncio.new_event_loop()
         try:
             changes = []
-            call_count = [0]
 
             async def collect():
                 async for change in fetcher.stream_changes_continuously(
-                    poll_interval_sec=0.01
+                    poll_interval_sec=0.0
                 ):
                     changes.append(change)
-                    call_count[0] += 1
-                    if call_count[0] >= 1:
-                        break
+                    break
 
             loop.run_until_complete(asyncio.wait_for(collect(), timeout=2.0))
-            # Should get 1 change after retry succeeds
             self.assertEqual(len(changes), 1)
-            # Should have called fetch_changes_batch twice (fail + retry)
-            self.assertEqual(self.mock_db_handler.fetch_changes_batch.call_count, 2)
+            self.assertGreaterEqual(call_count[0], 3)
         finally:
             loop.close()
 
-    @patch("lib.couchdb.changes_fetcher.ApiException", MockApiException)
     @patch("asyncio.sleep")
-    def test_stream_continuous_max_retries_exceeded(self, mock_sleep):
-        """Test that stream stops after max retries exceeded."""
-        self.mock_db_handler.fetch_changes_batch.side_effect = MockApiException(
-            500, "Server error"
+    def test_stream_continuous_connection_reset_no_permanent_abort(self, mock_sleep):
+        """Test that ConnectionResetError backs off and resets instead of aborting."""
+        call_count = [0]
+
+        def raw_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] <= 5:
+                raise ConnectionResetError(104, "Connection reset by peer")
+            return make_batch(rows=[make_row("doc1", "1-abc")], last_seq="1-abc")
+
+        self.mock_db_handler.fetch_changes_raw.side_effect = raw_side_effect
+
+        fetcher = ChangesFetcher(
+            self.mock_db_handler, max_retries=2, include_docs=False
         )
 
-        fetcher = ChangesFetcher(self.mock_db_handler, max_retries=2)
+        loop = asyncio.new_event_loop()
+        try:
+            changes = []
+
+            async def collect():
+                async for change in fetcher.stream_changes_continuously(
+                    poll_interval_sec=0.0
+                ):
+                    changes.append(change)
+                    break
+
+            # Must NOT raise — backs off 60s (mocked), resets, and eventually succeeds
+            loop.run_until_complete(asyncio.wait_for(collect(), timeout=2.0))
+            self.assertEqual(len(changes), 1)
+            self.assertGreater(call_count[0], 3)
+        finally:
+            loop.close()
+
+    # --- last_seq property ---
+
+    def test_last_seq_initially_none(self):
+        """last_seq is None before any fetch."""
+        fetcher = ChangesFetcher(self.mock_db_handler)
+        self.assertIsNone(fetcher.last_seq)
+
+    @patch("asyncio.sleep")
+    def test_last_seq_updated_after_fetch(self, mock_sleep):
+        """last_seq reflects the batch last_seq after fetch_changes completes."""
+        self.mock_db_handler.fetch_changes_raw.return_value = make_batch(
+            rows=[], last_seq="42-xyz"
+        )
+        fetcher = ChangesFetcher(self.mock_db_handler, include_docs=False)
+
+        loop = asyncio.new_event_loop()
+        try:
+
+            async def run():
+                async for _ in fetcher.fetch_changes(since="0"):
+                    pass
+
+            loop.run_until_complete(run())
+        finally:
+            loop.close()
+
+        self.assertEqual(fetcher.last_seq, "42-xyz")
+
+    # --- cursor advancement on empty batch ---
+
+    @patch("asyncio.sleep")
+    def test_stream_advances_cursor_on_empty_batch(self, mock_sleep):
+        """Empty batch with advanced last_seq updates current_seq for next poll."""
+        call_count = [0]
+
+        def raw_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                # Empty batch but CouchDB advanced the sequence
+                return make_batch(rows=[], last_seq="50-advanced", pending=0)
+            # Second call: yield a row so we can break
+            return make_batch(
+                rows=[make_row("doc1", "51-abc")], last_seq="51-abc", pending=0
+            )
+
+        self.mock_db_handler.fetch_changes_raw.side_effect = raw_side_effect
+        fetcher = ChangesFetcher(self.mock_db_handler, include_docs=False)
+
+        loop = asyncio.new_event_loop()
+        try:
+            changes = []
+
+            async def collect():
+                async for change in fetcher.stream_changes_continuously(
+                    since="0", poll_interval_sec=0.0
+                ):
+                    changes.append(change)
+                    break
+
+            loop.run_until_complete(asyncio.wait_for(collect(), timeout=2.0))
+        finally:
+            loop.close()
+
+        # Second call must use the advanced sequence, not "0"
+        second_call_kwargs = self.mock_db_handler.fetch_changes_raw.call_args_list[1][1]
+        self.assertEqual(second_call_kwargs["since"], "50-advanced")
+
+    # --- feed mode switching ---
+
+    @patch("asyncio.sleep")
+    def test_stream_switches_to_longpoll_when_caught_up(self, mock_sleep):
+        """pending=0 causes next poll to use feed='longpoll' with timeout."""
+        call_count = [0]
+
+        def raw_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                # Caught up — no pending changes
+                return make_batch(rows=[], last_seq="10-abc", pending=0)
+            # Second poll: yield a row so test can break
+            return make_batch(
+                rows=[make_row("doc1", "11-abc")], last_seq="11-abc", pending=0
+            )
+
+        self.mock_db_handler.fetch_changes_raw.side_effect = raw_side_effect
+        fetcher = ChangesFetcher(
+            self.mock_db_handler, include_docs=False, longpoll_timeout_ms=45_000
+        )
+
+        loop = asyncio.new_event_loop()
+        try:
+            changes = []
+
+            async def collect():
+                async for change in fetcher.stream_changes_continuously(
+                    since="0", poll_interval_sec=0.0
+                ):
+                    changes.append(change)
+                    break
+
+            loop.run_until_complete(asyncio.wait_for(collect(), timeout=2.0))
+        finally:
+            loop.close()
+
+        second_call_kwargs = self.mock_db_handler.fetch_changes_raw.call_args_list[1][1]
+        self.assertEqual(second_call_kwargs["feed"], "longpoll")
+        self.assertEqual(second_call_kwargs["timeout_ms"], 45_000)
+
+    @patch("asyncio.sleep")
+    def test_stream_reverts_to_normal_on_pending(self, mock_sleep):
+        """pending>0 after longpoll causes revert to feed='normal'."""
+        call_count = [0]
+
+        def raw_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                # First: caught up → switch to longpoll
+                return make_batch(rows=[], last_seq="10-abc", pending=0)
+            if call_count[0] == 2:
+                # Second (longpoll): changes arrive, pending>0 → revert to normal
+                return make_batch(
+                    rows=[make_row("doc1", "11-abc")], last_seq="11-abc", pending=5
+                )
+            # Third: break out
+            return make_batch(
+                rows=[make_row("doc2", "12-abc")], last_seq="12-abc", pending=0
+            )
+
+        self.mock_db_handler.fetch_changes_raw.side_effect = raw_side_effect
+        fetcher = ChangesFetcher(self.mock_db_handler, include_docs=False)
+
+        loop = asyncio.new_event_loop()
+        try:
+            seen = []
+
+            async def collect():
+                async for change in fetcher.stream_changes_continuously(
+                    since="0", poll_interval_sec=0.0
+                ):
+                    seen.append(change)
+                    if len(seen) >= 2:
+                        break
+
+            loop.run_until_complete(asyncio.wait_for(collect(), timeout=2.0))
+        finally:
+            loop.close()
+
+        # Third call should be back in normal mode
+        third_call_kwargs = self.mock_db_handler.fetch_changes_raw.call_args_list[2][1]
+        self.assertEqual(third_call_kwargs["feed"], "normal")
+
+    # --- recovery log after retries ---
+
+    @patch("asyncio.sleep")
+    def test_stream_recovery_log_after_retries(self, mock_sleep):
+        """A successful poll after a retry emits the 'Recovered after retries' debug log."""
+        call_count = [0]
+
+        def raw_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise ConnectionResetError(104, "reset")
+            if call_count[0] == 2:
+                # Empty batch: inner async-for completes → recovery log fires
+                return make_batch(rows=[], last_seq="1-abc", pending=0)
+            # Third call: yield a row so we can break
+            return make_batch(rows=[make_row("doc1", "2-abc")], last_seq="2-abc")
+
+        self.mock_db_handler.fetch_changes_raw.side_effect = raw_side_effect
+        fetcher = ChangesFetcher(
+            self.mock_db_handler, max_retries=3, include_docs=False
+        )
 
         loop = asyncio.new_event_loop()
         try:
 
             async def collect():
                 async for _ in fetcher.stream_changes_continuously(
-                    poll_interval_sec=0.01
+                    poll_interval_sec=0.0
                 ):
-                    pass
+                    break
+
+            with self.assertLogs(level="DEBUG") as cm:
+                loop.run_until_complete(asyncio.wait_for(collect(), timeout=2.0))
+        finally:
+            loop.close()
+
+        messages = " ".join(cm.output)
+        self.assertIn("Recovered after retries", messages)
+
+    # --- ApiException handling ---
+
+    @patch("asyncio.sleep")
+    @patch("lib.couchdb.changes_fetcher.ApiException", MockApiException)
+    def test_stream_api_exception_transient_retries(self, mock_sleep):
+        """ApiException with status 500 is retried with exponential backoff."""
+        call_count = [0]
+        self.mock_db_handler.fetch_changes_raw.return_value = make_batch(
+            rows=[make_row("doc1", "1-abc")], last_seq="1-abc"
+        )
+
+        def doc_side_effect(doc_id):
+            call_count[0] += 1
+            if call_count[0] < 3:
+                raise MockApiException("server error", status_code=500)
+            return {"_id": doc_id}
+
+        self.mock_db_handler.fetch_document_by_id.side_effect = doc_side_effect
+        fetcher = ChangesFetcher(self.mock_db_handler, max_retries=5, include_docs=True)
+
+        loop = asyncio.new_event_loop()
+        try:
+            changes = []
+
+            async def collect():
+                async for change in fetcher.stream_changes_continuously(
+                    poll_interval_sec=0.0
+                ):
+                    changes.append(change)
+                    break
+
+            loop.run_until_complete(asyncio.wait_for(collect(), timeout=2.0))
+        finally:
+            loop.close()
+
+        self.assertEqual(len(changes), 1)
+        self.assertGreaterEqual(call_count[0], 3)
+        # asyncio.sleep must have been called for each backoff
+        self.assertGreater(mock_sleep.call_count, 0)
+
+    @patch("asyncio.sleep")
+    @patch("lib.couchdb.changes_fetcher.ApiException", MockApiException)
+    def test_stream_api_exception_max_retries_exceeded_no_abort(self, mock_sleep):
+        """ApiException max retries exceeded → 60s sleep + reset, stream continues."""
+        call_count = [0]
+        self.mock_db_handler.fetch_changes_raw.return_value = make_batch(
+            rows=[make_row("doc1", "1-abc")], last_seq="1-abc"
+        )
+
+        def doc_side_effect(doc_id):
+            call_count[0] += 1
+            # Fail 3 times (exceeds max_retries=1 on 2nd failure), then succeed
+            if call_count[0] <= 3:
+                raise MockApiException("server error", status_code=500)
+            return {"_id": doc_id}
+
+        self.mock_db_handler.fetch_document_by_id.side_effect = doc_side_effect
+        fetcher = ChangesFetcher(self.mock_db_handler, max_retries=1, include_docs=True)
+
+        loop = asyncio.new_event_loop()
+        try:
+            changes = []
+
+            async def collect():
+                async for change in fetcher.stream_changes_continuously(
+                    poll_interval_sec=0.0
+                ):
+                    changes.append(change)
+                    break
+
+            # Must NOT raise; should eventually yield after 60s sleep (mocked)
+            loop.run_until_complete(asyncio.wait_for(collect(), timeout=2.0))
+        finally:
+            loop.close()
+
+        self.assertEqual(len(changes), 1)
+        # 60s sleep must have been called at least once (when max retries exceeded)
+        sleep_calls = [c[0][0] for c in mock_sleep.call_args_list]
+        self.assertIn(60.0, sleep_calls)
+
+    @patch("asyncio.sleep")
+    @patch("lib.couchdb.changes_fetcher.ApiException", MockApiException)
+    def test_stream_api_exception_non_transient_raises(self, mock_sleep):
+        """ApiException with non-transient status (e.g. 400) is immediately re-raised."""
+        self.mock_db_handler.fetch_changes_raw.return_value = make_batch(
+            rows=[make_row("doc1", "1-abc")], last_seq="1-abc"
+        )
+        self.mock_db_handler.fetch_document_by_id.side_effect = MockApiException(
+            "bad request", status_code=400
+        )
+        fetcher = ChangesFetcher(self.mock_db_handler, include_docs=True)
+
+        loop = asyncio.new_event_loop()
+        try:
+
+            async def collect():
+                async for _ in fetcher.stream_changes_continuously(
+                    poll_interval_sec=0.0
+                ):
+                    break
 
             with self.assertRaises(MockApiException):
                 loop.run_until_complete(asyncio.wait_for(collect(), timeout=2.0))
         finally:
             loop.close()
 
-    @patch("lib.couchdb.changes_fetcher.ApiException", MockApiException)
-    @patch("asyncio.sleep")
-    def test_stream_continuous_404_error_not_retried(self, mock_sleep):
-        """Test that 404 (DB not found) is not retried."""
-        self.mock_db_handler.fetch_changes_batch.side_effect = MockApiException(
-            404, "Not found"
-        )
+    # --- generic exception catch-all ---
 
-        fetcher = ChangesFetcher(self.mock_db_handler, max_retries=3)
+    @patch("asyncio.sleep")
+    def test_stream_generic_exception_raises(self, mock_sleep):
+        """An unexpected exception (not ApiException, not network) is logged and re-raised."""
+        self.mock_db_handler.fetch_changes_raw.side_effect = ValueError(
+            "malformed JSON"
+        )
+        fetcher = ChangesFetcher(self.mock_db_handler, include_docs=False)
 
         loop = asyncio.new_event_loop()
         try:
 
             async def collect():
                 async for _ in fetcher.stream_changes_continuously(
-                    poll_interval_sec=0.01
+                    poll_interval_sec=0.0
                 ):
-                    pass
+                    break
 
-            with self.assertRaises(MockApiException) as ctx:
+            with self.assertRaises(ValueError):
                 loop.run_until_complete(asyncio.wait_for(collect(), timeout=2.0))
-
-            self.assertEqual(ctx.exception.code, 404)
-            # Should only be called once (no retries)
-            self.assertEqual(self.mock_db_handler.fetch_changes_batch.call_count, 1)
         finally:
             loop.close()
 

--- a/tests/test_db_connection_manager.py
+++ b/tests/test_db_connection_manager.py
@@ -9,14 +9,18 @@ Tests for:
 import os
 import sys
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
+
+import requests
+import requests.exceptions
 
 
 # Create mocks for IBM Cloud SDK classes
 class MockApiException(Exception):
-    def __init__(self, message, code=None):
+    def __init__(self, message="", code=None):
         super().__init__(message)
         self.code = code
+        self.status_code = code
         self.message = message
 
 
@@ -33,11 +37,25 @@ import lib.couchdb.couchdb_connection
 
 lib.couchdb.couchdb_connection.ApiException = MockApiException
 
-from lib.couchdb.couchdb_connection import CouchDBClientFactory, CouchDBHandler
+from lib.couchdb.couchdb_connection import (
+    CouchDBClientFactory,
+    CouchDBHandler,
+    is_transient_doc_fetch_error,
+    is_transient_poll_error,
+)
 
 
 class TestCouchDBClientFactory(unittest.TestCase):
     """Tests for CouchDBClientFactory."""
+
+    def setUp(self):
+        # Isolate the dedup set between tests
+        self._saved_connections = CouchDBClientFactory._logged_connections.copy()
+        CouchDBClientFactory._logged_connections.clear()
+
+    def tearDown(self):
+        CouchDBClientFactory._logged_connections.clear()
+        CouchDBClientFactory._logged_connections.update(self._saved_connections)
 
     @patch("lib.couchdb.couchdb_connection.cloudant_v1.CloudantV1")
     @patch("lib.couchdb.couchdb_connection.CouchDbSessionAuthenticator")
@@ -135,10 +153,64 @@ class TestCouchDBClientFactory(unittest.TestCase):
             )
         self.assertIn("Failed to connect", str(ctx.exception))
 
+    @patch("lib.couchdb.couchdb_connection.cloudant_v1.CloudantV1")
+    @patch("lib.couchdb.couchdb_connection.CouchDbSessionAuthenticator")
+    @patch.dict(os.environ, {"TEST_USER": "admin", "TEST_PASS": "secret"})
+    def test_create_client_non_dict_server_info_uses_unknown_version(
+        self, mock_auth, mock_cloudant
+    ):
+        """Test that non-dict server info results in version='unknown'."""
+        mock_client = MagicMock()
+        # Return a truthy non-dict value so `info or {}` keeps it and isinstance fails
+        mock_client.get_server_information.return_value.get_result.return_value = (
+            "not-a-dict"
+        )
+        mock_cloudant.return_value = mock_client
+
+        # Should not raise; just log version="unknown"
+        client = CouchDBClientFactory.create_client(
+            url="http://localhost:5984",
+            user_env="TEST_USER",
+            pass_env="TEST_PASS",
+        )
+        self.assertEqual(client, mock_client)
+
+    @patch("lib.couchdb.couchdb_connection.cloudant_v1.CloudantV1")
+    @patch("lib.couchdb.couchdb_connection.CouchDbSessionAuthenticator")
+    @patch.dict(os.environ, {"TEST_USER": "admin", "TEST_PASS": "secret"})
+    def test_create_client_dedup_logs_debug_on_reconnect(
+        self, mock_auth, mock_cloudant
+    ):
+        """Second connection to same (url, user) logs DEBUG instead of INFO."""
+        mock_client = MagicMock()
+        mock_client.get_server_information.return_value.get_result.return_value = {
+            "version": "3.1.1"
+        }
+        mock_cloudant.return_value = mock_client
+
+        with self.assertLogs("lib.couchdb.couchdb_connection", level="DEBUG") as cm:
+            CouchDBClientFactory.create_client(
+                url="http://unique-dedup.example:5984",
+                user_env="TEST_USER",
+                pass_env="TEST_PASS",
+            )
+            CouchDBClientFactory.create_client(
+                url="http://unique-dedup.example:5984",
+                user_env="TEST_USER",
+                pass_env="TEST_PASS",
+            )
+
+        messages = [r.getMessage() for r in cm.records]
+        info_msgs = [m for m in messages if "Connected to CouchDB" in m]
+        debug_msgs = [m for m in messages if "Reconnected to CouchDB" in m]
+        self.assertEqual(len(info_msgs), 1, "First connect should log INFO once")
+        self.assertEqual(len(debug_msgs), 1, "Second connect should log DEBUG once")
+
 
 class TestCouchDBHandler(unittest.TestCase):
     """Tests for CouchDBHandler."""
 
+    @patch.dict(os.environ, {"TEST_USER": "admin", "TEST_PASS": "secret"})
     @patch("lib.couchdb.couchdb_connection.CouchDBClientFactory.create_client")
     def test_init_creates_client_and_verifies_db(self, mock_create_client):
         """Test handler initialization creates client and verifies db exists."""
@@ -165,6 +237,7 @@ class TestCouchDBHandler(unittest.TestCase):
         self.assertEqual(handler.db_name, "test_db")
         self.assertEqual(handler.server, mock_client)
 
+    @patch.dict(os.environ, {"TEST_USER": "admin", "TEST_PASS": "secret"})
     @patch("lib.couchdb.couchdb_connection.CouchDBClientFactory.create_client")
     def test_init_raises_on_missing_db(self, mock_create_client):
         """Test handler raises ConnectionError if database doesn't exist."""
@@ -183,6 +256,7 @@ class TestCouchDBHandler(unittest.TestCase):
             )
         self.assertIn("does not exist", str(ctx.exception))
 
+    @patch.dict(os.environ, {"TEST_USER": "admin", "TEST_PASS": "secret"})
     @patch("lib.couchdb.couchdb_connection.CouchDBClientFactory.create_client")
     def test_fetch_document_by_id_success(self, mock_create_client):
         """Test fetching a document by ID."""
@@ -205,6 +279,7 @@ class TestCouchDBHandler(unittest.TestCase):
         mock_client.get_document.assert_called_with(db="test_db", doc_id="doc123")
         self.assertEqual(doc["_id"], "doc123")
 
+    @patch.dict(os.environ, {"TEST_USER": "admin", "TEST_PASS": "secret"})
     @patch("lib.couchdb.couchdb_connection.CouchDBClientFactory.create_client")
     def test_fetch_document_by_id_not_found(self, mock_create_client):
         """Test fetching a non-existent document returns None."""
@@ -222,15 +297,16 @@ class TestCouchDBHandler(unittest.TestCase):
         doc = handler.fetch_document_by_id("missing_doc")
         self.assertIsNone(doc)
 
+    @patch.dict(os.environ, {"TEST_USER": "admin", "TEST_PASS": "secret"})
     @patch("lib.couchdb.couchdb_connection.CouchDBClientFactory.create_client")
-    def test_post_changes_success(self, mock_create_client):
-        """Test fetching changes from database."""
+    def test_fetch_document_by_id_non_dict_response_returns_none(
+        self, mock_create_client
+    ):
+        """Test that a non-dict response from get_document returns None."""
         mock_client = MagicMock()
         mock_create_client.return_value = mock_client
-        mock_client.post_changes.return_value.get_result.return_value = {
-            "results": [{"id": "doc1", "seq": "1-abc"}],
-            "last_seq": "1-abc",
-        }
+        # Simulate SDK returning a non-dict (e.g. a string or list)
+        mock_client.get_document.return_value.get_result.return_value = "not-a-dict"
 
         handler = CouchDBHandler(
             db_name="test_db",
@@ -239,26 +315,20 @@ class TestCouchDBHandler(unittest.TestCase):
             pass_env="TEST_PASS",
         )
 
-        result = handler.post_changes(since="0", include_docs=True, limit=10)
+        doc = handler.fetch_document_by_id("some_doc")
+        self.assertIsNone(doc)
 
-        mock_client.post_changes.assert_called_with(
-            db="test_db",
-            since="0",
-            include_docs=True,
-            limit=10,
-        )
-        self.assertEqual(len(result["results"]), 1)
-        self.assertEqual(result["last_seq"], "1-abc")
-
+    @patch.dict(os.environ, {"TEST_USER": "admin", "TEST_PASS": "secret"})
     @patch("lib.couchdb.couchdb_connection.CouchDBClientFactory.create_client")
-    def test_post_changes_normalizes_since_to_string(self, mock_create_client):
-        """Test that since parameter is normalized to string."""
+    def test_fetch_document_by_id_non_404_api_exception_re_raises(
+        self, mock_create_client
+    ):
+        """Test that a non-404 ApiException from get_document is re-raised."""
         mock_client = MagicMock()
         mock_create_client.return_value = mock_client
-        mock_client.post_changes.return_value.get_result.return_value = {
-            "results": [],
-            "last_seq": "5",
-        }
+        mock_client.get_document.side_effect = MockApiException(
+            "server error", code=500
+        )
 
         handler = CouchDBHandler(
             db_name="test_db",
@@ -267,25 +337,16 @@ class TestCouchDBHandler(unittest.TestCase):
             pass_env="TEST_PASS",
         )
 
-        # Pass int, should be converted to string
-        handler.post_changes(since=5)
+        with self.assertRaises(MockApiException):
+            handler.fetch_document_by_id("some_doc")
 
-        mock_client.post_changes.assert_called_with(
-            db="test_db",
-            since="5",  # Converted to string
-            include_docs=True,
-            limit=100,
-        )
-
+    @patch.dict(os.environ, {"TEST_USER": "admin", "TEST_PASS": "secret"})
     @patch("lib.couchdb.couchdb_connection.CouchDBClientFactory.create_client")
-    def test_post_changes_passes_feed_and_timeout(self, mock_create_client):
-        """Test that feed and timeout parameters are passed through."""
+    def test_fetch_document_by_id_generic_exception_re_raises(self, mock_create_client):
+        """Test that a generic exception from get_document is re-raised."""
         mock_client = MagicMock()
         mock_create_client.return_value = mock_client
-        mock_client.post_changes.return_value.get_result.return_value = {
-            "results": [],
-            "last_seq": "10",
-        }
+        mock_client.get_document.side_effect = RuntimeError("unexpected")
 
         handler = CouchDBHandler(
             db_name="test_db",
@@ -294,62 +355,336 @@ class TestCouchDBHandler(unittest.TestCase):
             pass_env="TEST_PASS",
         )
 
-        handler.post_changes(
-            since="10",
-            include_docs=False,
-            limit=25,
-            feed="longpoll",
-            timeout_ms=1500,
-        )
+        with self.assertRaises(RuntimeError):
+            handler.fetch_document_by_id("some_doc")
 
-        mock_client.post_changes.assert_called_with(
-            db="test_db",
-            since="10",
-            include_docs=False,
-            limit=25,
-            feed="longpoll",
-            timeout=1500,
-        )
-
+    @patch.dict(os.environ, {"TEST_USER": "admin", "TEST_PASS": "secret"})
     @patch("lib.couchdb.couchdb_connection.CouchDBClientFactory.create_client")
-    def test_fetch_changes_batch_filters_results(self, mock_create_client):
-        """Test that fetch_changes_batch returns results list and last_seq."""
+    def test_init_non_404_api_exception_re_raises(self, mock_create_client):
+        """Test that a non-404 ApiException during db verification is re-raised."""
         mock_client = MagicMock()
         mock_create_client.return_value = mock_client
-
-        handler = CouchDBHandler(
-            db_name="test_db",
-            url="http://localhost:5984",
-            user_env="TEST_USER",
-            pass_env="TEST_PASS",
+        mock_client.get_database_information.side_effect = MockApiException(
+            "forbidden", code=403
         )
 
-        with patch.object(handler, "post_changes") as mock_post_changes:
-            mock_post_changes.return_value = {
-                "results": [
-                    {"id": "doc1", "seq": "1-abc"},
-                    "not-a-dict",
-                ],
-                "last_seq": 123,
-            }
-
-            results, last_seq = handler.fetch_changes_batch(
-                since="0",
-                include_docs=False,
-                limit=5,
-                feed="normal",
-                timeout_ms=2000,
+        with self.assertRaises(MockApiException):
+            CouchDBHandler(
+                db_name="test_db",
+                url="http://localhost:5984",
+                user_env="TEST_USER",
+                pass_env="TEST_PASS",
             )
 
-            self.assertEqual(results, [{"id": "doc1", "seq": "1-abc"}])
-            self.assertEqual(last_seq, "123")
-            mock_post_changes.assert_called_once_with(
-                since="0",
-                include_docs=False,
-                limit=5,
-                feed="normal",
-                timeout_ms=2000,
+    @patch.dict(os.environ, {"TEST_USER": "admin", "TEST_PASS": "secret"})
+    @patch("lib.couchdb.couchdb_connection.CouchDBClientFactory.create_client")
+    def test_find_documents_success(self, mock_create_client):
+        """Test a successful Mango query returns the docs list."""
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        mock_client.post_find.return_value.get_result.return_value = {
+            "docs": [{"_id": "a"}, {"_id": "b"}]
+        }
+
+        handler = CouchDBHandler(
+            db_name="test_db",
+            url="http://localhost:5984",
+            user_env="TEST_USER",
+            pass_env="TEST_PASS",
+        )
+
+        docs = handler.find_documents({"status": "ready"})
+        self.assertEqual(len(docs), 2)
+        self.assertEqual(docs[0]["_id"], "a")
+        mock_client.post_find.assert_called_once_with(
+            db="test_db", selector={"status": "ready"}, fields=[], limit=200
+        )
+
+    @patch.dict(os.environ, {"TEST_USER": "admin", "TEST_PASS": "secret"})
+    @patch("lib.couchdb.couchdb_connection.CouchDBClientFactory.create_client")
+    def test_find_documents_non_dict_result_returns_empty(self, mock_create_client):
+        """Test that a non-dict post_find result returns an empty list."""
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        mock_client.post_find.return_value.get_result.return_value = "unexpected"
+
+        handler = CouchDBHandler(
+            db_name="test_db",
+            url="http://localhost:5984",
+            user_env="TEST_USER",
+            pass_env="TEST_PASS",
+        )
+
+        docs = handler.find_documents({"status": "ready"})
+        self.assertEqual(docs, [])
+
+    @patch.dict(os.environ, {"TEST_USER": "admin", "TEST_PASS": "secret"})
+    @patch("lib.couchdb.couchdb_connection.CouchDBClientFactory.create_client")
+    def test_find_documents_api_exception_re_raises(self, mock_create_client):
+        """Test that an ApiException from post_find is re-raised."""
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        mock_client.post_find.side_effect = MockApiException("bad request", code=400)
+
+        handler = CouchDBHandler(
+            db_name="test_db",
+            url="http://localhost:5984",
+            user_env="TEST_USER",
+            pass_env="TEST_PASS",
+        )
+
+        with self.assertRaises(MockApiException):
+            handler.find_documents({"status": "ready"})
+
+    @patch.dict(os.environ, {"TEST_USER": "admin", "TEST_PASS": "secret"})
+    @patch("lib.couchdb.couchdb_connection.CouchDBClientFactory.create_client")
+    def test_find_documents_generic_exception_re_raises(self, mock_create_client):
+        """Test that a generic exception from post_find is re-raised."""
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        mock_client.post_find.side_effect = RuntimeError("network failure")
+
+        handler = CouchDBHandler(
+            db_name="test_db",
+            url="http://localhost:5984",
+            user_env="TEST_USER",
+            pass_env="TEST_PASS",
+        )
+
+        with self.assertRaises(RuntimeError):
+            handler.find_documents({"status": "ready"})
+
+
+class TestCouchDBHandlerFetchChangesRaw(unittest.TestCase):
+    """Tests for CouchDBHandler.fetch_changes_raw using mocked requests.get."""
+
+    def setUp(self):
+        """Create a handler with mocked factory and env vars."""
+        with (
+            patch(
+                "lib.couchdb.couchdb_connection.CouchDBClientFactory.create_client"
+            ) as mock_factory,
+            patch.dict(os.environ, {"FC_USER": "admin", "FC_PASS": "secret"}),
+        ):
+            mock_factory.return_value = MagicMock()
+            self.handler = CouchDBHandler(
+                db_name="test_db",
+                url="http://localhost:5984",
+                user_env="FC_USER",
+                pass_env="FC_PASS",
             )
+        # handler._url = "http://localhost:5984", handler._auth = ("admin", "secret")
+
+    def _make_response(self, results=None, last_seq="1-abc", pending=0):
+        """Helper: return a mock requests.Response with the given JSON payload."""
+        mock_resp = Mock()
+        mock_resp.json.return_value = {
+            "results": results or [],
+            "last_seq": last_seq,
+            "pending": pending,
+        }
+        mock_resp.raise_for_status = Mock()
+        return mock_resp
+
+    @patch("lib.couchdb.couchdb_connection.requests.get")
+    def test_fetch_changes_raw_basic(self, mock_get):
+        """Test basic success: correct URL, params, and returned ChangesBatch."""
+        mock_get.return_value = self._make_response(
+            results=[
+                {"id": "doc1", "seq": "1-abc", "changes": [{"rev": "1-r1"}]},
+            ],
+            last_seq="1-abc",
+            pending=0,
+        )
+
+        batch = self.handler.fetch_changes_raw(since="0")
+
+        mock_get.assert_called_once()
+        call_kwargs = mock_get.call_args
+        self.assertIn("http://localhost:5984/test_db/_changes", call_kwargs[0][0])
+        self.assertEqual(call_kwargs[1]["params"]["feed"], "normal")
+        self.assertEqual(call_kwargs[1]["params"]["since"], "0")
+        self.assertEqual(call_kwargs[1]["params"]["include_docs"], "false")
+        self.assertEqual(call_kwargs[1]["auth"], ("admin", "secret"))
+
+        self.assertEqual(len(batch.rows), 1)
+        self.assertEqual(batch.rows[0].id, "doc1")
+        self.assertEqual(batch.rows[0].rev, "1-r1")
+        self.assertEqual(batch.last_seq, "1-abc")
+        self.assertEqual(batch.pending, 0)
+
+    @patch("lib.couchdb.couchdb_connection.requests.get")
+    def test_fetch_changes_raw_since_none_defaults_to_zero(self, mock_get):
+        """Test that since=None sends '0' to CouchDB."""
+        mock_get.return_value = self._make_response()
+
+        self.handler.fetch_changes_raw(since=None)
+
+        params = mock_get.call_args[1]["params"]
+        self.assertEqual(params["since"], "0")
+
+    @patch("lib.couchdb.couchdb_connection.requests.get")
+    def test_fetch_changes_raw_limit_param(self, mock_get):
+        """Test that limit is included in params when specified."""
+        mock_get.return_value = self._make_response()
+
+        self.handler.fetch_changes_raw(since="0", limit=50)
+
+        params = mock_get.call_args[1]["params"]
+        self.assertEqual(params["limit"], 50)
+
+    @patch("lib.couchdb.couchdb_connection.requests.get")
+    def test_fetch_changes_raw_no_limit_omits_param(self, mock_get):
+        """Test that limit is omitted from params when not specified."""
+        mock_get.return_value = self._make_response()
+
+        self.handler.fetch_changes_raw(since="0")
+
+        params = mock_get.call_args[1]["params"]
+        self.assertNotIn("limit", params)
+
+    @patch("lib.couchdb.couchdb_connection.requests.get")
+    def test_fetch_changes_raw_longpoll_mode(self, mock_get):
+        """Test that longpoll feed adds timeout param and uses correct socket timeout."""
+        mock_get.return_value = self._make_response()
+
+        self.handler.fetch_changes_raw(since="5", feed="longpoll", timeout_ms=30_000)
+
+        call_kwargs = mock_get.call_args[1]
+        params = call_kwargs["params"]
+        self.assertEqual(params["feed"], "longpoll")
+        self.assertEqual(params["timeout"], 30_000)
+        # Socket timeout = 30_000 / 1000 + 5 = 35.0
+        self.assertAlmostEqual(call_kwargs["timeout"], 35.0)
+
+    @patch("lib.couchdb.couchdb_connection.requests.get")
+    def test_fetch_changes_raw_normal_mode_no_timeout_param(self, mock_get):
+        """Test that normal feed does not add the CouchDB timeout param."""
+        mock_get.return_value = self._make_response()
+
+        self.handler.fetch_changes_raw(since="0", feed="normal")
+
+        params = mock_get.call_args[1]["params"]
+        self.assertNotIn("timeout", params)
+
+    @patch("lib.couchdb.couchdb_connection.requests.get")
+    def test_fetch_changes_raw_deleted_row(self, mock_get):
+        """Test that deleted=True in a result row is captured correctly."""
+        mock_get.return_value = self._make_response(
+            results=[
+                {
+                    "id": "doc-deleted",
+                    "seq": "5-xyz",
+                    "deleted": True,
+                    "changes": [{"rev": "3-r"}],
+                }
+            ],
+            last_seq="5-xyz",
+        )
+
+        batch = self.handler.fetch_changes_raw(since="4")
+
+        self.assertEqual(len(batch.rows), 1)
+        self.assertTrue(batch.rows[0].deleted)
+        self.assertEqual(batch.rows[0].id, "doc-deleted")
+
+    @patch("lib.couchdb.couchdb_connection.requests.get")
+    def test_fetch_changes_raw_pending_extracted(self, mock_get):
+        """Test that the pending count is extracted from the response."""
+        mock_get.return_value = self._make_response(pending=42, last_seq="10-z")
+
+        batch = self.handler.fetch_changes_raw(since="0")
+
+        self.assertEqual(batch.pending, 42)
+        self.assertEqual(batch.last_seq, "10-z")
+
+    @patch("lib.couchdb.couchdb_connection.requests.get")
+    def test_fetch_changes_raw_row_without_changes_has_none_rev(self, mock_get):
+        """Test that a row with no changes list produces rev=None."""
+        mock_get.return_value = self._make_response(
+            results=[{"id": "doc1", "seq": "1-abc"}],  # no "changes" key
+            last_seq="1-abc",
+        )
+
+        batch = self.handler.fetch_changes_raw(since="0")
+
+        self.assertIsNone(batch.rows[0].rev)
+
+    @patch("lib.couchdb.couchdb_connection.requests.get")
+    def test_fetch_changes_raw_http_error_propagates(self, mock_get):
+        """Test that an HTTP error from raise_for_status propagates."""
+        mock_resp = Mock()
+        mock_resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            response=Mock(status_code=503)
+        )
+        mock_get.return_value = mock_resp
+
+        with self.assertRaises(requests.exceptions.HTTPError):
+            self.handler.fetch_changes_raw(since="0")
+
+
+class TestTransientErrorClassifiers(unittest.TestCase):
+    """Tests for is_transient_poll_error and is_transient_doc_fetch_error."""
+
+    # --- is_transient_poll_error ---
+
+    def test_poll_error_requests_timeout_is_transient(self):
+        self.assertTrue(is_transient_poll_error(requests.exceptions.Timeout()))
+
+    def test_poll_error_requests_connection_error_is_transient(self):
+        self.assertTrue(is_transient_poll_error(requests.exceptions.ConnectionError()))
+
+    def test_poll_error_5xx_http_error_is_transient(self):
+        resp = Mock()
+        resp.status_code = 503
+        exc = requests.exceptions.HTTPError(response=resp)
+        self.assertTrue(is_transient_poll_error(exc))
+
+    def test_poll_error_4xx_http_error_is_not_transient(self):
+        resp = Mock()
+        resp.status_code = 404
+        exc = requests.exceptions.HTTPError(response=resp)
+        self.assertFalse(is_transient_poll_error(exc))
+
+    def test_poll_error_http_error_no_response_is_not_transient(self):
+        exc = requests.exceptions.HTTPError(response=None)
+        self.assertFalse(is_transient_poll_error(exc))
+
+    def test_poll_error_generic_exception_is_not_transient(self):
+        self.assertFalse(is_transient_poll_error(ValueError("unexpected")))
+
+    # --- is_transient_doc_fetch_error ---
+
+    def test_doc_fetch_error_500_is_transient(self):
+        exc = MockApiException("server error", code=500)
+        self.assertTrue(is_transient_doc_fetch_error(exc))
+
+    def test_doc_fetch_error_503_is_transient(self):
+        exc = MockApiException("unavailable", code=503)
+        self.assertTrue(is_transient_doc_fetch_error(exc))
+
+    def test_doc_fetch_error_429_is_transient(self):
+        exc = MockApiException("rate limited", code=429)
+        self.assertTrue(is_transient_doc_fetch_error(exc))
+
+    def test_doc_fetch_error_404_is_not_transient(self):
+        exc = MockApiException("not found", code=404)
+        self.assertFalse(is_transient_doc_fetch_error(exc))
+
+    def test_doc_fetch_error_400_is_not_transient(self):
+        exc = MockApiException("bad request", code=400)
+        self.assertFalse(is_transient_doc_fetch_error(exc))
+
+    def test_doc_fetch_error_requests_timeout_is_transient(self):
+        self.assertTrue(is_transient_doc_fetch_error(requests.exceptions.Timeout()))
+
+    def test_doc_fetch_error_requests_connection_error_is_transient(self):
+        self.assertTrue(
+            is_transient_doc_fetch_error(requests.exceptions.ConnectionError())
+        )
+
+    def test_doc_fetch_error_generic_exception_is_not_transient(self):
+        self.assertFalse(is_transient_doc_fetch_error(RuntimeError("unexpected")))
 
 
 if __name__ == "__main__":

--- a/tests/test_plan_db_manager.py
+++ b/tests/test_plan_db_manager.py
@@ -10,6 +10,7 @@ are replaced with MagicMock instances. These are false positives and can be igno
 The tests run correctly despite these warnings.
 """
 
+import os
 import unittest
 from unittest.mock import MagicMock, Mock, patch
 
@@ -58,6 +59,13 @@ class TestPlanDBManager(unittest.TestCase):
         )
         self.client_factory_patcher.start()
 
+        # Provide env vars required by CouchDBHandler.__init__
+        self.env_patcher = patch.dict(
+            os.environ,
+            {"MOCK_COUCH_USER": "mock_user", "MOCK_COUCH_PASS": "mock_pass"},
+        )
+        self.env_patcher.start()
+
         # Create manager instance (will use mocked client factory)
         self.manager = PlanDBManager()
 
@@ -80,6 +88,7 @@ class TestPlanDBManager(unittest.TestCase):
         """Clean up patches."""
         self.config_patcher.stop()
         self.client_factory_patcher.stop()
+        self.env_patcher.stop()
 
     # ==========================================
     # save_plan Tests

--- a/tests/test_yggdrasil_db_manager.py
+++ b/tests/test_yggdrasil_db_manager.py
@@ -5,9 +5,10 @@ from unittest.mock import ANY, MagicMock, patch
 
 # Mock IBM Cloud SDK modules before importing the module under test
 class MockApiException(Exception):
-    def __init__(self, message, code=None):
+    def __init__(self, message="", code=None):
         super().__init__(message)
         self.code = code
+        self.status_code = code
         self.message = message
 
 

--- a/tests/watchers/backends/test_couchdb.py
+++ b/tests/watchers/backends/test_couchdb.py
@@ -1,24 +1,19 @@
 """
-Unit tests for lib.watchers.backends.couchdb module.
+Unit tests for lib.watchers.backends.couchdb module — init and config.
 
-Tests the CouchDBBackend implementation with mocked CouchDB client.
+Polling, retry, and stream behavior is covered in test_couchdb_backend.py.
 """
 
-import asyncio
 import unittest
-from unittest.mock import AsyncMock, MagicMock, patch
 
-from lib.couchdb.changes_fetcher import ApiException
-from lib.watchers.backends.base import Checkpoint
 from lib.watchers.backends.checkpoint_store import InMemoryCheckpointStore
 from lib.watchers.backends.couchdb import CouchDBBackend
 
 
 class TestCouchDBBackendInit(unittest.TestCase):
-    """Tests for CouchDBBackend initialization."""
+    """Tests for CouchDBBackend initialization and config validation."""
 
     def setUp(self):
-        """Set up test fixtures."""
         self.store = InMemoryCheckpointStore()
         self.base_config = {
             "url": "https://couch.example.org",
@@ -28,7 +23,6 @@ class TestCouchDBBackendInit(unittest.TestCase):
         }
 
     def test_backend_key_format(self):
-        """Test backend_key is stored correctly."""
         backend = CouchDBBackend(
             backend_key="couchdb:projects",
             config=self.base_config,
@@ -37,12 +31,11 @@ class TestCouchDBBackendInit(unittest.TestCase):
         self.assertEqual(backend.backend_key, "couchdb:projects")
 
     def test_required_config_db(self):
-        """Test that 'db' is required in config."""
         config = {
             "url": "https://couch.example.org",
             "user_env": "TEST_COUCH_USER",
             "pass_env": "TEST_COUCH_PASS",
-        }  # Missing 'db'
+        }
         with self.assertRaises(KeyError) as ctx:
             CouchDBBackend(
                 backend_key="couchdb:test",
@@ -52,12 +45,11 @@ class TestCouchDBBackendInit(unittest.TestCase):
         self.assertIn("db", str(ctx.exception))
 
     def test_required_config_user_env(self):
-        """Test that 'user_env' is required in config."""
         config = {
             "url": "https://couch.example.org",
             "db": "test_db",
             "pass_env": "TEST_COUCH_PASS",
-        }  # Missing 'user_env'
+        }
         with self.assertRaises(KeyError) as ctx:
             CouchDBBackend(
                 backend_key="couchdb:test",
@@ -67,12 +59,11 @@ class TestCouchDBBackendInit(unittest.TestCase):
         self.assertIn("user_env", str(ctx.exception))
 
     def test_required_config_pass_env(self):
-        """Test that 'pass_env' is required in config."""
         config = {
             "url": "https://couch.example.org",
             "db": "test_db",
             "user_env": "TEST_COUCH_USER",
-        }  # Missing 'pass_env'
+        }
         with self.assertRaises(KeyError) as ctx:
             CouchDBBackend(
                 backend_key="couchdb:test",
@@ -82,369 +73,51 @@ class TestCouchDBBackendInit(unittest.TestCase):
         self.assertIn("pass_env", str(ctx.exception))
 
     def test_default_config_values(self):
-        """Test default config values are applied."""
         backend = CouchDBBackend(
             backend_key="couchdb:projects",
             config=self.base_config,
             checkpoint_store=self.store,
         )
         self.assertEqual(backend._db_name, "projects")
-        self.assertTrue(backend._include_docs)
-        self.assertEqual(backend._poll_interval, 1.0)
-        self.assertEqual(backend._start_seq, "0")  # DEFAULT_START_SEQ
-        self.assertEqual(backend._limit, 100)
-        self.assertEqual(backend._feed, "normal")
-        self.assertEqual(backend._longpoll_timeout_ms, 5000)
+        self.assertEqual(backend._poll_interval, CouchDBBackend.DEFAULT_POLL_INTERVAL)
+        self.assertEqual(backend._start_seq, CouchDBBackend.DEFAULT_START_SEQ)
+        self.assertIsNone(backend._limit)
+        self.assertEqual(
+            backend._longpoll_timeout_ms, CouchDBBackend.DEFAULT_LONGPOLL_TIMEOUT_MS
+        )
+        self.assertEqual(backend._max_retries, CouchDBBackend.DEFAULT_MAX_RETRIES)
+        self.assertEqual(backend._retry_delay, CouchDBBackend.DEFAULT_RETRY_DELAY)
 
     def test_custom_config_values(self):
-        """Test custom config values are respected."""
         config = {
-            "url": "https://couch.example.org",
-            "db": "projects",
-            "user_env": "TEST_COUCH_USER",
-            "pass_env": "TEST_COUCH_PASS",
-            "include_docs": False,
+            **self.base_config,
             "poll_interval": 10.0,
             "start_seq": "100-abc",
             "limit": 500,
+            "longpoll_timeout_ms": 30_000,
+            "max_observation_retries": 5,
+            "observation_retry_delay_s": 2.0,
         }
         backend = CouchDBBackend(
             backend_key="couchdb:projects",
             config=config,
             checkpoint_store=self.store,
         )
-        self.assertFalse(backend._include_docs)
         self.assertEqual(backend._poll_interval, 10.0)
         self.assertEqual(backend._start_seq, "100-abc")
         self.assertEqual(backend._limit, 500)
+        self.assertEqual(backend._longpoll_timeout_ms, 30_000)
+        self.assertEqual(backend._max_retries, 5)
+        self.assertEqual(backend._retry_delay, 2.0)
 
-
-class TestCouchDBBackendPolling(unittest.TestCase):
-    """Tests for CouchDBBackend polling behavior."""
-
-    def setUp(self):
-        """Set up test fixtures."""
-        self.store = InMemoryCheckpointStore()
-        self.config = {
-            "url": "https://couch.example.org",
-            "db": "testdb",
-            "user_env": "TEST_COUCH_USER",
-            "pass_env": "TEST_COUCH_PASS",
-        }
-
-    @patch.object(CouchDBBackend, "_create_handler")
-    def test_poll_yields_raw_watch_events(self, mock_create_handler):
-        """Test that polling yields RawWatchEvent objects."""
-        # Set up mock handler
-        mock_handler = MagicMock()
-        mock_create_handler.return_value = mock_handler
-
-        responses = [
-            (
-                [
-                    {
-                        "id": "doc1",
-                        "seq": "1-abc",
-                        "doc": {"_id": "doc1", "type": "project"},
-                    },
-                    {"id": "doc2", "seq": "2-def", "deleted": True, "doc": None},
-                ],
-                "2-def",
-            ),
-            ([], "2-def"),
-        ]
-
-        def _batch(**kwargs):
-            if responses:
-                return responses.pop(0)
-            return ([], "2-def")
-
-        mock_handler.fetch_changes_batch.side_effect = _batch
-
-        async def run_test():
-            backend = CouchDBBackend(
-                backend_key="couchdb:testdb",
-                config=self.config,
+    def test_empty_required_value_raises(self):
+        config = {**self.base_config, "db": ""}
+        with self.assertRaises(ValueError):
+            CouchDBBackend(
+                backend_key="couchdb:test",
+                config=config,
                 checkpoint_store=self.store,
             )
-
-            await backend.start()
-
-            events = []
-            async for event in backend.events():
-                events.append(event)
-                if len(events) >= 2:
-                    await backend.stop()
-                    break
-
-            self.assertEqual(len(events), 2)
-            self.assertEqual(events[0].id, "doc1")
-            self.assertEqual(events[0].seq, "1-abc")
-            self.assertFalse(events[0].deleted)
-            self.assertIsNotNone(events[0].doc)
-
-            self.assertEqual(events[1].id, "doc2")
-            self.assertTrue(events[1].deleted)
-
-        asyncio.run(run_test())
-
-    @patch.object(CouchDBBackend, "_create_handler")
-    def test_loads_checkpoint_on_start(self, mock_create_handler):
-        """Test that backend loads checkpoint on start."""
-        mock_handler = MagicMock()
-        mock_create_handler.return_value = mock_handler
-
-        # Pre-save a checkpoint
-        cp = Checkpoint(
-            backend_key="couchdb:testdb",
-            value="saved-seq-123",
-            updated_at="2024-01-15T12:00:00Z",
-        )
-        self.store.save(cp)
-
-        # Mock empty response (no new changes)
-        mock_handler.fetch_changes_batch.return_value = ([], "saved-seq-123")
-
-        async def run_test():
-            backend = CouchDBBackend(
-                backend_key="couchdb:testdb",
-                config=self.config,
-                checkpoint_store=self.store,
-            )
-
-            await backend.start()
-            await asyncio.sleep(0.1)
-            await backend.stop()
-
-            # Verify batch fetch was called with saved checkpoint
-            call_args = mock_handler.fetch_changes_batch.call_args
-            self.assertEqual(call_args.kwargs.get("since"), "saved-seq-123")
-            self.assertEqual(call_args.kwargs.get("feed"), "normal")
-
-        asyncio.run(run_test())
-
-    @patch.object(CouchDBBackend, "_create_handler")
-    def test_saves_checkpoint_after_batch(self, mock_create_handler):
-        """Test that backend saves checkpoint after processing batch."""
-        mock_handler = MagicMock()
-        mock_create_handler.return_value = mock_handler
-
-        mock_handler.fetch_changes_batch.return_value = (
-            [{"id": "doc1", "seq": "100-abc", "doc": {"_id": "doc1"}}],
-            "100-abc",
-        )
-
-        async def run_test():
-            backend = CouchDBBackend(
-                backend_key="couchdb:testdb",
-                config=self.config,
-                checkpoint_store=self.store,
-            )
-
-            await backend.start()
-
-            # Consume one event
-            async for event in backend.events():
-                break
-
-            await backend.stop()
-
-            # Verify checkpoint was saved with last_seq
-            saved = self.store.load("couchdb:testdb")
-            self.assertIsNotNone(saved)
-            assert saved is not None  # Help mypy understand the guard
-            self.assertEqual(saved.value, "100-abc")
-
-        asyncio.run(run_test())
-
-    @patch.object(CouchDBBackend, "_create_handler")
-    @patch.object(CouchDBBackend, "save_checkpoint")
-    def test_does_not_save_checkpoint_when_last_seq_unchanged(
-        self, mock_save_checkpoint, mock_create_handler
-    ):
-        """Test that checkpoint is not persisted when last_seq has not advanced."""
-        mock_handler = MagicMock()
-        mock_create_handler.return_value = mock_handler
-
-        # Pre-save checkpoint so backend starts from this seq.
-        cp = Checkpoint(
-            backend_key="couchdb:testdb",
-            value="saved-seq-123",
-            updated_at="2024-01-15T12:00:00Z",
-        )
-        self.store.save(cp)
-
-        # No new changes and same last_seq should not trigger a checkpoint write.
-        mock_handler.fetch_changes_batch.return_value = ([], "saved-seq-123")
-
-        async def run_test():
-            backend = CouchDBBackend(
-                backend_key="couchdb:testdb",
-                config=self.config,
-                checkpoint_store=self.store,
-            )
-
-            await backend.start()
-            await asyncio.sleep(0.05)
-            await backend.stop()
-
-            mock_save_checkpoint.assert_not_called()
-
-        asyncio.run(run_test())
-
-
-class TestCouchDBBackendRetry(unittest.TestCase):
-    """Tests for CouchDBBackend retry behavior."""
-
-    def setUp(self):
-        """Set up test fixtures."""
-        self.store = InMemoryCheckpointStore()
-        self.config = {
-            "url": "https://couch.example.org",
-            "db": "testdb",
-            "user_env": "TEST_COUCH_USER",
-            "pass_env": "TEST_COUCH_PASS",
-        }
-
-    @patch.object(CouchDBBackend, "_create_handler")
-    @patch("lib.couchdb.changes_fetcher.asyncio.sleep", new_callable=AsyncMock)
-    def test_retries_on_connection_error(self, mock_sleep, mock_create_handler):
-        """Test that backend retries on connection errors."""
-        mock_handler = MagicMock()
-        mock_handler.db_name = "testdb"  # Required by ChangesFetcher logging
-        mock_create_handler.return_value = mock_handler
-
-        # Use a call counter stored in a list to avoid threading issues with nonlocal
-        call_tracker = {"count": 0}
-
-        def mock_fetch_changes_batch(**kwargs):
-            call_tracker["count"] += 1
-            if call_tracker["count"] <= 2:
-                raise ApiException(code=503, message="Service Unavailable")
-            # Return success on 3rd+ call
-            return ([{"id": "doc1", "seq": "1-abc"}], "1-abc")
-
-        mock_handler.fetch_changes_batch.side_effect = mock_fetch_changes_batch
-
-        async def run_test():
-            backend = CouchDBBackend(
-                backend_key="couchdb:testdb",
-                config=self.config,
-                checkpoint_store=self.store,
-            )
-
-            await backend.start()
-
-            # Wait for retries and eventual success
-            events = []
-            try:
-                async with asyncio.timeout(2.0):
-                    async for event in backend.events():
-                        events.append(event)
-                        break  # Got the event, exit loop
-            except TimeoutError:
-                pass
-            finally:
-                await backend.stop()
-
-            # We got an event, proving recovery worked
-            self.assertEqual(len(events), 1)
-            self.assertEqual(events[0].id, "doc1")
-            # Verify: 2 failures + at least 1 success = >= 3 calls
-            # (stored after thread execution)
-            self.assertGreaterEqual(call_tracker["count"], 3)
-
-        asyncio.run(run_test())
-
-    @patch.object(CouchDBBackend, "_create_handler")
-    @patch("lib.couchdb.changes_fetcher.asyncio.sleep", new_callable=AsyncMock)
-    def test_does_not_recreate_handler_on_transient_errors(
-        self, mock_sleep, mock_create_handler
-    ):
-        """Retry policy is delegated to ChangesFetcher; backend handler is created once."""
-        handler = MagicMock()
-        handler.db_name = "testdb"  # Required by ChangesFetcher logging
-        mock_create_handler.return_value = handler
-
-        call_tracker = {"count": 0}
-
-        def _fetch_changes_batch(**kwargs):
-            call_tracker["count"] += 1
-            if call_tracker["count"] <= 2:
-                raise ApiException(code=503, message="Service Unavailable")
-            return ([{"id": "doc-recovered", "seq": "1-abc"}], "1-abc")
-
-        handler.fetch_changes_batch.side_effect = _fetch_changes_batch
-
-        async def run_test():
-            backend = CouchDBBackend(
-                backend_key="couchdb:testdb",
-                config=self.config,
-                checkpoint_store=self.store,
-            )
-
-            await backend.start()
-
-            events = []
-            try:
-                async with asyncio.timeout(2.0):
-                    async for event in backend.events():
-                        events.append(event)
-                        break
-            finally:
-                await backend.stop()
-
-            self.assertEqual(mock_create_handler.call_count, 1)
-            self.assertEqual(len(events), 1)
-            self.assertEqual(events[0].id, "doc-recovered")
-            # Verify retries occurred (3+ calls: 2 failures + success)
-            self.assertGreaterEqual(call_tracker["count"], 3)
-
-        asyncio.run(run_test())
-
-
-class TestCouchDBBackendGracefulStop(unittest.TestCase):
-    """Tests for CouchDBBackend graceful shutdown."""
-
-    def setUp(self):
-        """Set up test fixtures."""
-        self.store = InMemoryCheckpointStore()
-        self.config = {
-            "url": "https://couch.example.org",
-            "db": "testdb",
-            "user_env": "TEST_COUCH_USER",
-            "pass_env": "TEST_COUCH_PASS",
-        }
-
-    @patch.object(CouchDBBackend, "_create_handler")
-    def test_stop_during_polling(self, mock_create_handler):
-        """Test that stop() works during active polling."""
-        mock_handler = MagicMock()
-        mock_create_handler.return_value = mock_handler
-
-        # Mock response that returns empty results
-        mock_handler.fetch_changes_batch.return_value = ([], "0")
-
-        async def run_test():
-            backend = CouchDBBackend(
-                backend_key="couchdb:testdb",
-                config=self.config,
-                checkpoint_store=self.store,
-            )
-
-            await backend.start()
-            await asyncio.sleep(0.05)  # Let polling start
-
-            # Stop should complete quickly
-            import time
-
-            start = time.time()
-            await backend.stop()
-            elapsed = time.time() - start
-
-            self.assertLess(elapsed, 1.0)  # Should be fast
-
-        asyncio.run(run_test())
 
 
 if __name__ == "__main__":

--- a/tests/watchers/backends/test_couchdb_backend.py
+++ b/tests/watchers/backends/test_couchdb_backend.py
@@ -1,0 +1,708 @@
+"""
+CouchDB backend stream tests — groups A through G.
+
+Tests A–F drive ``CouchDBBackend.stream()`` directly via ``collect_stream()``.
+Tests G use the public ``start()`` / ``stop()`` / ``events()`` interface.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from ibm_cloud_sdk_core.api_exception import ApiException
+
+from lib.couchdb.couchdb_models import ChangesBatch, ChangesRow, FeedMode
+from lib.watchers.backends.checkpoint_store import InMemoryCheckpointStore
+from lib.watchers.backends.couchdb import CouchDBBackend, _is_internal_doc
+
+# ── Utilities ─────────────────────────────────────────────────────────────────
+
+_BASE_CONFIG = {
+    "url": "http://localhost:5984",
+    "db": "testdb",
+    "user_env": "COUCH_USER",
+    "pass_env": "COUCH_PASS",
+    "poll_interval": 0,
+    "max_observation_retries": 2,
+    "observation_retry_delay_s": 0,
+}
+
+
+def make_backend(extra_config=None, store=None):
+    config = {**_BASE_CONFIG}
+    if extra_config:
+        config.update(extra_config)
+    return CouchDBBackend(
+        backend_key="couchdb:testdb",
+        config=config,
+        checkpoint_store=store or InMemoryCheckpointStore(),
+    )
+
+
+def make_batch(rows=None, last_seq="1-abc", pending=0):
+    return ChangesBatch(rows=rows or [], last_seq=last_seq, pending=pending)
+
+
+def make_row(doc_id, seq="1-abc", deleted=False):
+    return ChangesRow(id=doc_id, seq=seq, deleted=deleted)
+
+
+def setup_handler(backend, batches, *, doc_return=None, doc_side_effect=None):
+    """
+    Return a MagicMock handler whose fetch_changes_raw cycles through ``batches``.
+
+    When batches are exhausted, sets ``backend._running = False`` so ``stream()``
+    exits cleanly on the next loop check.
+
+    ``doc_return`` sets a fixed return value for ``fetch_document_by_id``.
+    ``doc_side_effect`` sets a side_effect list for ``fetch_document_by_id``.
+    """
+    handler = MagicMock()
+    batch_it = iter(batches)
+
+    def fetch_raw(**kwargs):
+        try:
+            return next(batch_it)
+        except StopIteration:
+            backend._running = False
+            return ChangesBatch(rows=[], last_seq=None, pending=0)
+
+    handler.fetch_changes_raw.side_effect = fetch_raw
+    if doc_side_effect is not None:
+        handler.fetch_document_by_id.side_effect = doc_side_effect
+    else:
+        handler.fetch_document_by_id.return_value = doc_return
+    return handler
+
+
+async def collect_stream(backend, *, max_events=20):
+    """Iterate ``backend.stream()`` until stopped or ``max_events`` events collected."""
+    events = []
+    async for event in backend.stream():
+        events.append(event)
+        if len(events) >= max_events:
+            break
+    return events
+
+
+# ── A: Feed mode ──────────────────────────────────────────────────────────────
+
+
+class TestFeedMode(unittest.IsolatedAsyncioTestCase):
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_a1_first_call_uses_normal(self, _sleep):
+        """First poll uses feed=normal regardless of pending."""
+        backend = make_backend()
+        backend._running = True
+        handler = setup_handler(backend, [make_batch(pending=0)])
+        with patch.object(backend, "_create_handler", return_value=handler):
+            await collect_stream(backend)
+        first_call = handler.fetch_changes_raw.call_args_list[0]
+        self.assertEqual(first_call.kwargs["feed"], FeedMode.NORMAL.value)
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_a2_pending_zero_switches_to_longpoll(self, _sleep):
+        """After pending==0 batch, next poll uses feed=longpoll."""
+        backend = make_backend()
+        backend._running = True
+        handler = setup_handler(
+            backend,
+            [
+                make_batch(pending=0, last_seq="1"),
+                make_batch(pending=0, last_seq="2"),
+            ],
+        )
+        with patch.object(backend, "_create_handler", return_value=handler):
+            await collect_stream(backend)
+        second_call = handler.fetch_changes_raw.call_args_list[1]
+        self.assertEqual(second_call.kwargs["feed"], FeedMode.LONGPOLL.value)
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_a3_pending_nonzero_stays_normal(self, _sleep):
+        """While pending>0, subsequent polls remain feed=normal."""
+        backend = make_backend()
+        backend._running = True
+        handler = setup_handler(
+            backend,
+            [
+                make_batch(pending=3, last_seq="1"),
+                make_batch(pending=3, last_seq="2"),
+            ],
+        )
+        with patch.object(backend, "_create_handler", return_value=handler):
+            await collect_stream(backend)
+        second_call = handler.fetch_changes_raw.call_args_list[1]
+        self.assertEqual(second_call.kwargs["feed"], FeedMode.NORMAL.value)
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_a4_remains_longpoll_when_pending_stays_zero(self, _sleep):
+        """Once in longpoll mode, stays longpoll while pending==0."""
+        backend = make_backend()
+        backend._running = True
+        handler = setup_handler(
+            backend,
+            [
+                make_batch(pending=0, last_seq="1"),
+                make_batch(pending=0, last_seq="2"),
+                make_batch(pending=0, last_seq="3"),
+            ],
+        )
+        with patch.object(backend, "_create_handler", return_value=handler):
+            await collect_stream(backend)
+        # calls 2 and 3 (index 1, 2) should use longpoll
+        calls = handler.fetch_changes_raw.call_args_list
+        self.assertEqual(calls[1].kwargs["feed"], FeedMode.LONGPOLL.value)
+        self.assertEqual(calls[2].kwargs["feed"], FeedMode.LONGPOLL.value)
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_a5_longpoll_returns_to_normal_when_pending_nonzero(self, _sleep):
+        """Longpoll mode returns to normal when a batch has pending>0."""
+        backend = make_backend()
+        backend._running = True
+        handler = setup_handler(
+            backend,
+            [
+                make_batch(pending=0, last_seq="1"),  # → switches to longpoll
+                make_batch(pending=2, last_seq="2"),  # → back to normal
+                make_batch(pending=0, last_seq="3"),  # uses normal
+            ],
+        )
+        with patch.object(backend, "_create_handler", return_value=handler):
+            await collect_stream(backend)
+        calls = handler.fetch_changes_raw.call_args_list
+        self.assertEqual(calls[2].kwargs["feed"], FeedMode.NORMAL.value)
+
+
+# ── B: Document retrieval ──────────────────────────────────────────────────────
+
+
+class TestDocRetrieval(unittest.IsolatedAsyncioTestCase):
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_b1_deleted_row_skips_fetch(self, _sleep):
+        """Deleted rows emit event without calling fetch_document_by_id."""
+        backend = make_backend()
+        backend._running = True
+        row = make_row("doc-del", seq="1", deleted=True)
+        handler = setup_handler(backend, [make_batch(rows=[row])])
+        with patch.object(backend, "_create_handler", return_value=handler):
+            events = await collect_stream(backend)
+
+        self.assertEqual(len(events), 1)
+        self.assertTrue(events[0].deleted)
+        self.assertIsNone(events[0].doc)
+        handler.fetch_document_by_id.assert_not_called()
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_b2_non_deleted_row_fetches_doc(self, _sleep):
+        """Non-deleted rows call fetch_document_by_id and include doc in event."""
+        backend = make_backend()
+        backend._running = True
+        row = make_row("doc-1", seq="1", deleted=False)
+        doc = {"_id": "doc-1", "type": "project"}
+        handler = setup_handler(backend, [make_batch(rows=[row])], doc_return=doc)
+        with patch.object(backend, "_create_handler", return_value=handler):
+            events = await collect_stream(backend)
+
+        self.assertEqual(len(events), 1)
+        self.assertFalse(events[0].deleted)
+        self.assertEqual(events[0].doc, doc)
+        handler.fetch_document_by_id.assert_called_once_with("doc-1")
+
+
+# ── C: Internal doc filtering ──────────────────────────────────────────────────
+
+
+class TestInternalDocFiltering(unittest.TestCase):
+
+    def test_c1_design_doc_is_internal(self):
+        self.assertTrue(_is_internal_doc("_design/views"))
+
+    def test_c2_local_doc_is_internal(self):
+        self.assertTrue(_is_internal_doc("_local/mrview"))
+
+    def test_c3_normal_doc_is_not_internal(self):
+        self.assertFalse(_is_internal_doc("NGIS-ABC-123"))
+
+
+class TestInternalDocStream(unittest.IsolatedAsyncioTestCase):
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_c1_design_doc_yields_no_event(self, _sleep):
+        """_design/* rows produce no event."""
+        backend = make_backend()
+        backend._running = True
+        row = make_row("_design/views", seq="1")
+        handler = setup_handler(backend, [make_batch(rows=[row])])
+        with patch.object(backend, "_create_handler", return_value=handler):
+            events = await collect_stream(backend)
+        self.assertEqual(events, [])
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_c2_local_doc_yields_no_event(self, _sleep):
+        """_local/* rows produce no event."""
+        backend = make_backend()
+        backend._running = True
+        row = make_row("_local/mrview", seq="2")
+        handler = setup_handler(backend, [make_batch(rows=[row])])
+        with patch.object(backend, "_create_handler", return_value=handler):
+            events = await collect_stream(backend)
+        self.assertEqual(events, [])
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_c3_normal_doc_yields_event(self, _sleep):
+        """Normal doc rows produce an event."""
+        backend = make_backend()
+        backend._running = True
+        row = make_row("NGIS-ABC-123", seq="3")
+        doc = {"_id": "NGIS-ABC-123"}
+        handler = setup_handler(backend, [make_batch(rows=[row])], doc_return=doc)
+        with patch.object(backend, "_create_handler", return_value=handler):
+            events = await collect_stream(backend)
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].id, "NGIS-ABC-123")
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_c4_internal_doc_advances_checkpoint(self, _sleep):
+        """Internal doc rows still advance the checkpoint."""
+        store = InMemoryCheckpointStore()
+        backend = make_backend(store=store)
+        backend._running = True
+        row = make_row("_design/views", seq="42-abc")
+        handler = setup_handler(backend, [make_batch(rows=[row])])
+        with patch.object(backend, "_create_handler", return_value=handler):
+            await collect_stream(backend)
+        saved = store.load("couchdb:testdb")
+        self.assertIsNotNone(saved)
+        self.assertEqual(str(saved.value), "42-abc")
+
+
+# ── D: _changes poll failures ──────────────────────────────────────────────────
+
+
+class TestPollFailures(unittest.IsolatedAsyncioTestCase):
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_d1_poll_failure_retried(self, _sleep):
+        """A poll failure is retried; events from recovery batch are emitted."""
+        import requests
+
+        backend = make_backend()
+        backend._running = True
+
+        call_count = {"n": 0}
+        row = make_row("doc-1", seq="1")
+        doc = {"_id": "doc-1"}
+
+        def fetch_raw(**kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise requests.exceptions.Timeout("timed out")
+            if call_count["n"] == 2:
+                return make_batch(rows=[row])
+            backend._running = False
+            return ChangesBatch(rows=[], last_seq=None, pending=0)
+
+        handler = MagicMock()
+        handler.fetch_changes_raw.side_effect = fetch_raw
+        handler.fetch_document_by_id.return_value = doc
+
+        with patch.object(backend, "_create_handler", return_value=handler):
+            events = await collect_stream(backend)
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].id, "doc-1")
+        self.assertGreaterEqual(call_count["n"], 2)
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_d2_transient_poll_failure_logs_warning(self, _sleep):
+        """A transient poll failure logs at WARNING level."""
+        import requests
+
+        backend = make_backend()
+        backend._running = True
+
+        call_count = {"n": 0}
+
+        def fetch_raw(**kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise requests.exceptions.ConnectionError("refused")
+            backend._running = False
+            return ChangesBatch(rows=[], last_seq=None, pending=0)
+
+        handler = MagicMock()
+        handler.fetch_changes_raw.side_effect = fetch_raw
+
+        with patch.object(backend, "_create_handler", return_value=handler):
+            with patch.object(backend._logger, "warning") as mock_warn:
+                await collect_stream(backend)
+
+        mock_warn.assert_called()
+        warn_msg = mock_warn.call_args_list[0][0][0]
+        self.assertIn("poll failed", warn_msg)
+        self.assertIn("transient", warn_msg)
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_d3_since_not_advanced_after_poll_failure(self, _sleep):
+        """After a poll failure, the next call uses the same since value."""
+        import requests
+
+        backend = make_backend()
+        backend._running = True
+
+        call_args_recorded = []
+        call_count = {"n": 0}
+
+        def fetch_raw(**kwargs):
+            call_args_recorded.append(kwargs.get("since"))
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise requests.exceptions.Timeout("timeout")
+            backend._running = False
+            return ChangesBatch(rows=[], last_seq="5-new", pending=0)
+
+        handler = MagicMock()
+        handler.fetch_changes_raw.side_effect = fetch_raw
+
+        with patch.object(backend, "_create_handler", return_value=handler):
+            await collect_stream(backend)
+
+        # Both calls should use the same since (initial "0" or checkpoint)
+        self.assertEqual(call_args_recorded[0], call_args_recorded[1])
+
+
+# ── E: Document fetch failures and 404 ────────────────────────────────────────
+
+
+class TestDocFetchFailures(unittest.IsolatedAsyncioTestCase):
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_e1_transient_failure_then_success(self, _sleep):
+        """Transient fetch error is retried; successful retry emits event."""
+        backend = make_backend(extra_config={"max_observation_retries": 2})
+        backend._running = True
+        row = make_row("doc-1", seq="1")
+        doc = {"_id": "doc-1"}
+
+        handler = setup_handler(
+            backend,
+            [make_batch(rows=[row])],
+            doc_side_effect=[ApiException(code=503), doc],
+        )
+        with patch.object(backend, "_create_handler", return_value=handler):
+            events = await collect_stream(backend)
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].doc, doc)
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_e2_transient_failure_exhausted_skips(self, _sleep):
+        """Exhausting retries on transient error: no event, checkpoint advances."""
+        store = InMemoryCheckpointStore()
+        backend = make_backend(
+            extra_config={"max_observation_retries": 2},
+            store=store,
+        )
+        backend._running = True
+        row = make_row("doc-bad", seq="5-xyz")
+
+        handler = setup_handler(
+            backend,
+            [make_batch(rows=[row])],
+            doc_side_effect=[
+                ApiException(code=500),
+                ApiException(code=500),
+                ApiException(code=500),
+            ],
+        )
+        with patch.object(backend, "_create_handler", return_value=handler):
+            events = await collect_stream(backend)
+
+        self.assertEqual(events, [])
+        saved = store.load("couchdb:testdb")
+        self.assertIsNotNone(saved)
+        self.assertEqual(str(saved.value), "5-xyz")
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_e3_404_skips_and_warns(self, _sleep):
+        """fetch_document_by_id returning None (404) skips and logs warning."""
+        store = InMemoryCheckpointStore()
+        backend = make_backend(store=store)
+        backend._running = True
+        row = make_row("missing-doc", seq="7-abc")
+
+        handler = setup_handler(
+            backend,
+            [make_batch(rows=[row])],
+            doc_return=None,  # simulates 404
+        )
+        with patch.object(backend, "_create_handler", return_value=handler):
+            with patch.object(backend._logger, "warning") as mock_warn:
+                events = await collect_stream(backend)
+
+        self.assertEqual(events, [])
+        mock_warn.assert_called()
+        # Checkpoint still advances
+        saved = store.load("couchdb:testdb")
+        self.assertIsNotNone(saved)
+        self.assertEqual(str(saved.value), "7-abc")
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_e4_non_transient_error_skips_immediately(self, _sleep):
+        """Non-transient ApiException (e.g. 400) skips row without retrying."""
+        store = InMemoryCheckpointStore()
+        backend = make_backend(
+            extra_config={"max_observation_retries": 3},
+            store=store,
+        )
+        backend._running = True
+        row = make_row("bad-doc", seq="9-abc")
+
+        handler = setup_handler(
+            backend,
+            [make_batch(rows=[row])],
+            doc_side_effect=[ApiException(code=400)],
+        )
+        with patch.object(backend, "_create_handler", return_value=handler):
+            with patch.object(backend._logger, "error") as mock_error:
+                events = await collect_stream(backend)
+
+        self.assertEqual(events, [])
+        # Only 1 attempt (no retry on 400)
+        self.assertEqual(handler.fetch_document_by_id.call_count, 1)
+        mock_error.assert_called()
+        saved = store.load("couchdb:testdb")
+        self.assertIsNotNone(saved)
+        self.assertEqual(str(saved.value), "9-abc")
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_e5_retry_count_respected(self, _sleep):
+        """max_observation_retries=2 means exactly 3 fetch attempts (initial + 2)."""
+        backend = make_backend(extra_config={"max_observation_retries": 2})
+        backend._running = True
+        row = make_row("retry-doc", seq="11-abc")
+
+        handler = setup_handler(
+            backend,
+            [make_batch(rows=[row])],
+            doc_side_effect=[
+                ApiException(code=503),
+                ApiException(code=503),
+                ApiException(code=503),
+            ],
+        )
+        with patch.object(backend, "_create_handler", return_value=handler):
+            events = await collect_stream(backend)
+
+        self.assertEqual(events, [])
+        # 3 attempts: initial + 2 retries (max_observation_retries=2)
+        self.assertEqual(handler.fetch_document_by_id.call_count, 3)
+
+
+# ── F: Checkpoint semantics ────────────────────────────────────────────────────
+
+
+class TestCheckpointSemantics(unittest.IsolatedAsyncioTestCase):
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_f1_checkpoint_after_emitted_event(self, _sleep):
+        """Checkpoint saved with row seq after successfully emitting event."""
+        store = InMemoryCheckpointStore()
+        backend = make_backend(store=store)
+        backend._running = True
+        row = make_row("doc-1", seq="10-abc")
+        doc = {"_id": "doc-1"}
+
+        handler = setup_handler(backend, [make_batch(rows=[row])], doc_return=doc)
+        with patch.object(backend, "_create_handler", return_value=handler):
+            await collect_stream(backend)
+
+        saved = store.load("couchdb:testdb")
+        self.assertIsNotNone(saved)
+        self.assertEqual(str(saved.value), "10-abc")
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_f2_checkpoint_after_deleted_row(self, _sleep):
+        """Checkpoint saved after deleted row."""
+        store = InMemoryCheckpointStore()
+        backend = make_backend(store=store)
+        backend._running = True
+        row = make_row("doc-del", seq="20-xyz", deleted=True)
+
+        handler = setup_handler(backend, [make_batch(rows=[row])])
+        with patch.object(backend, "_create_handler", return_value=handler):
+            await collect_stream(backend)
+
+        saved = store.load("couchdb:testdb")
+        self.assertIsNotNone(saved)
+        self.assertEqual(str(saved.value), "20-xyz")
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_f3_checkpoint_after_internal_doc_skip(self, _sleep):
+        """Checkpoint saved when internal doc is skipped."""
+        store = InMemoryCheckpointStore()
+        backend = make_backend(store=store)
+        backend._running = True
+        row = make_row("_design/main", seq="30-def")
+
+        handler = setup_handler(backend, [make_batch(rows=[row])])
+        with patch.object(backend, "_create_handler", return_value=handler):
+            await collect_stream(backend)
+
+        saved = store.load("couchdb:testdb")
+        self.assertIsNotNone(saved)
+        self.assertEqual(str(saved.value), "30-def")
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_f4_checkpoint_after_404_skip(self, _sleep):
+        """Checkpoint saved when row is skipped due to 404."""
+        store = InMemoryCheckpointStore()
+        backend = make_backend(store=store)
+        backend._running = True
+        row = make_row("missing", seq="40-ghi")
+
+        handler = setup_handler(backend, [make_batch(rows=[row])], doc_return=None)
+        with patch.object(backend, "_create_handler", return_value=handler):
+            await collect_stream(backend)
+
+        saved = store.load("couchdb:testdb")
+        self.assertIsNotNone(saved)
+        self.assertEqual(str(saved.value), "40-ghi")
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_f5_checkpoint_saved_per_row(self, _sleep):
+        """In a 3-row batch, checkpoint is saved 3 times (once per row)."""
+        store = InMemoryCheckpointStore()
+        backend = make_backend(store=store)
+        backend._running = True
+
+        rows = [
+            make_row("doc-a", seq="1-a", deleted=True),
+            make_row("doc-b", seq="2-b", deleted=True),
+            make_row("doc-c", seq="3-c", deleted=True),
+        ]
+        handler = setup_handler(backend, [make_batch(rows=rows)])
+        with patch.object(backend, "_create_handler", return_value=handler):
+            with patch.object(
+                backend, "save_checkpoint", wraps=backend.save_checkpoint
+            ) as mock_save:
+                await collect_stream(backend)
+
+        self.assertEqual(mock_save.call_count, 3)
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_f6_no_checkpoint_on_poll_failure(self, _sleep):
+        """Poll failure does not advance checkpoint."""
+        import requests
+
+        store = InMemoryCheckpointStore()
+        backend = make_backend(store=store)
+        backend._running = True
+
+        call_count = {"n": 0}
+
+        def fetch_raw(**kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise requests.exceptions.Timeout("timeout")
+            backend._running = False
+            return ChangesBatch(rows=[], last_seq="failed-seq", pending=0)
+
+        handler = MagicMock()
+        handler.fetch_changes_raw.side_effect = fetch_raw
+
+        with patch.object(backend, "_create_handler", return_value=handler):
+            await collect_stream(backend)
+
+        # No checkpoint should have been saved (no rows were processed)
+        saved = store.load("couchdb:testdb")
+        self.assertIsNone(saved)
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_f7_since_advances_to_last_seq(self, _sleep):
+        """After a batch, ``since`` advances to ``batch.last_seq`` for next poll."""
+        backend = make_backend()
+        backend._running = True
+
+        call_args = []
+        call_count = {"n": 0}
+
+        def fetch_raw(**kwargs):
+            call_args.append(kwargs.get("since"))
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return make_batch(rows=[], last_seq="99-abc", pending=0)
+            backend._running = False
+            return ChangesBatch(rows=[], last_seq=None, pending=0)
+
+        handler = MagicMock()
+        handler.fetch_changes_raw.side_effect = fetch_raw
+
+        with patch.object(backend, "_create_handler", return_value=handler):
+            await collect_stream(backend)
+
+        # Second call should use the last_seq from the first batch
+        self.assertEqual(call_args[1], "99-abc")
+
+
+# ── G: Public interface contract ───────────────────────────────────────────────
+
+
+class TestPublicInterface(unittest.IsolatedAsyncioTestCase):
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_g1_start_stop_roundtrip(self, _sleep):
+        """start() / stop() round-trip does not raise."""
+        backend = make_backend()
+
+        # Infinite empty batches — stop() will cancel the producer task
+        handler = MagicMock()
+        handler.fetch_changes_raw.return_value = ChangesBatch(
+            rows=[], last_seq="0", pending=0
+        )
+
+        with patch.object(backend, "_create_handler", return_value=handler):
+            await backend.start()
+            self.assertTrue(backend.is_running)
+            await backend.stop()
+            self.assertFalse(backend.is_running)
+
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_g2_events_yields_through_queue(self, _sleep):
+        """Events are received via the public events() iterator (not stream() directly)."""
+        backend = make_backend()
+
+        row = make_row("queue-doc", seq="1-abc", deleted=True)
+        # After the batch with one row, return empty forever so the producer loops
+        # but we stop after consuming the event.
+        call_count = {"n": 0}
+
+        def fetch_raw(**kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return make_batch(rows=[row], pending=0)
+            return ChangesBatch(rows=[], last_seq="1-abc", pending=0)
+
+        handler = MagicMock()
+        handler.fetch_changes_raw.side_effect = fetch_raw
+
+        with patch.object(backend, "_create_handler", return_value=handler):
+            await backend.start()
+
+            received = []
+            async for event in backend.events():
+                received.append(event)
+                break  # get one event then stop consuming
+
+            await backend.stop()
+
+        self.assertEqual(len(received), 1)
+        self.assertEqual(received[0].id, "queue-doc")
+        self.assertTrue(received[0].deleted)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/watchers/test_manager.py
+++ b/tests/watchers/test_manager.py
@@ -543,6 +543,80 @@ class TestWatcherManagerIsRunning(unittest.TestCase):
         asyncio.run(run_test())
 
 
+class TestWatcherManagerPolicyConfig(unittest.TestCase):
+    """Tests for _resolve_watcher_policy and watcher_policy injection."""
+
+    def setUp(self):
+        WatcherManager._backend_registry.clear()
+        WatcherManager.register_backend("mock", MockWatcherBackend)
+        self.config = {
+            "endpoints": {
+                "mock_endpoint": {"backend": "mock", "url": "mock://", "auth": {}}
+            },
+            "connections": {
+                "conn1": {"endpoint": "mock_endpoint", "resource": {"db": "test"}}
+            },
+        }
+        self.store = InMemoryCheckpointStore()
+
+    def test_default_policy_values(self):
+        """Baseline defaults when no watcher_policy is injected."""
+        manager = WatcherManager(
+            config=self.config,
+            checkpoint_store=self.store,
+        )
+        policy = manager._resolve_watcher_policy()
+        self.assertEqual(policy["max_observation_retries"], 3)
+        self.assertAlmostEqual(policy["observation_retry_delay_s"], 1.0)
+
+    def test_injected_policy_overrides_defaults(self):
+        """watcher_policy kwarg bypasses ConfigLoader and overrides defaults."""
+        manager = WatcherManager(
+            config=self.config,
+            checkpoint_store=self.store,
+            watcher_policy={
+                "max_observation_retries": 7,
+                "observation_retry_delay_s": 0.5,
+            },
+        )
+        policy = manager._resolve_watcher_policy()
+        self.assertEqual(policy["max_observation_retries"], 7)
+        self.assertAlmostEqual(policy["observation_retry_delay_s"], 0.5)
+
+    def test_partial_policy_uses_defaults_for_missing_keys(self):
+        """Partially-specified watcher_policy falls back to defaults for absent keys."""
+        manager = WatcherManager(
+            config=self.config,
+            checkpoint_store=self.store,
+            watcher_policy={"max_observation_retries": 5},
+        )
+        policy = manager._resolve_watcher_policy()
+        self.assertEqual(policy["max_observation_retries"], 5)
+        self.assertAlmostEqual(policy["observation_retry_delay_s"], 1.0)  # default
+
+    def test_policy_merged_into_backend_config(self):
+        """Policy values appear in each backend's config after instantiation."""
+        manager = WatcherManager(
+            config=self.config,
+            checkpoint_store=self.store,
+            watcher_policy={
+                "max_observation_retries": 10,
+                "observation_retry_delay_s": 2.0,
+            },
+        )
+        manager.add_watcher_group("mock", "conn1")
+        manager._instantiate_watcher_backends()
+
+        group = manager._watcher_groups[("mock", "conn1")]
+        self.assertIsNotNone(group.backend_instance)
+        assert group.backend_instance is not None
+        self.assertEqual(
+            group.backend_instance.config.get("max_observation_retries"), 10
+        )
+        self.assertAlmostEqual(
+            group.backend_instance.config.get("observation_retry_delay_s"), 2.0
+        )
+
+
 if __name__ == "__main__":
-    unittest.main()
     unittest.main()


### PR DESCRIPTION
This pull request enhances the CouchDB change feed polling logic and documentation to improve reliability, configurability, and clarity around how changes are streamed and retried. The most significant changes include switching from using Cloudant SDK to fetch `_changes` to using raw HTTP/GET `requests`, implementing a more robust polling mechanism that adapts between normal and longpoll modes, clarifying the handling of special documents and errors, and updating retry/backoff behavior for transient failures. Documentation has also been expanded to clearly describe backend and watcher behaviors.

**CouchDB change feed polling and error handling improvements:**

- The `ChangesFetcher` class now dynamically switches between `feed=normal` and `feed=longpoll` modes depending on whether the feed is caught up (`pending == 0`), reducing polling overhead when the system is up-to-date. The longpoll timeout is now configurable (`longpoll_timeout_ms`). [[1]](diffhunk://#diff-55d27172c707cf8ad2505cf32e4d1953f5ba528ce2fa251ac7c9d548ba62eeacR48) [[2]](diffhunk://#diff-55d27172c707cf8ad2505cf32e4d1953f5ba528ce2fa251ac7c9d548ba62eeacR59-R69) [[3]](diffhunk://#diff-55d27172c707cf8ad2505cf32e4d1953f5ba528ce2fa251ac7c9d548ba62eeacR155-R174) [[4]](diffhunk://#diff-55d27172c707cf8ad2505cf32e4d1953f5ba528ce2fa251ac7c9d548ba62eeacL154-R220) [[5]](diffhunk://#diff-55d27172c707cf8ad2505cf32e4d1953f5ba528ce2fa251ac7c9d548ba62eeacL218-R263)
- Improved error handling: transient errors (HTTP 5xx, 429, network issues) now trigger exponential backoff and, after exceeding the retry limit, a 60-second pause before resuming polling instead of aborting. 404 errors on document fetches are treated as non-fatal skips, and `_design/*` and `_local/*` documents are silently ignored. [[1]](diffhunk://#diff-55d27172c707cf8ad2505cf32e4d1953f5ba528ce2fa251ac7c9d548ba62eeacR90-L105) [[2]](diffhunk://#diff-55d27172c707cf8ad2505cf32e4d1953f5ba528ce2fa251ac7c9d548ba62eeacL154-R220) [[3]](diffhunk://#diff-55d27172c707cf8ad2505cf32e4d1953f5ba528ce2fa251ac7c9d548ba62eeacL200-R247)
- The code now consistently uses `status_code` instead of the deprecated `code` attribute on `ApiException` for error handling. [[1]](diffhunk://#diff-72993342ef7fc5aa1b2c2ebe13a5c2367ff297f6d1f068baf23e0c89241ab2a6R184-R195) [[2]](diffhunk://#diff-72993342ef7fc5aa1b2c2ebe13a5c2367ff297f6d1f068baf23e0c89241ab2a6L210-R220) [[3]](diffhunk://#diff-72993342ef7fc5aa1b2c2ebe13a5c2367ff297f6d1f068baf23e0c89241ab2a6L221-R231) [[4]](diffhunk://#diff-72993342ef7fc5aa1b2c2ebe13a5c2367ff297f6d1f068baf23e0c89241ab2a6L269-R279)

**Documentation updates:**

- Expanded the architecture overview to document the CouchDB backend's polling modes, document filtering, checkpointing, error handling, and retry configuration.
- Added detailed documentation for the `PlanWatcher` and `ChangesFetcher` components, including their polling strategies and error handling.
- Updated the codebase structure table to reflect the addition of `ChangesFetcher` and typed CouchDB models.

**Codebase and dependency improvements:**

- The CouchDB connection now enables HTTP retries by default and stores credentials for use in raw HTTP requests, supporting the new polling logic. [[1]](diffhunk://#diff-72993342ef7fc5aa1b2c2ebe13a5c2367ff297f6d1f068baf23e0c89241ab2a6R99) [[2]](diffhunk://#diff-72993342ef7fc5aa1b2c2ebe13a5c2367ff297f6d1f068baf23e0c89241ab2a6R184-R195)
- The `ChangesFetcher` and connection modules now import and use the new typed models for change batches and rows. [[1]](diffhunk://#diff-55d27172c707cf8ad2505cf32e4d1953f5ba528ce2fa251ac7c9d548ba62eeacR24) [[2]](diffhunk://#diff-72993342ef7fc5aa1b2c2ebe13a5c2367ff297f6d1f068baf23e0c89241ab2a6R21-R26)

These changes collectively make CouchDB event watching more robust, observable, and maintainable, especially under high load or transient network failures.