### PR TITLE
fix: remove dead include_docs config, add Mango scan warning, add low poll limit warning

### DIFF
--- a/docs/getting_started/configuration.md
+++ b/docs/getting_started/configuration.md
@@ -65,7 +65,6 @@ Two key files:
             "resource": { "db": "projects" },
             "watch": {
                 "poll_interval": 3,
-                "include_docs": true,
                 "limit": 100,
                 "start_seq": "0"
             }
@@ -91,7 +90,7 @@ Two key files:
 
 | Key | Purpose |
 |---|---|
-| `watch` | Used by `WatcherManager` to poll the changes feed. Configures `poll_interval`, `include_docs`, `limit`, `start_seq`. |
+| `watch` | Used by `WatcherManager` to poll the changes feed. Configures `poll_interval`, `limit`, `start_seq`. A `limit` of at least 25 is recommended — very low values (< 5) will cause slow recovery after downtime. |
 | `data_access` | Used by `DataAccess` for realm data queries. Configures `realm_allowlist` (which realms may use this connection) and `max_limit` (max documents per query). |
 
 **`defaults`** provides fallback values for connections that omit optional fields (e.g. `start_seq`).

--- a/lib/couchdb/couchdb_connection.py
+++ b/lib/couchdb/couchdb_connection.py
@@ -270,6 +270,14 @@ class CouchDBHandler:
                     "Unexpected non-dict response from post_find on '%s'", self.db_name
                 )
                 return []
+            warning = result.get("warning")
+            if warning:
+                self._logger.warning(
+                    "CouchDB Mango query on '%s' may be doing a full collection scan "
+                    "(no matching index): %s",
+                    self.db_name,
+                    warning,
+                )
             docs = result.get("docs", [])
             return docs if isinstance(docs, list) else []
         except ApiException as e:

--- a/lib/watchers/backends/couchdb.py
+++ b/lib/watchers/backends/couchdb.py
@@ -150,6 +150,16 @@ class CouchDBBackend(WatcherBackend):
         )
         self._start_seq = str(config.get("start_seq", self.DEFAULT_START_SEQ))
         self._limit: int | None = config.get("limit", self.DEFAULT_LIMIT)
+        _LOW_LIMIT_THRESHOLD = 5
+        if self._limit is not None and self._limit < _LOW_LIMIT_THRESHOLD:
+            self._logger.warning(
+                "Backend '%s' has a very low poll limit (%d). "
+                "Recovery after downtime will require many sequential poll cycles. "
+                "Consider raising 'limit' to at least %d in the connection config.",
+                backend_key,
+                self._limit,
+                _LOW_LIMIT_THRESHOLD,
+            )
         self._longpoll_timeout_ms = int(
             config.get("longpoll_timeout_ms", self.DEFAULT_LONGPOLL_TIMEOUT_MS)
         )


### PR DESCRIPTION
This pull request improves CouchDB watcher configuration and logging to help users avoid common pitfalls and to surface potential performance issues. The main changes include removing the unused `include_docs` option from the documentation, adding warnings for very low poll limits, and logging when CouchDB queries may be inefficient.

**Documentation updates:**

* Removed the `include_docs` option from the example configuration and documentation table in `docs/getting_started/configuration.md`, as it is no longer used. [[1]](diffhunk://#diff-6af609a81d15b0302c76a9032958ea268e0820137f80e81a7696b1a17241a415L68) [[2]](diffhunk://#diff-6af609a81d15b0302c76a9032958ea268e0820137f80e81a7696b1a17241a415L94-R93)
* Added guidance in the documentation recommending a poll `limit` of at least 25, warning that very low values can slow recovery after downtime.

**Improved logging and configuration validation:**

* In `lib/watchers/backends/couchdb.py`, added a warning log if the configured poll `limit` is below 5, to help users avoid slow recovery scenarios.
* In `lib/couchdb/couchdb_connection.py`, added a warning log if a Mango query returns a warning (e.g., due to a missing index and a full collection scan), making potential performance issues more visible.