### PR TITLE
fix: add py.typed PEP 561 marker and fix cookbook Pattern 5 bugs

### DIFF
--- a/docs/realm_authoring/cookbook.md
+++ b/docs/realm_authoring/cookbook.md
@@ -136,8 +136,9 @@ The plan is stored in `yggdrasil_plans` with `status="draft"`. It executes only 
 Steps receive a `StepContext` providing workdir, emitter, scope, and realm. Decorate with `@step`:
 
 ```python
-from yggdrasil.flow.step import step
-from yggdrasil.flow.model import StepContext, StepResult
+from yggdrasil.flow.step import step, StepContext
+from yggdrasil.flow.model import StepResult
+from yggdrasil.flow.artifacts import SimpleArtifactRef
 
 
 @step
@@ -156,9 +157,11 @@ def run_pipeline(ctx: StepContext, config_file: str, threads: int = 4) -> StepRe
     if result.returncode != 0:
         raise RuntimeError(f"my_tool failed: {result.stderr.decode()}")
 
-    # Register output directory as artifact
+    # Register output directory as artifact.
+    # record_artifact() requires an ArtifactRefProtocol object, not a plain string.
+    # Use SimpleArtifactRef(key_name, folder) for the common case.
     outs_dir = ctx.workdir / ctx.scope["id"] / "output"
-    ctx.record_artifact("pipeline_output", path=outs_dir)
+    ctx.record_artifact(SimpleArtifactRef("pipeline_output", "output"), path=outs_dir)
 
     return StepResult(metrics={"returncode": result.returncode})
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ build-backend = "setuptools.build_meta"
 packages = ["yggdrasil", "lib"]
 
 [tool.setuptools.package-data]
-yggdrasil = ["assets/*"]
+yggdrasil = ["assets/*", "py.typed"]
 
 [tool.setuptools_scm]
 version_scheme = "post-release"


### PR DESCRIPTION
This pull request makes improvements to the artifact registration process and Python packaging configuration, and updates the documentation to clarify artifact usage.

**Documentation and API usage improvements:**

* Updated the example in `docs/realm_authoring/cookbook.md` to use `SimpleArtifactRef` when registering artifacts with `record_artifact()`, clarifying that an `ArtifactRefProtocol` object is required instead of a plain string. [[1]](diffhunk://#diff-ed593359d6ddb121fad46dfa23edaf1c536251f3a868dc9427f98ac5dd8fcf47L139-R141) [[2]](diffhunk://#diff-ed593359d6ddb121fad46dfa23edaf1c536251f3a868dc9427f98ac5dd8fcf47L159-R164)

**Packaging improvements:**

* Added `py.typed` to the `yggdrasil` package data in `pyproject.toml` to indicate type information is included, improving type checking support for consumers of the package.