### PR TITLE
Cleanup/core consistency

### DIFF
--- a/lib/core_utils/yggdrasil_core.py
+++ b/lib/core_utils/yggdrasil_core.py
@@ -504,19 +504,18 @@ class YggdrasilCore:
         """
         Initialize WatcherManager with validated WatchSpecs.
 
-        Config resolution:
-            WatcherManager loads main.json["external_systems"] when
-            config=None. We pass on_event so fan-out delivers events
-            to handle_event().
+        ``config`` and ``watcher_policy`` are extracted from ``self.config`` and
+        passed explicitly. WatcherManager performs no config loading of its own.
         """
         from lib.watchers.manager import WatcherManager
 
         self._logger.info("Setting up WatcherManager...")
 
         self.watcher_manager = WatcherManager(
-            config=None,  # WatcherManager self-loads from main.json
+            config=self.config.get("external_systems", {}),
             on_event=self.handle_event,
             logger=self._logger,
+            watcher_policy=self.config.get("watchers", {}),
         )
 
         for bound_spec in bound_specs:

--- a/lib/core_utils/yggdrasil_core.py
+++ b/lib/core_utils/yggdrasil_core.py
@@ -16,6 +16,7 @@ from lib.couchdb.project_db_manager import ProjectDBManager
 from lib.handlers.base_handler import BaseHandler
 from lib.ops.consumer_service import OpsConsumerService
 from lib.watchers.abstract_watcher import YggdrasilEvent
+from lib.watchers.manager import WatcherManager
 from lib.watchers.plan_watcher import PlanWatcher
 from lib.watchers.watchspec import BoundWatchSpec
 from yggdrasil.core.engine import Engine
@@ -215,16 +216,14 @@ class YggdrasilCore:
         Flow:
             1. Discover realms via ygg.realm entry points
             2. Register legacy ygg.handler entry points (backward compat)
-            3. Register internal test realm (dev mode)
-            4. Validate realm_id uniqueness
-            5. Instantiate and register handlers from each realm
-            6. Collect and validate watchspecs
-            7. Wire watchspecs into WatcherManager
+            3. Validate realm_id uniqueness
+            4. Instantiate and register handlers from each realm
+            5. Collect and validate watchspecs
+            6. Wire watchspecs into WatcherManager
         """
         self._logger.info("Discovering realms...")
 
         # 1. Discover realms via ygg.realm entry points
-        #    (Includes test_realm when registered as entry point)
         descriptors = discover_realms()
 
         # 2. Legacy ygg.handler support (backward compat)
@@ -235,21 +234,21 @@ class YggdrasilCore:
             self._logger.warning("No realms discovered.")
             return
 
-        # 4. Validate realm_id uniqueness
+        # 3. Validate realm_id uniqueness
         self._validate_realm_id_uniqueness(descriptors)
 
-        # 5. Register handlers from each realm
+        # 4. Register handlers from each realm
         all_bound_specs: list[BoundWatchSpec] = []
 
         for descriptor in descriptors:
             self._realm_registry[descriptor.realm_id] = descriptor
             self._register_realm_handlers(descriptor)
 
-            # 6. Collect watchspecs
+            # 5. Collect watchspecs
             bound_specs = self._collect_realm_watchspecs(descriptor)
             all_bound_specs.extend(bound_specs)
 
-        # 7. Validate watchspec bindings
+        # 6. Validate watchspec bindings
         if all_bound_specs:
             self._validate_watchspec_bindings(all_bound_specs)
             self._setup_watcher_manager(all_bound_specs)
@@ -507,8 +506,6 @@ class YggdrasilCore:
         ``config`` and ``watcher_policy`` are extracted from ``self.config`` and
         passed explicitly. WatcherManager performs no config loading of its own.
         """
-        from lib.watchers.manager import WatcherManager
-
         self._logger.info("Setting up WatcherManager...")
 
         self.watcher_manager = WatcherManager(
@@ -1435,13 +1432,14 @@ class YggdrasilCore:
         """
         Watchers call this to deliver events.
 
-        Routing logic (Phase 2):
+        Routing logic:
             1. If payload contains 'realm_id', filter to that realm's handlers
             2. If payload contains 'target_handlers', filter to those handler_ids
             3. Otherwise, broadcast to all handlers subscribed to event_type
 
-        After filtering, each handler generates a PlanDraft (async), which
-        is persisted to the database.  PlanWatcher handles execution.
+        After filtering, each handler generates a PlanDraft asynchronously and
+        persists it. PlanWatcher later observes approved/runnable plans and
+        triggers execution.
         """
         self._logger.info(
             "Received event '%s' from '%s'", event.event_type, event.source

--- a/lib/watchers/manager.py
+++ b/lib/watchers/manager.py
@@ -5,7 +5,7 @@ Responsibilities:
 - Instantiate backend instances (one per unique resource)
 - Start/stop backends concurrently
 - Validate backend type consistency
-- Collect WatchSpecs from realms
+- Register BoundWatchSpecs and deduplicate backend groups
 - Fan-out raw events to matching WatchSpecs with filter evaluation
 - Transform raw events into domain-level YggdrasilEvents
 """
@@ -68,7 +68,7 @@ class WatcherManager:
     Orchestrates watcher backend lifecycle.
 
     The WatcherManager is responsible for:
-    - Collecting watcher groups from WatchSpecs (Phase 2)
+    - Accepting BoundWatchSpecs via add_watchspec() and deduplicating backend groups internally
     - Deduplicating backends (one per unique resource)
     - Resolving connection configuration from endpoints + connections
     - Instantiating and managing backend lifecycle
@@ -97,8 +97,8 @@ class WatcherManager:
         config = load_config()
         manager = WatcherManager(config)
 
-        # Add watcher groups (typically done by realm discovery in Phase 2)
-        manager.add_watcher_group("couchdb", "projects_db")
+        # Register BoundWatchSpecs (typically done during realm setup)
+        manager.add_watchspec(bound_spec)
 
         # Start all backends
         await manager.start()
@@ -223,19 +223,19 @@ class WatcherManager:
         return dict(cls._backend_registry)
 
     # -------------------------------------------------------------------------
-    # Watcher Group Management
+    # Backend Group Management (internal)
     # -------------------------------------------------------------------------
 
-    def add_watcher_group(
+    def _ensure_watcher_group(
         self,
         backend_type: str,
         connection: str,
     ) -> WatcherBackendGroup:
         """
-        Add a watcher backend group if not already present.
+        Ensure a watcher backend group exists for (backend_type, connection),
+        creating it if needed. Returns the existing group on duplicate.
 
-        Returns existing group if duplicate (deduplication).
-        The connection fully identifies the resource via config.
+        Called internally by add_watchspec().
 
         Args:
             backend_type: Backend type identifier (e.g., "couchdb")
@@ -255,7 +255,7 @@ class WatcherManager:
             connection=connection,
         )
         self._watcher_groups[key] = group
-        self._logger.info("Added watcher group: %s", key)
+        self._logger.info("Created watcher backend group: %s", key)
         return group
 
     def get_watcher_groups(self) -> dict[tuple[str, str], WatcherBackendGroup]:
@@ -280,7 +280,7 @@ class WatcherManager:
         key = bound_spec.backend_group_key
 
         # Ensure backend group exists (dedup)
-        self.add_watcher_group(
+        self._ensure_watcher_group(
             backend_type=bound_spec.spec.backend,
             connection=bound_spec.spec.connection,
         )
@@ -692,7 +692,7 @@ class WatcherManager:
         self._logger.info("WatcherManager stopping...")
         self._running = False
 
-        # Cancel consumer tasks (Phase 2)
+        # Cancel consumer tasks
         for task in self._consumer_tasks:
             task.cancel()
 

--- a/lib/watchers/manager.py
+++ b/lib/watchers/manager.py
@@ -17,6 +17,7 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from lib.core_utils.external_systems_resolver import resolve_connection
 from lib.core_utils.logging_utils import custom_logger
 from lib.watchers.abstract_watcher import YggdrasilEvent
 from lib.watchers.backends.base import CheckpointStore, RawWatchEvent, WatcherBackend
@@ -74,7 +75,7 @@ class WatcherManager:
     - Instantiating and managing backend lifecycle
     - Validating backend type consistency
 
-    Configuration structure expected in self.config:
+    Configuration structure required for ``config``:
         {
             "endpoints": {
                 "couchdb": {
@@ -112,12 +113,9 @@ class WatcherManager:
     # Backend registry: maps backend type names to classes
     _backend_registry: dict[str, type[WatcherBackend]] = {}
 
-    # Config key in main.json for external systems
-    CONFIG_KEY = "external_systems"
-
     def __init__(
         self,
-        config: dict[str, Any] | None = None,
+        config: dict[str, Any],
         on_event: Callable[[YggdrasilEvent], None] | None = None,
         checkpoint_store: CheckpointStore | None = None,
         logger: logging.Logger | None = None,
@@ -127,37 +125,37 @@ class WatcherManager:
         Initialize the WatcherManager.
 
         Args:
-            config: Configuration dict with "endpoints" and "connections" keys.
-                    If None, loads from ConfigLoader("main.json")["external_systems"].
+            config: The ``external_systems`` config slice with "endpoints" and
+                    "connections" keys. Typically ``main_config["external_systems"]``.
+                    Structure::
+
+                        {
+                            "endpoints": {
+                                "couchdb": {
+                                    "backend": "couchdb",
+                                    "url": "https://...",
+                                    "auth": {"user_env": "...", "pass_env": "..."}
+                                }
+                            },
+                            "connections": {
+                                "projects_db": {
+                                    "endpoint": "couchdb",
+                                    "resource": {"db": "projects"}
+                                }
+                            }
+                        }
+
             on_event: Callback invoked for each transformed YggdrasilEvent.
                       Typically YggdrasilCore.handle_event.
             checkpoint_store: Storage for backend checkpoints.
                               Defaults to CouchDBCheckpointStore.
             logger: Optional logger instance.
-
-        The config structure expected:
-            {
-                "endpoints": {
-                    "couchdb": {
-                        "backend": "couchdb",
-                        "url": "https://...",
-                        "auth": {"user_env": "...", "pass_env": "..."}
-                    }
-                },
-                "connections": {
-                    "projects_db": {
-                        "endpoint": "couchdb",
-                        "resource": {"db": "projects"}
-                    }
-                }
-            }
-
-        If not passed explicitly, config is loaded from:
-            ConfigLoader().load_config("main.json")["external_systems"]
+            watcher_policy: Optional dict with retry policy overrides:
+                            ``max_observation_retries`` (int, default 3) and
+                            ``observation_retry_delay_s`` (float, default 1.0).
+                            If None or empty, hardcoded defaults are used.
+                            Typically ``main_config.get("watchers", {})``.
         """
-        if config is None:
-            config = self._load_default_config()
-
         self.config = config
         self._on_event = on_event
         self.checkpoint_store = checkpoint_store or CouchDBCheckpointStore()
@@ -169,31 +167,6 @@ class WatcherManager:
         self._bound_specs: dict[tuple[str, str], list[BoundWatchSpec]] = {}
         self._consumer_tasks: list[asyncio.Task[None]] = []
         self._running = False
-
-    @classmethod
-    def _load_default_config(cls) -> dict[str, Any]:
-        """
-        Load external_systems config from main.json via ConfigLoader.
-
-        Returns:
-            Dict with "endpoints" and "connections" keys.
-
-        Raises:
-            KeyError: If "external_systems" key is missing from main.json
-        """
-        from lib.core_utils.config_loader import ConfigLoader
-
-        full_config = ConfigLoader().load_config("main.json")
-        external_systems = full_config.get(cls.CONFIG_KEY)
-
-        if external_systems is None:
-            logger.warning(
-                "No '%s' key found in main.json; using empty config",
-                cls.CONFIG_KEY,
-            )
-            return {"endpoints": {}, "connections": {}}
-
-        return external_systems
 
     # -------------------------------------------------------------------------
     # Backend Registry
@@ -337,8 +310,6 @@ class WatcherManager:
         Raises:
             KeyError: If connection, endpoint, or required URL is missing
         """
-        from lib.core_utils.external_systems_resolver import resolve_connection
-
         # Delegate endpoint + connection lookup to shared resolver
         resolved_conn = resolve_connection(connection_name, self.config)
 
@@ -378,27 +349,18 @@ class WatcherManager:
     # -------------------------------------------------------------------------
 
     def _resolve_watcher_policy(self) -> dict[str, Any]:
-        """Load global watcher retry policy from ``main.json["watchers"]``.
+        """Return the resolved watcher retry policy.
 
-        Reads the optional top-level ``watchers`` key from the full main.json
-        config and returns a dict with defaults applied for any missing keys.
-        Falls back to all defaults if the config cannot be loaded (e.g. in tests).
+        Uses the ``watcher_policy`` dict passed at construction time.
+        Missing or unset keys fall back to the defaults specified in
+        the ``dict.get()`` calls below (``3`` and ``1.0``).
 
         Returns:
             Dict with keys:
             - ``max_observation_retries`` (int, default 3)
             - ``observation_retry_delay_s`` (float, default 1.0)
         """
-        if self._watcher_policy_override is not None:
-            raw: dict[str, Any] = self._watcher_policy_override
-        else:
-            try:
-                from lib.core_utils.config_loader import ConfigLoader
-
-                raw = ConfigLoader().load_config("main.json").get("watchers", {}) or {}
-            except Exception:
-                raw = {}
-
+        raw: dict[str, Any] = self._watcher_policy_override or {}
         return {
             "max_observation_retries": int(raw.get("max_observation_retries", 3)),
             "observation_retry_delay_s": float(

--- a/tests/watchers/test_manager.py
+++ b/tests/watchers/test_manager.py
@@ -122,9 +122,9 @@ class TestWatcherManagerGrouping(unittest.TestCase):
             checkpoint_store=self.store,
         )
 
-    def test_add_watcher_group_creates_group(self):
-        """Test add_watcher_group creates a new group."""
-        group = self.manager.add_watcher_group(
+    def test_ensure_watcher_group_creates_group(self):
+        """Test _ensure_watcher_group creates a new group."""
+        group = self.manager._ensure_watcher_group(
             backend_type="couchdb",
             connection="projects_db",
         )
@@ -132,13 +132,13 @@ class TestWatcherManagerGrouping(unittest.TestCase):
         self.assertEqual(group.backend_type, "couchdb")
         self.assertEqual(group.connection, "projects_db")
 
-    def test_add_watcher_group_deduplicates(self):
-        """Test add_watcher_group returns existing group on duplicate."""
-        group1 = self.manager.add_watcher_group(
+    def test_ensure_watcher_group_deduplicates(self):
+        """Test _ensure_watcher_group returns existing group on duplicate."""
+        group1 = self.manager._ensure_watcher_group(
             backend_type="couchdb",
             connection="projects_db",
         )
-        group2 = self.manager.add_watcher_group(
+        group2 = self.manager._ensure_watcher_group(
             backend_type="couchdb",
             connection="projects_db",
         )
@@ -148,11 +148,11 @@ class TestWatcherManagerGrouping(unittest.TestCase):
 
     def test_different_connections_create_separate_groups(self):
         """Test different connections create separate groups."""
-        group1 = self.manager.add_watcher_group(
+        group1 = self.manager._ensure_watcher_group(
             backend_type="couchdb",
             connection="projects_db",
         )
-        group2 = self.manager.add_watcher_group(
+        group2 = self.manager._ensure_watcher_group(
             backend_type="couchdb",
             connection="yggdrasil_db",
         )
@@ -313,7 +313,7 @@ class TestWatcherManagerBackendTypeValidation(unittest.TestCase):
         }
 
         manager = WatcherManager(config=config, checkpoint_store=self.store)
-        manager.add_watcher_group(backend_type="couchdb", connection="test_conn")
+        manager._ensure_watcher_group(backend_type="couchdb", connection="test_conn")
 
         # Should raise on instantiation due to backend type mismatch
         with self.assertRaises(ValueError) as ctx:
@@ -358,8 +358,8 @@ class TestWatcherManagerLifecycle(unittest.TestCase):
                 config=self.config,
                 checkpoint_store=self.store,
             )
-            manager.add_watcher_group("mock", "conn1")
-            manager.add_watcher_group("mock", "conn2")
+            manager._ensure_watcher_group("mock", "conn1")
+            manager._ensure_watcher_group("mock", "conn2")
 
             await manager.start()
 
@@ -381,7 +381,7 @@ class TestWatcherManagerLifecycle(unittest.TestCase):
                 config=self.config,
                 checkpoint_store=self.store,
             )
-            manager.add_watcher_group("mock", "conn1")
+            manager._ensure_watcher_group("mock", "conn1")
 
             await manager.start()
             self.assertTrue(manager.is_running)
@@ -402,8 +402,8 @@ class TestWatcherManagerLifecycle(unittest.TestCase):
                 config=self.config,
                 checkpoint_store=self.store,
             )
-            manager.add_watcher_group("mock", "conn1")
-            manager.add_watcher_group("mock", "conn2")
+            manager._ensure_watcher_group("mock", "conn1")
+            manager._ensure_watcher_group("mock", "conn2")
 
             await manager.start()
             await manager.stop()
@@ -465,8 +465,8 @@ class TestWatcherManagerLifecycle(unittest.TestCase):
                 config=config,
                 checkpoint_store=self.store,
             )
-            manager.add_watcher_group("mock", "good_conn")
-            manager.add_watcher_group("failing", "bad_conn")
+            manager._ensure_watcher_group("mock", "good_conn")
+            manager._ensure_watcher_group("failing", "bad_conn")
 
             # Should not raise, but log error
             await manager.start()
@@ -517,7 +517,7 @@ class TestWatcherManagerIsRunning(unittest.TestCase):
                 config=self.config,
                 checkpoint_store=self.store,
             )
-            manager.add_watcher_group("mock", "conn1")
+            manager._ensure_watcher_group("mock", "conn1")
 
             await manager.start()
             self.assertTrue(manager.is_running)
@@ -534,7 +534,7 @@ class TestWatcherManagerIsRunning(unittest.TestCase):
                 config=self.config,
                 checkpoint_store=self.store,
             )
-            manager.add_watcher_group("mock", "conn1")
+            manager._ensure_watcher_group("mock", "conn1")
 
             await manager.start()
             await manager.stop()
@@ -604,7 +604,7 @@ class TestWatcherManagerPolicyConfig(unittest.TestCase):
                 "observation_retry_delay_s": 2.0,
             },
         )
-        manager.add_watcher_group("mock", "conn1")
+        manager._ensure_watcher_group("mock", "conn1")
         manager._instantiate_watcher_backends()
 
         group = manager._watcher_groups[("mock", "conn1")]


### PR DESCRIPTION
This PR refactors how configuration and watcher group management are handled in the watcher subsystem. The main improvements are to make WatcherManager configuration explicit (no longer loaded internally from files), clarify the watcher group registration API, and update documentation and tests for these changes. The changes enhance clarity, testability, and separation of concerns in the watcher management logic.

**Configuration and Policy Handling:**

- The `WatcherManager` now requires the external systems configuration (`external_systems`) and watcher policy to be passed explicitly at construction, rather than loading them internally from `main.json`. This makes configuration more transparent and testable. [[1]](diffhunk://#diff-8894e90d51d2db81e0022509453f00f2d42b0a1f5b858bded7496f840361efd4L507-R515) [[2]](diffhunk://#diff-f772d90432a0396987cb2236379fa1acb2f3373b95965c056eefb8d2478428d9L115-R118) [[3]](diffhunk://#diff-f772d90432a0396987cb2236379fa1acb2f3373b95965c056eefb8d2478428d9L155-L160) [[4]](diffhunk://#diff-f772d90432a0396987cb2236379fa1acb2f3373b95965c056eefb8d2478428d9L381-R363)
- The watcher retry policy is now resolved only from the explicitly provided configuration, with fallback to hardcoded defaults if not set.

**Watcher Group Management API:**

- The internal method for registering watcher backend groups has been renamed from `add_watcher_group` to `_ensure_watcher_group`, clarifying its deduplication behavior and internal use. All usages and tests have been updated accordingly. [[1]](diffhunk://#diff-f772d90432a0396987cb2236379fa1acb2f3373b95965c056eefb8d2478428d9L226-R211) [[2]](diffhunk://#diff-f772d90432a0396987cb2236379fa1acb2f3373b95965c056eefb8d2478428d9L258-R231) [[3]](diffhunk://#diff-f772d90432a0396987cb2236379fa1acb2f3373b95965c056eefb8d2478428d9L283-R256) [[4]](diffhunk://#diff-ea9d08ea33be8671b49f9bf3bfcabfe701b44f66ff277d60e95f70531feec7f5L125-R141) [[5]](diffhunk://#diff-ea9d08ea33be8671b49f9bf3bfcabfe701b44f66ff277d60e95f70531feec7f5L151-R155) [[6]](diffhunk://#diff-ea9d08ea33be8671b49f9bf3bfcabfe701b44f66ff277d60e95f70531feec7f5L316-R316) [[7]](diffhunk://#diff-ea9d08ea33be8671b49f9bf3bfcabfe701b44f66ff277d60e95f70531feec7f5L361-R362) [[8]](diffhunk://#diff-ea9d08ea33be8671b49f9bf3bfcabfe701b44f66ff277d60e95f70531feec7f5L384-R384) [[9]](diffhunk://#diff-ea9d08ea33be8671b49f9bf3bfcabfe701b44f66ff277d60e95f70531feec7f5L405-R406)
- The public API for registering watcher specs is now clearly `add_watchspec`, and documentation has been updated to reflect this. [[1]](diffhunk://#diff-f772d90432a0396987cb2236379fa1acb2f3373b95965c056eefb8d2478428d9L71-R78) [[2]](diffhunk://#diff-f772d90432a0396987cb2236379fa1acb2f3373b95965c056eefb8d2478428d9L100-R102)

**Code and Documentation Cleanup:**

- Removed all internal config loading logic from `WatcherManager` and related documentation/comments. [[1]](diffhunk://#diff-f772d90432a0396987cb2236379fa1acb2f3373b95965c056eefb8d2478428d9L173-L197) [[2]](diffhunk://#diff-f772d90432a0396987cb2236379fa1acb2f3373b95965c056eefb8d2478428d9L155-L160)
- Updated docstrings and comments throughout to clarify the new configuration flow and watcher group registration process. [[1]](diffhunk://#diff-f772d90432a0396987cb2236379fa1acb2f3373b95965c056eefb8d2478428d9L71-R78) [[2]](diffhunk://#diff-f772d90432a0396987cb2236379fa1acb2f3373b95965c056eefb8d2478428d9L100-R102) [[3]](diffhunk://#diff-f772d90432a0396987cb2236379fa1acb2f3373b95965c056eefb8d2478428d9L115-R118) [[4]](diffhunk://#diff-f772d90432a0396987cb2236379fa1acb2f3373b95965c056eefb8d2478428d9L155-L160) [[5]](diffhunk://#diff-f772d90432a0396987cb2236379fa1acb2f3373b95965c056eefb8d2478428d9L226-R211)

**Core System Integration:**

- The core setup (`YggdrasilCore.setup_realms`) is updated to pass the correct configuration slices and watcher policy to `WatcherManager`, and to clarify the realm discovery and handler registration flow. [[1]](diffhunk://#diff-8894e90d51d2db81e0022509453f00f2d42b0a1f5b858bded7496f840361efd4R19) [[2]](diffhunk://#diff-8894e90d51d2db81e0022509453f00f2d42b0a1f5b858bded7496f840361efd4L218-L227) [[3]](diffhunk://#diff-8894e90d51d2db81e0022509453f00f2d42b0a1f5b858bded7496f840361efd4L238-R251) [[4]](diffhunk://#diff-8894e90d51d2db81e0022509453f00f2d42b0a1f5b858bded7496f840361efd4L507-R515)

**Minor Cleanups:**

- Miscellaneous docstring and comment improvements for clarity, and minor renaming for consistency. [[1]](diffhunk://#diff-8894e90d51d2db81e0022509453f00f2d42b0a1f5b858bded7496f840361efd4L1439-R1442) [[2]](diffhunk://#diff-f772d90432a0396987cb2236379fa1acb2f3373b95965c056eefb8d2478428d9L8-R8) [[3]](diffhunk://#diff-f772d90432a0396987cb2236379fa1acb2f3373b95965c056eefb8d2478428d9L340-L341) [[4]](diffhunk://#diff-f772d90432a0396987cb2236379fa1acb2f3373b95965c056eefb8d2478428d9L695-R657)

These changes collectively improve the maintainability and clarity of the watcher management subsystem.