### PR TITLE
Feature/data access v0.3.1 write - Update

### DIFF
--- a/docs/design/prds/data_access_controlled_writes_prd_v_0_3.md
+++ b/docs/design/prds/data_access_controlled_writes_prd_v_0_3.md
@@ -1,12 +1,13 @@
 # PRD: Realm-Scoped DataAccess with Controlled Writes
 
 **Version**: v0.3  
-**Status**: Draft  
+**Status**: Implemented (see v0.3.1 addendum)  
 **Target branch**: data-access  
 **Owner**: Yggdrasil core
 
 ## Changelog
 
+- v0.3.1 addendum: realm-facing write API revised from `put(doc_id, doc, mode=...)` to `save(doc, *, doc_id, selector, view, mode)`. See addendum section below.
 - v0.3: Evolves the read-only DataAccess design into a controlled read/write access layer. Adds realm- and phase-scoped permissions, execution-only writes, write traceability, and a backend-adapter boundary. CouchDB remains the first supported backend, but the design avoids hard-coding DataAccess around CouchDB-specific concepts.
 - v0.2: Read-only DataAccess for realm-controlled reads from CouchDB.
 
@@ -291,24 +292,24 @@ The same method name may return an awaitable in planning and a concrete value in
 
 DataAccess should not try to make this work without `await` in async planning code. Automatically awaiting “behind the scenes” inside a normal method is not a good Python API: an async operation cannot be transparently awaited from a synchronous-looking call without either blocking the event loop or returning a coroutine/task-like object. Realm authors should use `await` in async planning code.
 
-Writes are execution-only in this PR, so the realm-facing write API should be a single synchronous method:
+Writes are execution-only in this PR, so the realm-facing write API is a single synchronous method:
 
 ```python
-result = ctx.data.resource("x_flowcells_db").put(
-    doc_id=doc_id,
-    doc=doc,
+result = ctx.data.resource("x_flowcells_db").save(
+    doc,
+    doc_id=doc_id,   # or selector={...} or view={...}
     mode="upsert",
 )
 ```
 
-No `put_blocking` is exposed in the first implementation.
+No `save_blocking` is exposed in the first implementation.
 
 The implementation may keep existing `get_blocking` methods temporarily while migrating docs and realm code toward phase-aware `get`. Long term, the preferred API is:
 
 ```text
 planning async context:    await client.get(...)
 execution sync context:    client.get(...)
-execution write context:   client.put(...)
+execution write context:   client.save(...)
 ```
 
 If Yggdrasil later supports async steps, DataAccess can adapt by returning an async execution client for async steps, while preserving the same operation names where possible.
@@ -321,7 +322,7 @@ The public resource client returned by DataAccess should expose a small operatio
 client = ctx.data.resource("x_flowcells_db")
 client.get(...)
 client.find(...)
-client.put(...)
+client.save(...)
 ```
 
 For a CouchDB-backed connection, this resource client may be implemented by a renamed `CouchDBDataClient`.
@@ -349,11 +350,20 @@ Authorization can happen either when constructing the client or when invoking in
 
 ### 5.8 CouchDB write API
 
-Initial write support should include one operation:
+Initial write support includes one operation:
 
 ```python
-put(doc_id: str, doc: dict[str, Any], *, mode: Literal["create", "update", "upsert"] = "upsert") -> DataAccessWriteResult
+save(
+    doc: dict[str, Any],
+    *,
+    doc_id: str | None = None,
+    selector: dict[str, Any] | None = None,
+    view: dict[str, Any] | None = None,
+    mode: Literal["create", "update", "upsert"] = "upsert",
+) -> DataAccessWriteResult
 ```
+
+Exactly one of `doc_id`, `selector`, or `view` must be provided (identity mode). `doc` must be clean — no `_id` or `_rev` keys.
 
 Modes:
 
@@ -363,7 +373,7 @@ Modes:
 
 For CouchDB, `upsert` may require fetching the existing document revision internally. This is part of the authorized write operation and does not expose general read capability to the realm.
 
-Suggested result model:
+Result model:
 
 ```python
 @dataclass(frozen=True)
@@ -371,14 +381,15 @@ class DataAccessWriteResult:
     backend: str
     connection_name: str
     resource: str
-    operation: str
+    operation: Literal["create", "update", "upsert"]   # requested write intent
+    identity: Literal["doc_id", "selector", "view"]    # target resolution method
     doc_id: str
     status: Literal["created", "updated"]
     old_rev: str | None
     new_rev: str | None
 ```
 
-A status string is preferred over `created: bool` because it is clearer in logs and leaves room for future statuses without adding more booleans. Timestamps should not be encoded as a substitute for status. Write timing belongs to the event layer or trace metadata, not to the semantic write result itself.
+A status string is preferred over `created: bool` because it is clearer in logs and leaves room for future statuses without adding more booleans. `operation` records the write intent; `identity` records how the target document was resolved.
 
 ### 5.9 Trace context and write events
 
@@ -421,8 +432,9 @@ Event payload should include:
   "connection": "x_flowcells_db",
   "backend": "couchdb",
   "operation": "upsert",
+  "identity": "doc_id",
   "doc_id": "...",
-  "created": true,
+  "status": "created",
   "old_rev": null,
   "new_rev": "1-..."
 }
@@ -435,19 +447,19 @@ The `dmx` realm step should look approximately like:
 ```python
 @step
 def create_x_flowcell_doc(ctx: StepContext, flowcell_id: str, scenario: dict) -> StepResult:
-    doc_id = build_x_flowcell_doc_id(flowcell_id)
     doc = build_taca_x_flowcell_doc(scenario)
 
-    result = ctx.data.resource("x_flowcells_db").put(
-        doc_id=doc_id,
-        doc=doc,
+    result = ctx.data.resource("x_flowcells_db").save(
+        doc,
+        selector={"flowcell_id": flowcell_id},
         mode="upsert",
     )
 
     return StepResult(metrics={
         "x_flowcell_doc_id": result.doc_id,
-        "x_flowcell_created": result.created,
+        "x_flowcell_status": result.status,
         "x_flowcell_rev": result.new_rev,
+        "x_flowcell_identity": result.identity,
     })
 ```
 
@@ -490,8 +502,8 @@ Below there are example phases you may use, or get inspired to create your own.
 - Rename or supersede `CouchDBReadClient` with `CouchDBDataClient` for CouchDB-backed resources.
 - Preserve existing read behavior.
 - Move toward phase-aware method names: `await get(...)` in planning, `get(...)` in sync execution.
-- Add a single realm-facing write method: `put(...)`.
-- Do not expose `put_blocking` in this PR.
+- Add a single realm-facing write method: `save(...)`.
+- Do not expose `save_blocking` in this PR.
 
 ### Phase 5: Implement CouchDB write behavior
 
@@ -524,10 +536,12 @@ Add tests for:
 - Missing realm policy denies access.
 - Missing phase policy denies access.
 - CouchDB `max_limit` still applies to query reads.
-- `put(mode="create")` fails if document exists.
-- `put(mode="update")` fails if document is missing.
-- `put(mode="upsert")` creates or updates as expected.
-- Write events include trace context.
+- `save(doc_id=..., mode="create")` fails if document exists.
+- `save(doc_id=..., mode="update")` fails if document is missing.
+- `save(doc_id=..., mode="upsert")` creates or updates as expected.
+- `save(selector=..., mode="upsert")` creates via POST (CouchDB-generated `_id`) when no match; updates on single match.
+- `save(view=..., mode="upsert")` same semantics as selector, resolved through a view query.
+- Write events include `operation` and `identity` fields in addition to trace context.
 - Realm code cannot access raw backend client internals through public API.
 
 ## 8. Acceptance Criteria
@@ -559,4 +573,33 @@ R4. Future backends may not map cleanly to `read`/`write`.
 
 R5. Write event emission could fail after the backend write succeeds.  
 - Mitigation: Treat backend write success as authoritative for the returned `DataAccessWriteResult`. Event emission failures should be caught and logged according to existing emitter failure policy. This PR should not require a full new reliability mechanism for secondary event emission, but it must not report the backend write as failed if only trace emission failed.
+
+---
+
+## v0.3.1 Addendum — `save()` replaces realm-facing `put()`
+
+During implementation/testing, the realm-facing write API was revised from `put(doc_id, doc, mode=...)` to `save(doc, *, doc_id=None, selector=None, view=None, mode="upsert")`.
+
+**Reason:** some legacy CouchDB databases, especially `x_flowcells`, rely on CouchDB-generated `_id` values while identifying logical documents by external keys such as `flowcell_id` through selectors or views. A doc-id-only API cannot support that cleanly.
+
+`save()` is now the preferred and only realm-facing write method. It separates:
+
+- `operation`: requested write intent — `"create"`, `"update"`, or `"upsert"`
+- `identity`: target-resolution method — `"doc_id"`, `"selector"`, or `"view"`
+
+Examples:
+
+```python
+client.save(body, doc_id="known:id", mode="upsert")
+client.save(body, selector={"flowcell_id": flowcell_id}, mode="upsert")
+client.save(
+    body,
+    view={"design": "flowcells", "view": "by_flowcell_id", "key": flowcell_id},
+    mode="upsert",
+)
+```
+
+Selector/view identity modes use `limit=2` and fail with `DataAccessWriteError` if more than one match exists. If no match exists, they create the document using a CouchDB-generated `_id`.
+
+Selector/view saves are not atomic uniqueness guarantees. Concurrent writers can both observe zero matches and create duplicates. This is acceptable for Yggdrasil-managed low-contention legacy integration, and later calls fail loudly once duplicates exist.
 

--- a/docs/flow_api/overview.md
+++ b/docs/flow_api/overview.md
@@ -238,7 +238,7 @@ Calling `ctx.data.connection(name)` returns a different client type depending on
 | Phase | Client returned | Read methods | Write methods |
 |-------|-----------------|--------------|---------------|
 | `"planning"` | `CouchDBPlanningClient` | `async` — must be `await`ed | none |
-| `"execution"` | `CouchDBExecutionClient` | sync — return results directly | `put()` |
+| `"execution"` | `CouchDBExecutionClient` | sync — return results directly | `save()` |
 
 **Planning phase** (inside `generate_plan_drafts`):
 
@@ -273,15 +273,26 @@ Both clients expose the same read methods (async in planning, sync in execution)
 | `require(doc_id)` | `dict` | `DataAccessNotFoundError` if absent |
 | `require_one(selector)` | `dict` | `DataAccessNotFoundError` if no match |
 
-### Writing — `put()` (execution phase only)
+### Writing — `save()` (execution phase only)
 
-`CouchDBExecutionClient.put(doc_id, body, mode)` writes a document. The `body` dict must be **clean** — no `_id` or `_rev` keys; the client manages revision tracking internally.
+`CouchDBExecutionClient.save(doc, *, doc_id, selector, view, mode)` writes a document using one of three identity modes. The `doc` dict must be **clean** — no `_id` or `_rev` keys; the client manages revision tracking internally. Exactly one of `doc_id`, `selector`, or `view` must be provided.
 
 ```python
-result = client.put("run_123", {"status": "done"}, mode="upsert")
+# Write by explicit document ID
+result = client.save({"status": "done"}, doc_id="run_123", mode="upsert")
 # result.status  → "created" or "updated"
 # result.new_rev → new CouchDB revision string
 # result.old_rev → previous revision (None if created)
+# result.identity → "doc_id"
+
+# Write without _id — CouchDB generates one (selector identity)
+result = client.save({"status": "done"}, selector={"type": "run", "run_id": "r-1"}, mode="upsert")
+# result.identity → "selector"
+# result.doc_id   → CouchDB-generated or matched ID
+
+# Write by view row (view identity)
+result = client.save({"status": "done"}, view={"design": "runs", "view": "by_id", "key": "r-1"}, mode="update")
+# result.identity → "view"
 ```
 
 | `mode` | Behaviour |
@@ -289,6 +300,17 @@ result = client.put("run_123", {"status": "done"}, mode="upsert")
 | `"create"` | Fail (raise) if the document already exists |
 | `"update"` | Fail (raise) if the document does not exist |
 | `"upsert"` | Create if absent, update if present; retries once on conflict |
+
+`DataAccessWriteResult` fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status` | `"created" \| "updated"` | Outcome |
+| `doc_id` | `str` | Resolved or provided document ID |
+| `operation` | `"create" \| "update" \| "upsert"` | Requested write mode |
+| `identity` | `"doc_id" \| "selector" \| "view"` | Identity resolution method used |
+| `old_rev` | `str \| None` | Previous revision (`None` if created) |
+| `new_rev` | `str \| None` | New revision after write |
 
 ### API entry points
 
@@ -302,7 +324,7 @@ Access is controlled per-realm, per-phase in the connection's `data_access.realm
 - A realm must appear in `realms` for a given connection to access it at all.
 - Each phase (`planning`, `execution`) has its own `permissions` list.
 - `"read"` grants access to `get`, `find`, and related methods.
-- `"write"` grants access to `put()`. It does **not** imply `"read"` — a realm with only `"write"` can call `put()` but not `get()`.
+- `"write"` grants access to `save()`. It does **not** imply `"read"` — a realm with only `"write"` can call `save()` but not `get()`.
 - Planning phase requires at least `"read"` — a planning-phase connection with write-only permission is denied.
 
 ### Configuration shape

--- a/docs/realm_authoring/cookbook.md
+++ b/docs/realm_authoring/cookbook.md
@@ -181,7 +181,7 @@ def run_pipeline(ctx: StepContext, config_file: str, threads: int = 4) -> StepRe
 | `run_mode` | `str` | `"auto"` or `"manual"` |
 | `fingerprint` | `str` | SHA-256 fingerprint for this run |
 | `run_id` | `str` | Unique run ID |
-| `data` | `DataAccess` | Phase-aware gateway to configured data sources. Call `ctx.data.connection(conn)` to get a sync client for reads (`get`, `find`, `require`, …) and writes (`put`). |
+| `data` | `DataAccess` | Phase-aware gateway to configured data sources. Call `ctx.data.connection(conn)` to get a sync client for reads (`get`, `find`, `require`, …) and writes (`save`). |
 
 ---
 
@@ -381,7 +381,7 @@ The fetch is visible via step events and metrics (not baked into plan params), w
 
 ## Pattern 8b: Writing to CouchDB in a step
 
-Steps with write permission can call `put()` on the execution client. Pass a clean body dict — do not include `_id` or `_rev`; the client manages them:
+Steps with write permission can call `save()` on the execution client. Pass a clean body dict — do not include `_id` or `_rev`; the client manages them. Provide exactly one of `doc_id`, `selector`, or `view` to identify the target document:
 
 ```python
 @step
@@ -390,11 +390,23 @@ def update_run_status(ctx: StepContext, run_id: str) -> StepResult:
 
     # Body must not contain _id or _rev — those are managed by the client
     body = {"status": "complete", "processed_by": "yggdrasil"}
-    result = client.put(run_id, body, mode="upsert")
+
+    # Write by explicit document ID
+    result = client.save(body, doc_id=run_id, mode="upsert")
     # result.status is "created" or "updated"
     # result.old_rev / result.new_rev carry revision info
+    # result.identity → "doc_id"
 
     return StepResult(metrics={"write_status": result.status, "new_rev": result.new_rev})
+```
+
+To let CouchDB auto-generate the document ID, use selector or view identity instead:
+
+```python
+# CouchDB generates the _id on create; selector matches the doc on update
+result = client.save(body, selector={"type": "run_status", "run_id": run_id}, mode="upsert")
+# result.identity → "selector"
+# result.doc_id   → CouchDB-generated ID (on create) or matched ID (on update)
 ```
 
 **`mode` values:**
@@ -405,7 +417,7 @@ def update_run_status(ctx: StepContext, run_id: str) -> StepResult:
 | `"update"` | Fail if the document does not exist |
 | `"upsert"` | Create if absent, update if present; retries once on conflict |
 
-> **Note on write vs read:** A realm configured with only `"write"` permission can call `put()` but not `get()` or `find()`. Grant `"read"` explicitly for realms that need both.
+> **Note on write vs read:** A realm configured with only `"write"` permission can call `save()` but not `get()` or `find()`. Grant `"read"` explicitly for realms that need both.
 
 ---
 

--- a/docs/reference/test_realm.md
+++ b/docs/reference/test_realm.md
@@ -33,8 +33,9 @@ Standard recipes (selected via `"recipe"` field, in RECIPES registry):
 - **data_access_denied**: Verifies DataAccess correctly rejects unauthorized connections
 - **data_fetch_all_methods**: Exercises every read method on the execution-phase DataAccess client
 - **data_verify_limit_clamping**: Confirms `find()` results are clamped to the effective `max_limit` from `data_access.options`
-- **data_write_exec**: Writes a document to CouchDB at execution time via `client.put()`; proves write permission works end-to-end
-- **data_write_only_permission**: Proves write permission does not imply read; `put()` must succeed, `get()` must raise `DataAccessDeniedError`
+- **data_write_exec**: Writes a document to CouchDB at execution time via `client.save()`; proves write permission works end-to-end
+- **data_write_only_permission**: Proves write permission does not imply read; `save()` must succeed, `get()` must raise `DataAccessDeniedError`
+- **data_write_no_id**: Writes a document without supplying a `_id`; CouchDB auto-generates the ID via selector identity; the resolved `doc_id` appears in step metrics
 
 Planning-time recipes (handler processes the doc before building steps; not in RECIPES registry):
 - **data_fetch_plan**: Async-fetches a CouchDB doc *during planning*; bakes the result as a structured `ref_doc` dict into step params.
@@ -56,7 +57,8 @@ Available steps (for custom mode):
 - **step_exercise_all_fetch_methods**: Exercise every read method on the execution-phase DataAccess client in one step (params: `connection`, `doc_id`, `selector_type`)
 - **step_verify_limit_clamping**: Assert that `find()` results are clamped to the effective `max_limit` from `data_access.options` (params: `connection`, `selector_type`, `request_limit`, `expected_max`)
 - **step_emit_metadata**: Emit structured metadata baked into the plan at planning time (params: `scenario` dict and/or `ref_doc` dict)
-- **step_write_to_db**: Write a document via `client.put()` with write permission; returns `write_status`, `doc_id`, `old_rev`, `new_rev` in metrics (params: `connection`, `doc_id`, `mode`)
+- **step_write_to_db**: Write a document via `client.save(doc, doc_id=..., mode=...)` with write permission; returns `write_status`, `doc_id`, `old_rev`, `new_rev` in metrics (params: `connection`, `doc_id`, `mode`)
+- **step_write_to_db_no_id**: Write a document using Mango selector identity — no `_id` supplied, CouchDB auto-generates it; returns `write_status`, `doc_id`, `old_rev`, `new_rev`, `identity`, `operation` in metrics (params: `connection`, `selector`, `mode`)
 - **step_expect_read_denied**: Assert that `client.get()` raises `DataAccessDeniedError` on a write-only connection; step succeeds only if denial is raised (params: `connection`, `doc_id`)
 
 ---
@@ -635,7 +637,7 @@ curl http://localhost:5984/yggdrasil_plans/test_realm:test_scenario:data_fetch_p
 
 ## Scenario 17: Execution-Time Write
 
-**Purpose**: Prove that a step with execution write permission can call `client.put()` via
+**Purpose**: Prove that a step with execution write permission can call `client.save()` via
 `ctx.data.connection()` and have the result visible in step metrics and the
 `data_access.write.succeeded` event.
 
@@ -654,7 +656,7 @@ curl http://localhost:5984/yggdrasil_plans/test_realm:test_scenario:data_fetch_p
 ```
 
 **Expected**:
-- `write_doc` step calls `ctx.data.connection("test_realm_write_db").put("data_access_test:write_result", body, mode="upsert")`
+- `write_doc` step calls `ctx.data.connection("test_realm_write_db").save(body, doc_id="data_access_test:write_result", mode="upsert")`
 - Body is a clean dict without `_id` or `_rev` — DataAccess manages those internally
 - `step.write_result` event emitted with `write_status`, `doc_id`, `old_rev`, `new_rev`
 - `data_access.write.succeeded` event emitted by the DataAccess layer (visible in event spool)
@@ -666,7 +668,7 @@ curl http://localhost:5984/yggdrasil_plans/test_realm:test_scenario:data_fetch_p
 ## Scenario 18: Write-Only Permission (Read Denied)
 
 **Purpose**: Prove that a connection with only `"write"` in its execution permissions correctly
-denies read operations. `put()` must succeed; `get()` must raise `DataAccessDeniedError`.
+denies read operations. `save()` must succeed; `get()` must raise `DataAccessDeniedError`.
 
 **Requires**: Connection `test_realm_write_db` (write-only for test_realm — same connection as Scenario 17).
 
@@ -682,11 +684,41 @@ denies read operations. `put()` must succeed; `get()` must raise `DataAccessDeni
 ```
 
 **Expected**:
-- `write_only_put` step calls `put()` → must succeed (write permission is present)
+- `write_only_put` step calls `save()` → must succeed (write permission is present)
 - `write_only_read_denied` step calls `get()` on the same connection → must raise `DataAccessDeniedError`
 - `step_expect_read_denied` treats the `DataAccessDeniedError` as the expected outcome; emits `step.read_denied_as_expected`
 - Step metrics include `read_correctly_denied: true` and the denial reason
 - Plan completes successfully — both steps pass
+
+---
+
+## Scenario 19: Write Without _id (Auto-Generated ID)
+
+**Purpose**: Prove that a step can write a document to CouchDB without supplying a `_id`. The
+selector identity path of `save()` is used; CouchDB generates the document ID on create. The
+resolved `doc_id`, `identity`, and `operation` are visible in step metrics.
+
+**Requires**: Connection `test_realm_write_db` configured with
+`data_access.realms.test_realm.execution.permissions: ["write"]`.
+
+**Insert as**:
+```json
+{
+  "_id": "test_scenario:data_write_no_id",
+  "type": "ygg_test_scenario",
+  "recipe": "data_write_no_id",
+  "name": "Write Without _id",
+  "auto_run": true
+}
+```
+
+**Expected**:
+- `write_doc_no_id` step calls `client.save(body, selector={...}, mode="upsert")` — no `_id` in body or call
+- On first run: CouchDB creates a new document and returns a generated ID
+- `step.write_result` event emitted with `write_status`, `doc_id`, `old_rev`, `new_rev`, `identity="selector"`, `operation="upsert"`
+- `data_access.write.succeeded` event emitted by the DataAccess layer
+- Step metrics include `identity="selector"` confirming the selector path was used
+- `echo_confirm` step succeeds after write
 
 ---
 
@@ -873,7 +905,8 @@ Once retry logic is implemented, use **fail_fast** or **fail_mid_plan** scenario
 | Metadata Harvest | metadata_harvest | ✓ | <50ms | Domain fields baked as structured dict in plan params |
 | Plan-Time Fetch (Structured) | data_fetch_plan | ✓ | <1s | CouchDB ref doc baked as structured dict in plan params |
 | Execution-Time Write | data_write_exec | ✓ | <1s | Write succeeds; write_status + revs in step metrics |
-| Write-Only Permission | data_write_only_permission | ✓ | <1s | put() passes, get() correctly denied |
+| Write-Only Permission | data_write_only_permission | ✓ | <1s | save() passes, get() correctly denied |
+| Write Without _id | data_write_no_id | ✓ | <1s | CouchDB generates ID; identity="selector" in metrics |
 
 ---
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -183,7 +183,7 @@ def my_step(ctx: StepContext, **params) -> StepResult:
 }
 ```
 
-> **Note:** `"write"` permission does not grant `"read"`. A realm that only has `"write"` can call `put()` but calling `get()` or `find()` will still raise `DataAccessDeniedError`. Grant `"read"` explicitly if reads are also needed.
+> **Note:** `"write"` permission does not grant `"read"`. A realm that only has `"write"` can call `save()` but calling `get()` or `find()` will still raise `DataAccessDeniedError`. Grant `"read"` explicitly if reads are also needed.
 
 ### `DataAccessDeniedError` — no data_access policy for connection
 

--- a/lib/couchdb/couchdb_connection.py
+++ b/lib/couchdb/couchdb_connection.py
@@ -338,6 +338,135 @@ class CouchDBHandler:
             )
             raise
 
+    def post_document(self, doc: dict[str, Any]) -> dict[str, Any]:
+        """Create a document and let CouchDB generate the document ID.
+
+        Unlike put_document(), the caller does not supply a doc_id. CouchDB
+        assigns a UUID. Use this when the logical identity of the document
+        will be determined by a selector or view query rather than a known ID.
+
+        Args:
+            doc: Document body. Must NOT contain '_id' or '_rev'.
+
+        Returns:
+            Response dict from CouchDB: {"id": <generated>, "rev": ..., "ok": True}.
+
+        Raises:
+            ValueError: doc contains '_id' or '_rev'.
+            ApiException: Propagated as-is on backend failure.
+        """
+        reserved = {"_id", "_rev"} & doc.keys()
+        if reserved:
+            raise ValueError(
+                f"doc must not contain {sorted(reserved)!r}. "
+                "post_document() does not accept pre-assigned identity fields."
+            )
+        body = dict(doc)
+        try:
+            response = self.server.post_document(
+                db=self.db_name,
+                document=cloudant_v1.Document.from_dict(body),
+            )
+            return response.get_result()
+        except ApiException as e:
+            self._logger.error(
+                "Cloudant API error in post_document on '%s': %s %s",
+                self.db_name,
+                e.status_code,
+                e.message,
+            )
+            raise
+        except Exception as e:
+            self._logger.error(
+                "Error in post_document on database '%s': %s", self.db_name, e
+            )
+            raise
+
+    def query_view(
+        self,
+        ddoc: str,
+        view: str,
+        *,
+        key: Any = None,
+        limit: int | None = None,
+        include_docs: bool = False,
+        reduce: bool = False,
+        stable: bool = False,
+    ) -> dict[str, Any]:
+        """Query a CouchDB view and return the raw result dict.
+
+        Callers access ``result["rows"]`` for the list of view rows.
+
+        Args:
+            ddoc: Design document name (without the ``_design/`` prefix).
+            view: View name within the design document.
+            key: Optional key to filter rows. When None, all rows are returned.
+                 Omitted from the request entirely when None — do not pass None
+                 to query for documents with a null key; that case is not
+                 supported by this method.
+            limit: Maximum number of rows to return. Omitted when None.
+            include_docs: If True, include full document bodies in each row.
+                          Defaults to False. Set to True when the caller needs
+                          ``_id`` and ``_rev`` without a separate fetch.
+            reduce: If True, run the view's reduce function. Defaults to False.
+                    Save-path callers must use False to get individual map rows
+                    with ``id`` fields — a reduce result has no row ``id``.
+            stable: If True, request a stable (potentially stale) view read.
+                    Defaults to False, which uses CouchDB's default (update
+                    before responding). Combining stable=True with update=True
+                    (the CouchDB default) is generally discouraged per IBM SDK
+                    docs — omit unless you have a specific reason.
+
+        Returns:
+            Raw result dict containing at least ``{"rows": [...]}``.
+
+        Raises:
+            ApiException: Propagated as-is on backend failure.
+        """
+        kwargs: dict[str, Any] = {
+            "db": self.db_name,
+            "ddoc": ddoc,
+            "view": view,
+            "include_docs": include_docs,
+            "reduce": reduce,
+            "stable": stable,
+        }
+        if key is not None:
+            kwargs["key"] = key
+        if limit is not None:
+            kwargs["limit"] = limit
+        try:
+            response = self.server.post_view(**kwargs)
+            result = response.get_result()
+            if not isinstance(result, dict):
+                self._logger.warning(
+                    "Unexpected non-dict response from post_view on '%s' ('%s/%s')",
+                    self.db_name,
+                    ddoc,
+                    view,
+                )
+                return {"rows": []}
+            return result
+        except ApiException as e:
+            self._logger.error(
+                "Cloudant API error in query_view on '%s' ('%s/%s'): %s %s",
+                self.db_name,
+                ddoc,
+                view,
+                e.status_code,
+                e.message,
+            )
+            raise
+        except Exception as e:
+            self._logger.error(
+                "Error in query_view on '%s' ('%s/%s'): %s",
+                self.db_name,
+                ddoc,
+                view,
+                e,
+            )
+            raise
+
     def fetch_changes_raw(
         self,
         *,

--- a/lib/couchdb/couchdb_connection.py
+++ b/lib/couchdb/couchdb_connection.py
@@ -248,7 +248,7 @@ class CouchDBHandler:
         Args:
             doc_id: Target document ID.
             doc: Document body. Must NOT contain '_id' or '_rev' — this method
-                injects them. Caller contract: CouchDBExecutionClient.put() already
+                injects them. Caller contract: CouchDBExecutionClient.save() already
                 validates this at the realm-facing boundary; this check is a
                 defensive duplicate for any direct handler callers.
             rev: Current document revision. Required for updates; absent for create.

--- a/lib/realms/test_realm/recipes.py
+++ b/lib/realms/test_realm/recipes.py
@@ -798,6 +798,56 @@ def data_write_only_permission(
 
 
 # ---------------------------------------------------------------------------
+# Recipe: data_write_no_id
+# ---------------------------------------------------------------------------
+
+
+def data_write_no_id(
+    overrides: dict[str, Any] | None = None,
+) -> list[StepSpec]:
+    """
+    Generate a plan that writes a document to CouchDB without supplying a _id.
+
+    Uses the selector identity path of save() so CouchDB auto-generates the
+    document ID on create. The resolved/generated doc_id appears in step metrics,
+    along with identity="selector" and operation="upsert" to make the write
+    path visible for verification.
+
+    Steps:
+        1. write_doc_no_id: Write with selector identity, no explicit _id
+        2. echo_confirm: Confirm write completed (depends on write_doc_no_id)
+
+    Args:
+        overrides: Optional param overrides by step_id.
+
+    Returns:
+        List of StepSpec for Engine execution
+    """
+    overrides = overrides or {}
+
+    steps = [
+        _make_step(
+            step_id="write_doc_no_id",
+            name="Write Doc Without _id",
+            fn_name="step_write_to_db_no_id",
+            params={
+                "connection": "test_realm_write_db",
+                "mode": "upsert",
+            },
+        ),
+        _make_step(
+            step_id="echo_confirm",
+            name="Confirm Write",
+            fn_name="step_echo",
+            params={"message": "CouchDB auto-generated ID write complete!"},
+            deps=["write_doc_no_id"],
+        ),
+    ]
+
+    return _apply_overrides(steps, overrides)
+
+
+# ---------------------------------------------------------------------------
 # Helper: Apply parameter overrides
 # ---------------------------------------------------------------------------
 
@@ -844,6 +894,7 @@ RECIPES: dict[str, Any] = {
     "data_verify_limit_clamping": data_verify_limit_clamping,
     "data_write_exec": data_write_exec,
     "data_write_only_permission": data_write_only_permission,
+    "data_write_no_id": data_write_no_id,
 }
 
 

--- a/lib/realms/test_realm/recipes.py
+++ b/lib/realms/test_realm/recipes.py
@@ -703,7 +703,7 @@ def data_write_exec(
     Generate a plan that writes a document to CouchDB at execution time.
 
     Proves that a step with execution write permission can call
-    client.put() successfully via ctx.data.connection(). The write result
+    client.save() successfully via ctx.data.connection(). The write result
     (status, doc_id, old_rev, new_rev) is returned in step metrics and
     emitted as a step.write_result event so it is visible in the execution
     record.

--- a/lib/realms/test_realm/steps.py
+++ b/lib/realms/test_realm/steps.py
@@ -20,6 +20,7 @@ stops the plan on failure.
 
 import random
 import time
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -313,7 +314,7 @@ def step_write_to_db(
         "written_by": "test_realm/step_write_to_db",
     }
     client = ctx.data.connection(connection)
-    result = client.put(doc_id, body, mode=mode)
+    result = client.save(body, doc_id=doc_id, mode=mode)
 
     ctx.emit(
         "step.write_result",
@@ -328,6 +329,73 @@ def step_write_to_db(
             "doc_id": result.doc_id,
             "old_rev": result.old_rev,
             "new_rev": result.new_rev,
+        }
+    )
+
+
+@step
+def step_write_to_db_no_id(
+    ctx: StepContext,
+    connection: str = "test_realm_write_db",
+    selector: dict[str, Any] | None = None,
+    mode: str = "upsert",
+) -> StepResult:
+    """
+    Write a document to CouchDB without providing a _id.
+
+    Uses Mango selector identity so CouchDB auto-generates the document ID on
+    create. Demonstrates the selector identity path of save().
+
+    Args:
+        ctx: Step execution context
+        connection: Connection name with execution write permission
+        selector: Mango selector for identity (default: match by type + written_by)
+        mode: Write mode — "create", "update", or "upsert" (default)
+
+    Returns:
+        StepResult with write outcome fields; doc_id is CouchDB-generated on create
+
+    Raises:
+        RuntimeError: If ctx.data was not injected
+        DataAccessDeniedError: If the realm lacks write permission
+        DataAccessWriteError: If the write fails (e.g. conflict)
+    """
+    if ctx.data is None:
+        raise RuntimeError(
+            "ctx.data is None — DataAccess was not injected by the Engine"
+        )
+
+    effective_selector = selector or {
+        "type": "ygg_test_write_result_no_id",
+        "written_by": "test_realm/step_write_to_db_no_id",
+    }
+    body = {
+        "type": "ygg_test_write_result_no_id",
+        "status": "written",
+        "written_by": "test_realm/step_write_to_db_no_id",
+        "write_mode": mode,
+        "updated_at": datetime.now(UTC).isoformat(),
+    }
+    client = ctx.data.connection(connection)
+    result = client.save(body, selector=effective_selector, mode=mode)
+
+    ctx.emit(
+        "step.write_result",
+        write_status=result.status,
+        doc_id=result.doc_id,
+        old_rev=result.old_rev,
+        new_rev=result.new_rev,
+        identity=result.identity,
+        operation=result.operation,
+    )
+    return StepResult(
+        metrics={
+            "write_status": result.status,
+            "doc_id": result.doc_id,
+            "old_rev": result.old_rev,
+            "new_rev": result.new_rev,
+            "identity": result.identity,
+            "operation": result.operation,
         }
     )
 

--- a/tests/test_couchdb_data_client.py
+++ b/tests/test_couchdb_data_client.py
@@ -29,7 +29,14 @@ from yggdrasil.flow.data_access.models import (
 # ---------------------------------------------------------------------------
 
 
-def make_handler_mock(*, get_result=None, find_result=None, put_result=None):
+def make_handler_mock(
+    *,
+    get_result=None,
+    find_result=None,
+    put_result=None,
+    post_doc_result=None,
+    view_result=None,
+):
     handler = MagicMock()
     handler.fetch_document_by_id.return_value = get_result
     handler.find_documents.return_value = find_result or []
@@ -38,6 +45,12 @@ def make_handler_mock(*, get_result=None, find_result=None, put_result=None):
         "rev": "1-abc",
         "ok": True,
     }
+    handler.post_document.return_value = post_doc_result or {
+        "id": "gen-uuid-123",
+        "rev": "1-new",
+        "ok": True,
+    }
+    handler.query_view.return_value = view_result or {"rows": []}
     return handler
 
 
@@ -444,6 +457,16 @@ class TestCouchDBExecutionClientPutModes(unittest.TestCase):
             client.put("x", {}, mode="upsert")
         self.assertIn("_rev", str(ctx.exception))
 
+    def test_put_result_has_identity_doc_id(self):
+        handler = make_handler_mock(put_result={"rev": "1-abc"})
+        result = make_execution_client(handler).put("x", {}, mode="create")
+        self.assertEqual(result.identity, "doc_id")
+
+    def test_put_result_operation_matches_mode(self):
+        handler = make_handler_mock(put_result={"rev": "1-abc"})
+        result = make_execution_client(handler).put("x", {}, mode="create")
+        self.assertEqual(result.operation, "create")
+
 
 # ---------------------------------------------------------------------------
 # CouchDBExecutionClient.put() — result shape
@@ -464,6 +487,7 @@ class TestCouchDBExecutionClientWriteResult(unittest.TestCase):
         self.assertEqual(result.operation, "upsert")
         self.assertEqual(result.doc_id, "x")
         self.assertIn(result.status, ("created", "updated"))
+        self.assertEqual(result.identity, "doc_id")
 
     def test_write_result_status_is_str_not_bool(self):
         result = self._make_result()
@@ -573,6 +597,637 @@ class TestCouchDBExecutionClientEvents(unittest.TestCase):
         for fn in filenames:
             self.assertTrue(fn.startswith("data_access_write_"))
             self.assertTrue(fn.endswith(".json"))
+
+
+# ---------------------------------------------------------------------------
+# _emit() spool filename fix — no doc_id / doc_id=None must not raise
+# ---------------------------------------------------------------------------
+
+
+class TestEmitSpoolFilename(unittest.TestCase):
+    """Spool filename is UUID-only; absent or None doc_id must not crash."""
+
+    def _make_trace(self, emitter):
+        return DataAccessTraceContext(
+            realm="r",
+            phase="execution",
+            plan_id="p1",
+            run_id="r1",
+            step_id="s1",
+            step_name="step",
+            emitter=emitter,
+        )
+
+    def test_emit_no_doc_id_does_not_raise(self):
+        mock_emitter = MagicMock()
+        handler = make_handler_mock(put_result={"rev": "1-abc"})
+        client = make_execution_client(
+            handler, trace_context=self._make_trace(mock_emitter)
+        )
+        client._emit(
+            "data_access.write.succeeded", operation="save", identity="selector"
+        )
+        mock_emitter.emit.assert_called_once()
+        fn = mock_emitter.emit.call_args[0][0]["_spool_path"]["filename"]
+        self.assertRegex(fn, r"^data_access_write_[0-9a-f]{32}\.json$")
+
+    def test_emit_doc_id_none_does_not_raise(self):
+        mock_emitter = MagicMock()
+        handler = make_handler_mock(put_result={"rev": "1-abc"})
+        client = make_execution_client(
+            handler, trace_context=self._make_trace(mock_emitter)
+        )
+        client._emit(
+            "data_access.write.denied", doc_id=None, operation="save", identity="view"
+        )
+        mock_emitter.emit.assert_called_once()
+        fn = mock_emitter.emit.call_args[0][0]["_spool_path"]["filename"]
+        self.assertRegex(fn, r"^data_access_write_[0-9a-f]{32}\.json$")
+
+
+# ---------------------------------------------------------------------------
+# save() — validation
+# ---------------------------------------------------------------------------
+
+
+class TestCouchDBExecutionClientSaveValidation(unittest.TestCase):
+    """ValueError is raised before any I/O for bad arguments."""
+
+    def _client(self):
+        return make_execution_client(make_handler_mock())
+
+    def test_no_identity_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._client().save({})
+        self.assertIn("exactly one", str(ctx.exception))
+
+    def test_two_identities_doc_id_and_selector(self):
+        with self.assertRaises(ValueError):
+            self._client().save({}, doc_id="x", selector={"type": "run"})
+
+    def test_all_three_identities(self):
+        with self.assertRaises(ValueError):
+            self._client().save(
+                {},
+                doc_id="x",
+                selector={"type": "run"},
+                view={"design": "d", "view": "v", "key": "k"},
+            )
+
+    def test_doc_with_id_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._client().save({"_id": "x"}, doc_id="y")
+        self.assertIn("_id", str(ctx.exception))
+        self.assertIn("clean_doc", str(ctx.exception))
+
+    def test_doc_with_rev_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._client().save({"_rev": "1-a"}, doc_id="y")
+        self.assertIn("_rev", str(ctx.exception))
+
+    def test_view_missing_design_key(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._client().save({}, view={"view": "v", "key": "k"})
+        self.assertIn("design", str(ctx.exception))
+
+    def test_view_missing_view_key(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._client().save({}, view={"design": "d", "key": "k"})
+        self.assertIn("view", str(ctx.exception))
+
+    def test_view_missing_key_field(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._client().save({}, view={"design": "d", "view": "v"})
+        self.assertIn("key", str(ctx.exception))
+
+    def test_view_key_none_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._client().save({}, view={"design": "d", "view": "v", "key": None})
+        self.assertIn("None", str(ctx.exception))
+
+
+# ---------------------------------------------------------------------------
+# save() — permissions
+# ---------------------------------------------------------------------------
+
+
+class TestCouchDBExecutionClientSavePermissions(unittest.TestCase):
+    def _make_trace(self, emitter):
+        return DataAccessTraceContext(
+            realm="r",
+            phase="execution",
+            plan_id="p1",
+            run_id="r1",
+            step_id="s1",
+            step_name="step",
+            emitter=emitter,
+        )
+
+    def test_denied_without_write_permission(self):
+        from yggdrasil.flow.data_access.errors import DataAccessDeniedError
+
+        client = make_execution_client(
+            make_handler_mock(), permissions=frozenset({"read"})
+        )
+        with self.assertRaises(DataAccessDeniedError):
+            client.save({}, doc_id="x")
+
+    def test_succeeds_with_write_only_no_read(self):
+        handler = make_handler_mock(get_result=None)
+        client = make_execution_client(handler, permissions=frozenset({"write"}))
+        result = client.save({}, doc_id="x")
+        self.assertIsInstance(result, DataAccessWriteResult)
+
+    def test_denied_event_emitted(self):
+        mock_emitter = MagicMock()
+        from yggdrasil.flow.data_access.errors import DataAccessDeniedError
+
+        client = make_execution_client(
+            make_handler_mock(),
+            permissions=frozenset({"read"}),
+            trace_context=self._make_trace(mock_emitter),
+        )
+        with self.assertRaises(DataAccessDeniedError):
+            client.save({}, doc_id="x")
+        mock_emitter.emit.assert_called_once()
+        event = mock_emitter.emit.call_args[0][0]
+        self.assertEqual(event["type"], "data_access.write.denied")
+        self.assertEqual(event["identity"], "doc_id")
+        self.assertEqual(event["operation"], "upsert")
+
+
+# ---------------------------------------------------------------------------
+# save(doc_id=...) — doc_id mode
+# ---------------------------------------------------------------------------
+
+
+class TestCouchDBExecutionClientSaveByDocId(unittest.TestCase):
+    def test_creates_when_absent(self):
+        handler = make_handler_mock(get_result=None, put_result={"rev": "1-new"})
+        client = make_execution_client(handler)
+        result = client.save({"val": 1}, doc_id="x")
+        self.assertEqual(result.status, "created")
+        self.assertEqual(result.doc_id, "x")
+        self.assertEqual(result.operation, "upsert")
+        self.assertEqual(result.identity, "doc_id")
+
+    def test_updates_when_present(self):
+        handler = make_handler_mock(
+            get_result={"_id": "x", "_rev": "1-old"},
+            put_result={"rev": "2-new"},
+        )
+        client = make_execution_client(handler)
+        result = client.save({"val": 2}, doc_id="x")
+        self.assertEqual(result.status, "updated")
+        self.assertEqual(result.old_rev, "1-old")
+        self.assertEqual(result.new_rev, "2-new")
+
+
+# ---------------------------------------------------------------------------
+# save(selector=...) — selector mode
+# ---------------------------------------------------------------------------
+
+
+class TestCouchDBExecutionClientSaveBySelector(unittest.TestCase):
+    def test_creates_via_post_when_no_match(self):
+        handler = make_handler_mock(find_result=[])
+        client = make_execution_client(handler)
+        result = client.save({"val": 1}, selector={"type": "run"})
+        self.assertEqual(result.status, "created")
+        self.assertEqual(result.doc_id, "gen-uuid-123")
+        handler.put_document.assert_not_called()
+        handler.post_document.assert_called_once()
+
+    def test_updates_single_match(self):
+        handler = make_handler_mock(
+            find_result=[{"_id": "abc", "_rev": "1-xyz", "val": 0}],
+            put_result={"rev": "2-new"},
+        )
+        client = make_execution_client(handler)
+        result = client.save({"val": 1}, selector={"type": "run"})
+        self.assertEqual(result.status, "updated")
+        self.assertEqual(result.doc_id, "abc")
+        handler.post_document.assert_not_called()
+        handler.put_document.assert_called_once_with("abc", {"val": 1}, rev="1-xyz")
+
+    def test_raises_on_multiple_matches(self):
+        handler = make_handler_mock(
+            find_result=[
+                {"_id": "a", "_rev": "1-a"},
+                {"_id": "b", "_rev": "1-b"},
+            ]
+        )
+        client = make_execution_client(handler)
+        with self.assertRaises(DataAccessWriteError) as ctx:
+            client.save({"val": 1}, selector={"type": "run"})
+        self.assertIn("2", str(ctx.exception))
+
+    def test_uses_limit_2_for_find(self):
+        handler = make_handler_mock(find_result=[])
+        client = make_execution_client(handler)
+        client.save({"val": 1}, selector={"type": "run"})
+        handler.find_documents.assert_called_once_with({"type": "run"}, limit=2)
+
+    def test_update_retries_on_409(self):
+        handler = make_handler_mock(
+            find_result=[{"_id": "abc", "_rev": "1-xyz"}],
+        )
+        handler.put_document.side_effect = [
+            make_api_exception(409),
+            {"rev": "3-new", "ok": True},
+        ]
+        handler.fetch_document_by_id.return_value = {"_id": "abc", "_rev": "2-mid"}
+        client = make_execution_client(handler)
+        result = client.save({"val": 1}, selector={"type": "run"})
+        self.assertEqual(result.status, "updated")
+        self.assertEqual(result.new_rev, "3-new")
+
+    def test_query_failure_raises_write_error(self):
+        handler = make_handler_mock()
+        handler.find_documents.side_effect = make_api_exception(500)
+        client = make_execution_client(handler)
+        with self.assertRaises(DataAccessWriteError):
+            client.save({"val": 1}, selector={"type": "run"})
+
+
+# ---------------------------------------------------------------------------
+# save(view=...) — view mode
+# ---------------------------------------------------------------------------
+
+
+class TestCouchDBExecutionClientSaveByView(unittest.TestCase):
+    _view_spec = {"design": "flowcells", "view": "by_id", "key": "fc-1"}
+
+    def test_creates_via_post_when_no_rows(self):
+        handler = make_handler_mock(view_result={"rows": []})
+        client = make_execution_client(handler)
+        result = client.save({"val": 1}, view=self._view_spec)
+        self.assertEqual(result.status, "created")
+        self.assertEqual(result.doc_id, "gen-uuid-123")
+        handler.put_document.assert_not_called()
+
+    def test_updates_with_include_docs(self):
+        row = {
+            "id": "abc",
+            "key": "fc-1",
+            "value": None,
+            "doc": {"_id": "abc", "_rev": "1-xyz", "val": 0},
+        }
+        handler = make_handler_mock(
+            view_result={"rows": [row]},
+            put_result={"rev": "2-new"},
+        )
+        client = make_execution_client(handler)
+        spec = {**self._view_spec, "include_docs": True}
+        result = client.save({"val": 1}, view=spec)
+        self.assertEqual(result.status, "updated")
+        self.assertEqual(result.doc_id, "abc")
+        handler.fetch_document_by_id.assert_not_called()
+
+    def test_updates_without_include_docs_fetches_separately(self):
+        row = {"id": "abc", "key": "fc-1", "value": None}
+        handler = make_handler_mock(
+            view_result={"rows": [row]},
+            get_result={"_id": "abc", "_rev": "1-xyz"},
+            put_result={"rev": "2-new"},
+        )
+        client = make_execution_client(handler)
+        spec = {**self._view_spec, "include_docs": False}
+        result = client.save({"val": 1}, view=spec)
+        self.assertEqual(result.status, "updated")
+        handler.fetch_document_by_id.assert_called_once_with("abc")
+
+    def test_raises_on_multiple_rows(self):
+        rows = [
+            {"id": "a", "key": "fc-1", "value": None},
+            {"id": "b", "key": "fc-1", "value": None},
+        ]
+        handler = make_handler_mock(view_result={"rows": rows})
+        client = make_execution_client(handler)
+        with self.assertRaises(DataAccessWriteError) as ctx:
+            client.save({"val": 1}, view=self._view_spec)
+        self.assertIn("2", str(ctx.exception))
+
+    def test_uses_limit_2_for_query(self):
+        handler = make_handler_mock(view_result={"rows": []})
+        client = make_execution_client(handler)
+        client.save({"val": 1}, view=self._view_spec)
+        call_kwargs = handler.query_view.call_args[1]
+        self.assertEqual(call_kwargs["limit"], 2)
+
+    def test_maps_design_key_to_ddoc(self):
+        handler = make_handler_mock(view_result={"rows": []})
+        client = make_execution_client(handler)
+        client.save({"val": 1}, view=self._view_spec)
+        args = handler.query_view.call_args[0]
+        self.assertEqual(args[0], "flowcells")
+        self.assertEqual(args[1], "by_id")
+
+    def test_query_failure_raises_write_error(self):
+        handler = make_handler_mock()
+        handler.query_view.side_effect = make_api_exception(500)
+        client = make_execution_client(handler)
+        with self.assertRaises(DataAccessWriteError):
+            client.save({"val": 1}, view=self._view_spec)
+
+
+# ---------------------------------------------------------------------------
+# clean_doc()
+# ---------------------------------------------------------------------------
+
+
+class TestCouchDBExecutionClientCleanDoc(unittest.TestCase):
+    def _client(self):
+        return make_execution_client(make_handler_mock())
+
+    def test_strips_id(self):
+        self.assertEqual(self._client().clean_doc({"_id": "x", "a": 1}), {"a": 1})
+
+    def test_strips_rev(self):
+        self.assertEqual(self._client().clean_doc({"_rev": "1-abc", "a": 1}), {"a": 1})
+
+    def test_strips_both(self):
+        self.assertEqual(
+            self._client().clean_doc({"_id": "x", "_rev": "1-abc", "a": 1}),
+            {"a": 1},
+        )
+
+    def test_preserves_other_fields(self):
+        doc = {"type": "run", "status": "new"}
+        self.assertEqual(self._client().clean_doc(doc), doc)
+
+    def test_empty_doc(self):
+        self.assertEqual(self._client().clean_doc({}), {})
+
+
+# ---------------------------------------------------------------------------
+# save() — result shape
+# ---------------------------------------------------------------------------
+
+
+class TestCouchDBExecutionClientSaveResultShape(unittest.TestCase):
+    def test_operation_reflects_mode_default_upsert(self):
+        handler = make_handler_mock(get_result=None)
+        result = make_execution_client(handler).save({"a": 1}, doc_id="x")
+        self.assertEqual(result.operation, "upsert")
+
+    def test_doc_id_is_generated_for_selector_create(self):
+        handler = make_handler_mock(find_result=[])
+        result = make_execution_client(handler).save({"a": 1}, selector={"type": "run"})
+        self.assertEqual(result.doc_id, "gen-uuid-123")
+        self.assertEqual(result.identity, "selector")
+
+    def test_doc_id_is_provided_for_doc_id_mode(self):
+        handler = make_handler_mock(get_result=None)
+        result = make_execution_client(handler).save({"a": 1}, doc_id="my-doc")
+        self.assertEqual(result.doc_id, "my-doc")
+        self.assertEqual(result.identity, "doc_id")
+
+
+# ---------------------------------------------------------------------------
+# save() — event emission
+# ---------------------------------------------------------------------------
+
+
+class TestCouchDBExecutionClientSaveEvents(unittest.TestCase):
+    def _make_trace(self, emitter):
+        return DataAccessTraceContext(
+            realm="r",
+            phase="execution",
+            plan_id="p1",
+            run_id="r1",
+            step_id="s1",
+            step_name="step",
+            emitter=emitter,
+        )
+
+    def test_succeeded_has_operation_upsert_by_default(self):
+        mock_emitter = MagicMock()
+        handler = make_handler_mock(get_result=None)
+        client = make_execution_client(
+            handler, trace_context=self._make_trace(mock_emitter)
+        )
+        client.save({"a": 1}, doc_id="x")
+        event = mock_emitter.emit.call_args[0][0]
+        self.assertEqual(event["operation"], "upsert")
+
+    def test_succeeded_has_identity_doc_id(self):
+        mock_emitter = MagicMock()
+        handler = make_handler_mock(get_result=None)
+        client = make_execution_client(
+            handler, trace_context=self._make_trace(mock_emitter)
+        )
+        client.save({"a": 1}, doc_id="x")
+        event = mock_emitter.emit.call_args[0][0]
+        self.assertEqual(event["identity"], "doc_id")
+
+    def test_succeeded_has_identity_selector(self):
+        mock_emitter = MagicMock()
+        handler = make_handler_mock(find_result=[])
+        client = make_execution_client(
+            handler, trace_context=self._make_trace(mock_emitter)
+        )
+        client.save({"a": 1}, selector={"type": "run"})
+        event = mock_emitter.emit.call_args[0][0]
+        self.assertEqual(event["identity"], "selector")
+
+    def test_succeeded_has_identity_view(self):
+        mock_emitter = MagicMock()
+        handler = make_handler_mock(view_result={"rows": []})
+        client = make_execution_client(
+            handler, trace_context=self._make_trace(mock_emitter)
+        )
+        client.save({"a": 1}, view={"design": "d", "view": "v", "key": "k"})
+        event = mock_emitter.emit.call_args[0][0]
+        self.assertEqual(event["identity"], "view")
+
+    def test_succeeded_selector_includes_selector_and_resolved_doc_id(self):
+        mock_emitter = MagicMock()
+        handler = make_handler_mock(find_result=[])
+        client = make_execution_client(
+            handler, trace_context=self._make_trace(mock_emitter)
+        )
+        sel = {"type": "run"}
+        client.save({"a": 1}, selector=sel)
+        event = mock_emitter.emit.call_args[0][0]
+        self.assertEqual(event["selector"], sel)
+        self.assertEqual(event["doc_id"], "gen-uuid-123")
+
+    def test_succeeded_view_includes_view_spec_and_resolved_doc_id(self):
+        mock_emitter = MagicMock()
+        handler = make_handler_mock(view_result={"rows": []})
+        client = make_execution_client(
+            handler, trace_context=self._make_trace(mock_emitter)
+        )
+        view_spec = {"design": "d", "view": "v", "key": "k"}
+        client.save({"a": 1}, view=view_spec)
+        event = mock_emitter.emit.call_args[0][0]
+        self.assertEqual(event["view"], view_spec)
+        self.assertEqual(event["doc_id"], "gen-uuid-123")
+
+    def test_failed_selector_event_includes_selector(self):
+        mock_emitter = MagicMock()
+        handler = make_handler_mock()
+        handler.find_documents.side_effect = make_api_exception(500)
+        client = make_execution_client(
+            handler, trace_context=self._make_trace(mock_emitter)
+        )
+        sel = {"type": "run"}
+        with self.assertRaises(DataAccessWriteError):
+            client.save({"a": 1}, selector=sel)
+        mock_emitter.emit.assert_called_once()
+        event = mock_emitter.emit.call_args[0][0]
+        self.assertEqual(event["type"], "data_access.write.failed")
+        self.assertEqual(event["selector"], sel)
+
+    def test_failed_view_event_includes_view(self):
+        mock_emitter = MagicMock()
+        handler = make_handler_mock()
+        handler.query_view.side_effect = make_api_exception(500)
+        client = make_execution_client(
+            handler, trace_context=self._make_trace(mock_emitter)
+        )
+        view_spec = {"design": "d", "view": "v", "key": "k"}
+        with self.assertRaises(DataAccessWriteError):
+            client.save({"a": 1}, view=view_spec)
+        mock_emitter.emit.assert_called_once()
+        event = mock_emitter.emit.call_args[0][0]
+        self.assertEqual(event["type"], "data_access.write.failed")
+        self.assertEqual(event["view"], view_spec)
+
+
+# ---------------------------------------------------------------------------
+# save(doc_id=...) — mode matrix
+# ---------------------------------------------------------------------------
+
+
+class TestCouchDBExecutionClientSaveByDocIdModes(unittest.TestCase):
+    def test_create_mode_succeeds_when_absent(self):
+        handler = make_handler_mock(put_result={"rev": "1-new"})
+        result = make_execution_client(handler).save(
+            {"v": 1}, doc_id="x", mode="create"
+        )
+        self.assertEqual(result.status, "created")
+        self.assertEqual(result.operation, "create")
+        self.assertEqual(result.identity, "doc_id")
+        # create goes straight to PUT — no pre-fetch of the existing doc
+        handler.fetch_document_by_id.assert_not_called()
+
+    def test_create_mode_fails_when_doc_exists(self):
+        handler = make_handler_mock()
+        handler.put_document.side_effect = make_api_exception(409)
+        with self.assertRaises(DataAccessWriteError):
+            make_execution_client(handler).save({}, doc_id="x", mode="create")
+
+    def test_update_mode_succeeds_when_present(self):
+        handler = make_handler_mock(
+            get_result={"_id": "x", "_rev": "1-old"},
+            put_result={"rev": "2-new"},
+        )
+        result = make_execution_client(handler).save(
+            {"v": 2}, doc_id="x", mode="update"
+        )
+        self.assertEqual(result.status, "updated")
+        self.assertEqual(result.operation, "update")
+
+    def test_update_mode_fails_when_doc_absent(self):
+        handler = make_handler_mock(get_result=None)
+        with self.assertRaises(DataAccessWriteError):
+            make_execution_client(handler).save({}, doc_id="x", mode="update")
+
+
+# ---------------------------------------------------------------------------
+# save(selector=...) — mode matrix
+# ---------------------------------------------------------------------------
+
+
+class TestCouchDBExecutionClientSaveBySelectorModes(unittest.TestCase):
+    _sel = {"type": "run"}
+
+    def test_create_mode_creates_on_no_match(self):
+        handler = make_handler_mock(find_result=[])
+        result = make_execution_client(handler).save(
+            {"v": 1}, selector=self._sel, mode="create"
+        )
+        self.assertEqual(result.status, "created")
+        self.assertEqual(result.operation, "create")
+
+    def test_create_mode_fails_on_single_match(self):
+        handler = make_handler_mock(find_result=[{"_id": "a", "_rev": "1-a"}])
+        with self.assertRaises(DataAccessWriteError):
+            make_execution_client(handler).save({}, selector=self._sel, mode="create")
+
+    def test_update_mode_updates_on_single_match(self):
+        handler = make_handler_mock(
+            find_result=[{"_id": "a", "_rev": "1-a"}],
+            put_result={"rev": "2-new"},
+        )
+        result = make_execution_client(handler).save(
+            {"v": 2}, selector=self._sel, mode="update"
+        )
+        self.assertEqual(result.status, "updated")
+        self.assertEqual(result.operation, "update")
+
+    def test_update_mode_fails_on_no_match(self):
+        handler = make_handler_mock(find_result=[])
+        with self.assertRaises(DataAccessWriteError):
+            make_execution_client(handler).save({}, selector=self._sel, mode="update")
+
+    def test_identity_is_selector_in_result(self):
+        handler = make_handler_mock(find_result=[])
+        result = make_execution_client(handler).save({"v": 1}, selector=self._sel)
+        self.assertEqual(result.identity, "selector")
+
+
+# ---------------------------------------------------------------------------
+# save(view=...) — mode matrix
+# ---------------------------------------------------------------------------
+
+
+class TestCouchDBExecutionClientSaveByViewModes(unittest.TestCase):
+    _spec = {"design": "fc", "view": "by_id", "key": "k1"}
+
+    def _row(self, doc_id="abc", rev="1-xyz"):
+        return {
+            "id": doc_id,
+            "key": "k1",
+            "value": None,
+            "doc": {"_id": doc_id, "_rev": rev},
+        }
+
+    def test_create_mode_creates_on_no_rows(self):
+        handler = make_handler_mock(view_result={"rows": []})
+        result = make_execution_client(handler).save(
+            {"v": 1}, view=self._spec, mode="create"
+        )
+        self.assertEqual(result.status, "created")
+        self.assertEqual(result.operation, "create")
+
+    def test_create_mode_fails_on_single_row(self):
+        handler = make_handler_mock(view_result={"rows": [self._row()]})
+        with self.assertRaises(DataAccessWriteError):
+            make_execution_client(handler).save({}, view=self._spec, mode="create")
+
+    def test_update_mode_updates_on_single_row(self):
+        handler = make_handler_mock(
+            view_result={"rows": [self._row()]},
+            put_result={"rev": "2-new"},
+        )
+        result = make_execution_client(handler).save(
+            {"v": 2}, view=self._spec, mode="update"
+        )
+        self.assertEqual(result.status, "updated")
+        self.assertEqual(result.operation, "update")
+
+    def test_update_mode_fails_on_no_rows(self):
+        handler = make_handler_mock(view_result={"rows": []})
+        with self.assertRaises(DataAccessWriteError):
+            make_execution_client(handler).save({}, view=self._spec, mode="update")
+
+    def test_identity_is_view_in_result(self):
+        handler = make_handler_mock(view_result={"rows": []})
+        result = make_execution_client(handler).save({"v": 1}, view=self._spec)
+        self.assertEqual(result.identity, "view")
 
 
 if __name__ == "__main__":

--- a/tests/test_couchdb_data_client.py
+++ b/tests/test_couchdb_data_client.py
@@ -128,10 +128,10 @@ class TestCouchDBPlanningClient(unittest.IsolatedAsyncioTestCase):
         doc = await client.require("x")
         self.assertEqual(doc["val"], 1)
 
-    def test_planning_client_has_no_put_method(self):
+    def test_planning_client_has_no_save_method(self):
         handler = make_handler_mock()
         client = make_planning_client(handler)
-        self.assertFalse(hasattr(client, "put"))
+        self.assertFalse(hasattr(client, "save"))
 
 
 # ---------------------------------------------------------------------------
@@ -186,130 +186,75 @@ class TestCouchDBExecutionClientReads(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# CouchDBExecutionClient.put() — permission tests
+# CouchDBExecutionClient.save(doc_id=...) — mode tests
 # ---------------------------------------------------------------------------
 
 
-class TestCouchDBExecutionClientPutPermissions(unittest.TestCase):
-    def test_put_denied_without_write_permission(self):
-        handler = make_handler_mock()
-        client = make_execution_client(handler, permissions=frozenset({"read"}))
-        with self.assertRaises(DataAccessDeniedError):
-            client.put("x", {})
-
-    def test_put_succeeds_with_only_write_permission_no_read(self):
-        handler = make_handler_mock()
-        client = make_execution_client(handler, permissions=frozenset({"write"}))
-        # create mode: no pre-fetch needed
-        result = client.put("x", {}, mode="create")
-        self.assertIsInstance(result, DataAccessWriteResult)
-
-    def test_upsert_succeeds_with_only_write_permission(self):
-        """Internal _rev fetch must NOT require realm-level 'read' permission."""
-        handler = make_handler_mock(get_result=None)  # absent → create path
-        client = make_execution_client(handler, permissions=frozenset({"write"}))
-        result = client.put("x", {}, mode="upsert")
-        self.assertEqual(result.status, "created")
-
-
-# ---------------------------------------------------------------------------
-# CouchDBExecutionClient.put() — input validation
-# ---------------------------------------------------------------------------
-
-
-class TestCouchDBExecutionClientPutValidation(unittest.TestCase):
-    def test_invalid_mode_raises_value_error(self):
-        handler = make_handler_mock()
-        client = make_execution_client(handler)
-        with self.assertRaises(ValueError) as ctx:
-            client.put("x", {}, mode="replace")
-        self.assertIn("replace", str(ctx.exception))
-
-    def test_doc_with_id_raises_value_error(self):
-        handler = make_handler_mock()
-        client = make_execution_client(handler)
-        with self.assertRaises(ValueError) as ctx:
-            client.put("x", {"_id": "x"})
-        self.assertIn("_id", str(ctx.exception))
-
-    def test_doc_with_rev_raises_value_error(self):
-        handler = make_handler_mock()
-        client = make_execution_client(handler)
-        with self.assertRaises(ValueError) as ctx:
-            client.put("x", {"_rev": "1-abc"})
-        self.assertIn("_rev", str(ctx.exception))
-
-
-# ---------------------------------------------------------------------------
-# CouchDBExecutionClient.put() — mode tests
-# ---------------------------------------------------------------------------
-
-
-class TestCouchDBExecutionClientPutModes(unittest.TestCase):
-    def test_put_create_returns_created_status(self):
+class TestCouchDBExecutionClientSaveByDocIdRetryPaths(unittest.TestCase):
+    def test_create_returns_created_status(self):
         handler = make_handler_mock(put_result={"rev": "1-abc", "ok": True})
         client = make_execution_client(handler)
-        result = client.put("x", {"val": 1}, mode="create")
+        result = client.save({}, doc_id="x", mode="create")
         handler.fetch_document_by_id.assert_not_called()
         self.assertEqual(result.status, "created")
         self.assertIsNone(result.old_rev)
         self.assertEqual(result.new_rev, "1-abc")
 
-    def test_put_create_fails_on_409(self):
+    def test_create_fails_on_409(self):
         handler = make_handler_mock()
         handler.put_document.side_effect = make_api_exception(409)
         client = make_execution_client(handler)
         with self.assertRaises(DataAccessWriteError) as ctx:
-            client.put("x", {}, mode="create")
+            client.save({}, doc_id="x", mode="create")
         self.assertIn("already exists", str(ctx.exception))
 
-    def test_put_update_returns_updated_status(self):
+    def test_update_returns_updated_status(self):
         handler = make_handler_mock(
             get_result={"_id": "x", "_rev": "1-old"},
             put_result={"rev": "2-new", "ok": True},
         )
         client = make_execution_client(handler)
-        result = client.put("x", {"val": 2}, mode="update")
+        result = client.save({"val": 2}, doc_id="x", mode="update")
         self.assertEqual(result.status, "updated")
         self.assertEqual(result.old_rev, "1-old")
         self.assertEqual(result.new_rev, "2-new")
 
-    def test_put_update_fails_when_doc_absent(self):
+    def test_update_fails_when_doc_absent(self):
         handler = make_handler_mock(get_result=None)
         client = make_execution_client(handler)
         with self.assertRaises(DataAccessWriteError) as ctx:
-            client.put("x", {}, mode="update")
+            client.save({}, doc_id="x", mode="update")
         self.assertIn("does not exist", str(ctx.exception))
 
-    def test_put_update_fetch_failure_raises_write_error(self):
+    def test_update_fetch_failure_raises_write_error(self):
         """ApiException during pre-fetch is wrapped as DataAccessWriteError."""
         handler = make_handler_mock()
         handler.fetch_document_by_id.side_effect = make_api_exception(500)
         client = make_execution_client(handler)
         with self.assertRaises(DataAccessWriteError) as ctx:
-            client.put("x", {}, mode="update")
+            client.save({}, doc_id="x", mode="update")
         self.assertIn("pre-check", str(ctx.exception))
 
-    def test_put_upsert_creates_when_absent(self):
+    def test_upsert_creates_when_absent(self):
         handler = make_handler_mock(
             get_result=None,
             put_result={"rev": "1-abc", "ok": True},
         )
         client = make_execution_client(handler)
-        result = client.put("x", {}, mode="upsert")
+        result = client.save({}, doc_id="x", mode="upsert")
         self.assertEqual(result.status, "created")
 
-    def test_put_upsert_updates_when_present(self):
+    def test_upsert_updates_when_present(self):
         handler = make_handler_mock(
             get_result={"_id": "x", "_rev": "1-old"},
             put_result={"rev": "2-new", "ok": True},
         )
         client = make_execution_client(handler)
-        result = client.put("x", {"val": 2}, mode="upsert")
+        result = client.save({"val": 2}, doc_id="x", mode="upsert")
         self.assertEqual(result.status, "updated")
         self.assertEqual(result.old_rev, "1-old")
 
-    def test_put_upsert_retries_once_on_409(self):
+    def test_upsert_retries_once_on_409(self):
         handler = make_handler_mock()
         # First fetch returns present doc
         handler.fetch_document_by_id.side_effect = [
@@ -322,30 +267,30 @@ class TestCouchDBExecutionClientPutModes(unittest.TestCase):
             {"rev": "3-xyz", "ok": True},
         ]
         client = make_execution_client(handler)
-        result = client.put("x", {"val": 1}, mode="upsert")
+        result = client.save({"val": 1}, doc_id="x", mode="upsert")
         self.assertEqual(result.status, "updated")
         self.assertEqual(result.new_rev, "3-xyz")
 
-    def test_put_upsert_raises_after_two_409s(self):
+    def test_upsert_raises_after_two_409s(self):
         handler = make_handler_mock()
         handler.fetch_document_by_id.return_value = {"_id": "x", "_rev": "1-old"}
         handler.put_document.side_effect = make_api_exception(409)
         client = make_execution_client(handler)
         with self.assertRaises(DataAccessWriteError) as ctx:
-            client.put("x", {}, mode="upsert")
+            client.save({}, doc_id="x", mode="upsert")
         self.assertIn("consecutive", str(ctx.exception))
 
-    def test_put_upsert_fetch_failure_raises_write_error(self):
+    def test_upsert_fetch_failure_raises_write_error(self):
         from requests.exceptions import RequestException
 
         handler = make_handler_mock()
         handler.fetch_document_by_id.side_effect = RequestException("timeout")
         client = make_execution_client(handler)
         with self.assertRaises(DataAccessWriteError) as ctx:
-            client.put("x", {}, mode="upsert")
+            client.save({}, doc_id="x", mode="upsert")
         self.assertIn("pre-check", str(ctx.exception))
 
-    def test_put_upsert_retry_fetch_failure_raises_write_error(self):
+    def test_upsert_retry_fetch_failure_raises_write_error(self):
         """Fetch failure during retry raises DataAccessWriteError."""
         from requests.exceptions import RequestException
 
@@ -358,7 +303,7 @@ class TestCouchDBExecutionClientPutModes(unittest.TestCase):
         handler.put_document.side_effect = make_api_exception(409)
         client = make_execution_client(handler)
         with self.assertRaises(DataAccessWriteError):
-            client.put("x", {}, mode="upsert")
+            client.save({}, doc_id="x", mode="upsert")
 
     # --- Fix 3: create-path 409 retry ---
 
@@ -374,7 +319,7 @@ class TestCouchDBExecutionClientPutModes(unittest.TestCase):
             {"rev": "2-xyz", "ok": True},  # retry update: success
         ]
         client = make_execution_client(handler)
-        result = client.put("x", {}, mode="upsert")
+        result = client.save({}, doc_id="x", mode="upsert")
         self.assertEqual(result.status, "updated")
         self.assertEqual(result.new_rev, "2-xyz")
 
@@ -391,7 +336,7 @@ class TestCouchDBExecutionClientPutModes(unittest.TestCase):
         ]
         client = make_execution_client(handler)
         with self.assertRaises(DataAccessWriteError) as ctx:
-            client.put("x", {}, mode="upsert")
+            client.save({}, doc_id="x", mode="upsert")
         self.assertIn("consecutive", str(ctx.exception))
 
     def test_upsert_create_path_409_refetch_absent_retries_create(self):
@@ -406,7 +351,7 @@ class TestCouchDBExecutionClientPutModes(unittest.TestCase):
             {"rev": "1-abc", "ok": True},  # second create: success
         ]
         client = make_execution_client(handler)
-        result = client.put("x", {}, mode="upsert")
+        result = client.save({}, doc_id="x", mode="upsert")
         self.assertEqual(result.status, "created")
 
     def test_upsert_create_path_non_409_error_raises(self):
@@ -416,7 +361,7 @@ class TestCouchDBExecutionClientPutModes(unittest.TestCase):
         handler.put_document.side_effect = make_api_exception(500)
         client = make_execution_client(handler)
         with self.assertRaises(DataAccessWriteError) as ctx:
-            client.put("x", {}, mode="upsert")
+            client.save({}, doc_id="x", mode="upsert")
         self.assertIn("500", str(ctx.exception))
 
     # --- Fix 4: retry transport errors wrapped ---
@@ -436,7 +381,7 @@ class TestCouchDBExecutionClientPutModes(unittest.TestCase):
         ]
         client = make_execution_client(handler)
         with self.assertRaises(DataAccessWriteError) as ctx:
-            client.put("x", {}, mode="upsert")
+            client.save({}, doc_id="x", mode="upsert")
         self.assertIn("connection reset", str(ctx.exception))
 
     # --- Fix 5: _rev guard ---
@@ -446,7 +391,7 @@ class TestCouchDBExecutionClientPutModes(unittest.TestCase):
         handler = make_handler_mock(get_result={"_id": "x", "value": 1})  # no _rev
         client = make_execution_client(handler)
         with self.assertRaises(DataAccessWriteError) as ctx:
-            client.put("x", {}, mode="update")
+            client.save({}, doc_id="x", mode="update")
         self.assertIn("_rev", str(ctx.exception))
 
     def test_upsert_raises_when_existing_doc_has_no_rev(self):
@@ -454,22 +399,22 @@ class TestCouchDBExecutionClientPutModes(unittest.TestCase):
         handler = make_handler_mock(get_result={"_id": "x", "value": 1})  # no _rev
         client = make_execution_client(handler)
         with self.assertRaises(DataAccessWriteError) as ctx:
-            client.put("x", {}, mode="upsert")
+            client.save({}, doc_id="x", mode="upsert")
         self.assertIn("_rev", str(ctx.exception))
 
-    def test_put_result_has_identity_doc_id(self):
+    def test_result_has_identity_doc_id(self):
         handler = make_handler_mock(put_result={"rev": "1-abc"})
-        result = make_execution_client(handler).put("x", {}, mode="create")
+        result = make_execution_client(handler).save({}, doc_id="x", mode="create")
         self.assertEqual(result.identity, "doc_id")
 
-    def test_put_result_operation_matches_mode(self):
+    def test_result_operation_matches_mode(self):
         handler = make_handler_mock(put_result={"rev": "1-abc"})
-        result = make_execution_client(handler).put("x", {}, mode="create")
+        result = make_execution_client(handler).save({}, doc_id="x", mode="create")
         self.assertEqual(result.operation, "create")
 
 
 # ---------------------------------------------------------------------------
-# CouchDBExecutionClient.put() — result shape
+# CouchDBExecutionClient.save() — result shape
 # ---------------------------------------------------------------------------
 
 
@@ -477,7 +422,7 @@ class TestCouchDBExecutionClientWriteResult(unittest.TestCase):
     def _make_result(self):
         handler = make_handler_mock(put_result={"rev": "1-abc", "ok": True})
         client = make_execution_client(handler)
-        return client.put("x", {"val": 1}, mode="upsert")
+        return client.save({"val": 1}, doc_id="x", mode="upsert")
 
     def test_write_result_fields(self):
         result = self._make_result()
@@ -496,7 +441,7 @@ class TestCouchDBExecutionClientWriteResult(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# CouchDBExecutionClient.put() — event emission
+# CouchDBExecutionClient.save() — event emission
 # ---------------------------------------------------------------------------
 
 
@@ -518,7 +463,7 @@ class TestCouchDBExecutionClientEvents(unittest.TestCase):
         client = make_execution_client(
             handler, trace_context=self._make_trace(mock_emitter)
         )
-        client.put("x", {}, mode="create")
+        client.save({}, doc_id="x", mode="create")
         mock_emitter.emit.assert_called_once()
         event = mock_emitter.emit.call_args[0][0]
         self.assertEqual(event["type"], "data_access.write.succeeded")
@@ -535,7 +480,7 @@ class TestCouchDBExecutionClientEvents(unittest.TestCase):
             handler, permissions=frozenset({"read"}), trace_context=trace
         )
         with self.assertRaises(DataAccessDeniedError):
-            client.put("x", {})
+            client.save({}, doc_id="x")
         mock_emitter.emit.assert_called_once()
         event = mock_emitter.emit.call_args[0][0]
         self.assertEqual(event["type"], "data_access.write.denied")
@@ -548,7 +493,7 @@ class TestCouchDBExecutionClientEvents(unittest.TestCase):
             handler, trace_context=self._make_trace(mock_emitter)
         )
         with self.assertRaises(DataAccessWriteError):
-            client.put("x", {}, mode="create")
+            client.save({}, doc_id="x", mode="create")
         mock_emitter.emit.assert_called_once()
         event = mock_emitter.emit.call_args[0][0]
         self.assertEqual(event["type"], "data_access.write.failed")
@@ -560,13 +505,13 @@ class TestCouchDBExecutionClientEvents(unittest.TestCase):
         client = make_execution_client(
             handler, trace_context=self._make_trace(mock_emitter)
         )
-        result = client.put("x", {}, mode="create")
+        result = client.save({}, doc_id="x", mode="create")
         self.assertEqual(result.status, "created")
 
     def test_no_emission_when_trace_context_is_none(self):
         handler = make_handler_mock(put_result={"rev": "1-abc"})
         client = make_execution_client(handler, trace_context=None)
-        result = client.put("x", {}, mode="create")
+        result = client.save({}, doc_id="x", mode="create")
         self.assertIsNotNone(result)
 
     def test_spool_path_hints_in_event(self):
@@ -574,7 +519,7 @@ class TestCouchDBExecutionClientEvents(unittest.TestCase):
         trace = self._make_trace(mock_emitter)
         handler = make_handler_mock(put_result={"rev": "1-abc"})
         client = make_execution_client(handler, trace_context=trace)
-        client.put("x", {}, mode="create")
+        client.save({}, doc_id="x", mode="create")
         event = mock_emitter.emit.call_args[0][0]
         sp = event["_spool_path"]
         self.assertEqual(sp["realm"], trace.realm)
@@ -582,13 +527,13 @@ class TestCouchDBExecutionClientEvents(unittest.TestCase):
         self.assertEqual(sp["step_id"], trace.step_id)
 
     def test_write_events_have_unique_filenames(self):
-        """Two put() calls in the same step produce unique _spool_path filenames."""
+        """Two save() calls in the same step produce unique _spool_path filenames."""
         mock_emitter = MagicMock()
         trace = self._make_trace(mock_emitter)
         handler = make_handler_mock(put_result={"rev": "1-abc"})
         client = make_execution_client(handler, trace_context=trace)
-        client.put("doc_a", {}, mode="create")
-        client.put("doc_b", {}, mode="create")
+        client.save({}, doc_id="doc_a", mode="create")
+        client.save({}, doc_id="doc_b", mode="create")
         filenames = [
             c[0][0]["_spool_path"]["filename"] for c in mock_emitter.emit.call_args_list
         ]

--- a/tests/test_db_connection_manager.py
+++ b/tests/test_db_connection_manager.py
@@ -815,5 +815,270 @@ class TestCouchDBHandlerPutDocument(unittest.TestCase):
             self.handler.put_document("doc1", {"status": "x"})
 
 
+class TestCouchDBHandlerPostDocument(unittest.TestCase):
+    """Tests for CouchDBHandler.post_document."""
+
+    def setUp(self):
+        with (
+            patch(
+                "lib.couchdb.couchdb_connection.CouchDBClientFactory.create_client"
+            ) as mock_factory,
+            patch.dict(os.environ, {"PD_USER": "admin", "PD_PASS": "secret"}),
+        ):
+            self.mock_client = MagicMock()
+            mock_factory.return_value = self.mock_client
+            self.handler = CouchDBHandler(
+                db_name="test_db",
+                url="http://localhost:5984",
+                user_env="PD_USER",
+                pass_env="PD_PASS",
+            )
+        self.mock_client.reset_mock()
+
+    def _set_post_result(self, result):
+        self.mock_client.post_document.return_value.get_result.return_value = result
+
+    def test_returns_sdk_response(self):
+        """post_document returns the SDK response dict unchanged."""
+        expected = {"id": "gen-uuid-abc", "rev": "1-new", "ok": True}
+        self._set_post_result(expected)
+
+        result = self.handler.post_document({"status": "ready"})
+
+        self.assertEqual(result, expected)
+
+    def test_calls_sdk_with_correct_db(self):
+        """post_document forwards correct db to the SDK."""
+        self._set_post_result({"id": "x", "rev": "1-r", "ok": True})
+
+        self.handler.post_document({"status": "ready"})
+
+        call_kwargs = self.mock_client.post_document.call_args[1]
+        self.assertEqual(call_kwargs["db"], "test_db")
+
+    def test_does_not_inject_id_into_body(self):
+        """post_document must NOT inject _id — CouchDB generates it."""
+        self._set_post_result({"id": "gen-x", "rev": "1-r", "ok": True})
+
+        with patch("lib.couchdb.couchdb_connection.cloudant_v1") as mock_cv1:
+            self.handler.post_document({"type": "run", "status": "new"})
+            body = mock_cv1.Document.from_dict.call_args[0][0]
+
+        self.assertNotIn("_id", body)
+        self.assertNotIn("_rev", body)
+        self.assertEqual(body["type"], "run")
+
+    def test_does_not_mutate_caller_doc(self):
+        """post_document must not modify the caller's dict."""
+        self._set_post_result({"id": "gen-x", "rev": "1-r", "ok": True})
+        original = {"type": "run", "status": "new"}
+        snapshot = dict(original)
+
+        self.handler.post_document(original)
+
+        self.assertEqual(original, snapshot)
+
+    def test_raises_if_doc_contains_id(self):
+        """ValueError is raised if caller's doc contains _id."""
+        with self.assertRaises(ValueError) as ctx:
+            self.handler.post_document({"_id": "existing", "status": "x"})
+        self.assertIn("_id", str(ctx.exception))
+        self.mock_client.post_document.assert_not_called()
+
+    def test_raises_if_doc_contains_rev(self):
+        """ValueError is raised if caller's doc contains _rev."""
+        with self.assertRaises(ValueError) as ctx:
+            self.handler.post_document({"_rev": "1-abc", "status": "x"})
+        self.assertIn("_rev", str(ctx.exception))
+        self.mock_client.post_document.assert_not_called()
+
+    def test_raises_if_doc_contains_both_reserved_keys(self):
+        """ValueError is raised if caller's doc contains both _id and _rev."""
+        with self.assertRaises(ValueError):
+            self.handler.post_document({"_id": "x", "_rev": "1-abc", "status": "x"})
+        self.mock_client.post_document.assert_not_called()
+
+    def test_api_exception_propagates(self):
+        """ApiException from the SDK propagates unchanged."""
+        self.mock_client.post_document.side_effect = MockApiException(
+            "server error", code=500
+        )
+
+        with self.assertRaises(MockApiException) as ctx:
+            self.handler.post_document({"status": "x"})
+        self.assertEqual(ctx.exception.status_code, 500)
+
+    def test_generic_exception_propagates(self):
+        """Non-ApiException from the SDK propagates unchanged."""
+        self.mock_client.post_document.side_effect = RuntimeError("network failure")
+
+        with self.assertRaises(RuntimeError):
+            self.handler.post_document({"status": "x"})
+
+
+class TestCouchDBHandlerQueryView(unittest.TestCase):
+    """Tests for CouchDBHandler.query_view."""
+
+    def setUp(self):
+        with (
+            patch(
+                "lib.couchdb.couchdb_connection.CouchDBClientFactory.create_client"
+            ) as mock_factory,
+            patch.dict(os.environ, {"QV_USER": "admin", "QV_PASS": "secret"}),
+        ):
+            self.mock_client = MagicMock()
+            mock_factory.return_value = self.mock_client
+            self.handler = CouchDBHandler(
+                db_name="test_db",
+                url="http://localhost:5984",
+                user_env="QV_USER",
+                pass_env="QV_PASS",
+            )
+        self.mock_client.reset_mock()
+
+    def _set_view_result(self, result):
+        self.mock_client.post_view.return_value.get_result.return_value = result
+
+    def test_returns_raw_result_dict(self):
+        """query_view returns the full result dict from the SDK."""
+        rows = [{"id": "doc1", "key": "k", "value": None}]
+        self._set_view_result({"rows": rows, "total_rows": 1, "offset": 0})
+
+        result = self.handler.query_view("design_doc", "my_view", key="k")
+
+        self.assertEqual(result["rows"], rows)
+
+    def test_calls_sdk_with_mandatory_kwargs(self):
+        """query_view always sends db, ddoc, view, include_docs, reduce, stable."""
+        self._set_view_result({"rows": []})
+
+        self.handler.query_view("design_doc", "my_view")
+
+        call_kwargs = self.mock_client.post_view.call_args[1]
+        self.assertEqual(call_kwargs["db"], "test_db")
+        self.assertEqual(call_kwargs["ddoc"], "design_doc")
+        self.assertEqual(call_kwargs["view"], "my_view")
+        self.assertIn("include_docs", call_kwargs)
+        self.assertIn("reduce", call_kwargs)
+        self.assertIn("stable", call_kwargs)
+
+    def test_default_flags_are_false(self):
+        """Default include_docs, reduce, and stable are all False."""
+        self._set_view_result({"rows": []})
+
+        self.handler.query_view("ddoc", "view")
+
+        call_kwargs = self.mock_client.post_view.call_args[1]
+        self.assertFalse(call_kwargs["include_docs"])
+        self.assertFalse(call_kwargs["reduce"])
+        self.assertFalse(call_kwargs["stable"])
+
+    def test_key_included_when_provided(self):
+        """key is sent to the SDK when not None."""
+        self._set_view_result({"rows": []})
+
+        self.handler.query_view("ddoc", "view", key="flowcell-1")
+
+        call_kwargs = self.mock_client.post_view.call_args[1]
+        self.assertEqual(call_kwargs["key"], "flowcell-1")
+
+    def test_key_omitted_when_none(self):
+        """key is not sent to the SDK when None (the default)."""
+        self._set_view_result({"rows": []})
+
+        self.handler.query_view("ddoc", "view", key=None)
+
+        call_kwargs = self.mock_client.post_view.call_args[1]
+        self.assertNotIn("key", call_kwargs)
+
+    def test_limit_included_when_provided(self):
+        """limit is sent to the SDK when not None."""
+        self._set_view_result({"rows": []})
+
+        self.handler.query_view("ddoc", "view", limit=10)
+
+        call_kwargs = self.mock_client.post_view.call_args[1]
+        self.assertEqual(call_kwargs["limit"], 10)
+
+    def test_limit_omitted_when_none(self):
+        """limit is not sent to the SDK when None (the default)."""
+        self._set_view_result({"rows": []})
+
+        self.handler.query_view("ddoc", "view", limit=None)
+
+        call_kwargs = self.mock_client.post_view.call_args[1]
+        self.assertNotIn("limit", call_kwargs)
+
+    def test_key_and_limit_both_sent_when_provided(self):
+        """key and limit are both included when both are specified."""
+        self._set_view_result({"rows": []})
+
+        self.handler.query_view("ddoc", "view", key="k1", limit=2)
+
+        call_kwargs = self.mock_client.post_view.call_args[1]
+        self.assertEqual(call_kwargs["key"], "k1")
+        self.assertEqual(call_kwargs["limit"], 2)
+
+    def test_include_docs_true_forwarded(self):
+        """include_docs=True is forwarded to the SDK."""
+        self._set_view_result({"rows": []})
+
+        self.handler.query_view("ddoc", "view", include_docs=True)
+
+        call_kwargs = self.mock_client.post_view.call_args[1]
+        self.assertTrue(call_kwargs["include_docs"])
+
+    def test_reduce_true_forwarded(self):
+        """reduce=True is forwarded to the SDK."""
+        self._set_view_result({"rows": []})
+
+        self.handler.query_view("ddoc", "view", reduce=True)
+
+        call_kwargs = self.mock_client.post_view.call_args[1]
+        self.assertTrue(call_kwargs["reduce"])
+
+    def test_stable_true_forwarded(self):
+        """stable=True is forwarded to the SDK."""
+        self._set_view_result({"rows": []})
+
+        self.handler.query_view("ddoc", "view", stable=True)
+
+        call_kwargs = self.mock_client.post_view.call_args[1]
+        self.assertTrue(call_kwargs["stable"])
+
+    def test_non_dict_result_returns_empty_rows(self):
+        """Non-dict SDK result returns {"rows": []}."""
+        self.mock_client.post_view.return_value.get_result.return_value = "not-a-dict"
+
+        result = self.handler.query_view("ddoc", "view")
+
+        self.assertEqual(result, {"rows": []})
+
+    def test_404_api_exception_propagates(self):
+        """ApiException from the SDK propagates unchanged."""
+        self.mock_client.post_view.side_effect = MockApiException("not found", code=404)
+
+        with self.assertRaises(MockApiException) as ctx:
+            self.handler.query_view("ddoc", "view")
+        self.assertEqual(ctx.exception.status_code, 404)
+
+    def test_500_api_exception_propagates(self):
+        """5xx ApiException propagates unchanged."""
+        self.mock_client.post_view.side_effect = MockApiException(
+            "server error", code=500
+        )
+
+        with self.assertRaises(MockApiException) as ctx:
+            self.handler.query_view("ddoc", "view")
+        self.assertEqual(ctx.exception.status_code, 500)
+
+    def test_generic_exception_propagates(self):
+        """Non-ApiException from the SDK propagates unchanged."""
+        self.mock_client.post_view.side_effect = RuntimeError("connection reset")
+
+        with self.assertRaises(RuntimeError):
+            self.handler.query_view("ddoc", "view")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_test_realm_steps.py
+++ b/tests/test_test_realm_steps.py
@@ -24,6 +24,7 @@ _ALL_STEP_NAMES = [
     "step_fetch_from_db",
     "step_expect_denied",
     "step_write_to_db",
+    "step_write_to_db_no_id",
     "step_expect_read_denied",
     "step_exercise_all_fetch_methods",
     "step_verify_limit_clamping",
@@ -99,6 +100,7 @@ class TestStepWriteToDb(unittest.TestCase):
             connection_name="test_realm_write_db",
             resource="yggdrasil",
             operation="upsert",
+            identity="doc_id",
             doc_id="data_access_test:write_result",
             status=status,
             old_rev=old_rev,
@@ -107,30 +109,30 @@ class TestStepWriteToDb(unittest.TestCase):
 
     def _make_ctx(self, write_result):
         ctx = MagicMock()
-        ctx.data.connection.return_value.put.return_value = write_result
+        ctx.data.connection.return_value.save.return_value = write_result
         return ctx
 
-    def test_put_called_with_clean_body(self):
-        """Body passed to put() must not contain _id or _rev."""
+    def test_save_called_with_clean_body(self):
+        """Body passed to save() must not contain _id or _rev."""
         result = self._make_write_result()
         ctx = self._make_ctx(result)
 
         self.step_fn(ctx)
 
-        put_call = ctx.data.connection.return_value.put.call_args
-        body = put_call[0][1]  # second positional argument
+        save_call = ctx.data.connection.return_value.save.call_args
+        body = save_call[0][0]  # first positional argument
         self.assertNotIn("_id", body)
         self.assertNotIn("_rev", body)
 
-    def test_put_called_with_correct_doc_id_and_mode(self):
+    def test_save_called_with_correct_doc_id_and_mode(self):
         result = self._make_write_result()
         ctx = self._make_ctx(result)
 
         self.step_fn(ctx, doc_id="custom:doc", mode="create")
 
-        put_call = ctx.data.connection.return_value.put.call_args
-        self.assertEqual(put_call[0][0], "custom:doc")
-        self.assertEqual(put_call[1]["mode"], "create")
+        save_call = ctx.data.connection.return_value.save.call_args
+        self.assertEqual(save_call[1]["doc_id"], "custom:doc")
+        self.assertEqual(save_call[1]["mode"], "create")
 
     def test_metrics_include_write_result_fields_on_create(self):
         result = self._make_write_result(
@@ -156,6 +158,97 @@ class TestStepWriteToDb(unittest.TestCase):
         self.assertEqual(step_result.metrics["write_status"], "updated")
         self.assertEqual(step_result.metrics["old_rev"], "1-abc")
         self.assertEqual(step_result.metrics["new_rev"], "2-def")
+
+    def test_raises_if_ctx_data_is_none(self):
+        ctx = MagicMock()
+        ctx.data = None
+        with self.assertRaises(RuntimeError):
+            self.step_fn(ctx)
+
+
+# ---------------------------------------------------------------------------
+# Functional: step_write_to_db_no_id
+# ---------------------------------------------------------------------------
+
+
+class TestStepWriteToDbNoId(unittest.TestCase):
+    """Functional tests for step_write_to_db_no_id."""
+
+    def setUp(self):
+        from lib.realms.test_realm.steps import step_write_to_db_no_id
+        from yggdrasil.flow.data_access.models import DataAccessWriteResult
+
+        self.step_fn = step_write_to_db_no_id
+        self.WriteResult = DataAccessWriteResult
+
+    def _make_write_result(
+        self,
+        status="created",
+        doc_id="auto-generated-id-abc",
+        old_rev=None,
+        new_rev="1-xyz",
+    ):
+        return self.WriteResult(
+            backend="couchdb",
+            connection_name="test_realm_write_db",
+            resource="yggdrasil",
+            operation="upsert",
+            identity="selector",
+            doc_id=doc_id,
+            status=status,
+            old_rev=old_rev,
+            new_rev=new_rev,
+        )
+
+    def _make_ctx(self, write_result):
+        ctx = MagicMock()
+        ctx.data.connection.return_value.save.return_value = write_result
+        return ctx
+
+    def test_save_called_with_selector_mode_not_doc_id(self):
+        """save() must use selector=... and mode=..., not doc_id=..."""
+        ctx = self._make_ctx(self._make_write_result())
+        self.step_fn(ctx, mode="upsert")
+        save_call = ctx.data.connection.return_value.save.call_args
+        self.assertIn("selector", save_call[1])
+        self.assertEqual(save_call[1]["mode"], "upsert")
+        self.assertNotIn("doc_id", save_call[1])
+
+    def test_save_called_with_clean_body(self):
+        """Body passed to save() must not contain _id or _rev."""
+        ctx = self._make_ctx(self._make_write_result())
+        self.step_fn(ctx)
+        save_call = ctx.data.connection.return_value.save.call_args
+        body = save_call[0][0]
+        self.assertNotIn("_id", body)
+        self.assertNotIn("_rev", body)
+
+    def test_default_selector_applied_when_none_provided(self):
+        """When selector param is None, a non-empty default selector must be used."""
+        ctx = self._make_ctx(self._make_write_result())
+        self.step_fn(ctx)
+        save_call = ctx.data.connection.return_value.save.call_args
+        sel = save_call[1]["selector"]
+        self.assertIsInstance(sel, dict)
+        self.assertTrue(len(sel) > 0)
+
+    def test_custom_selector_overrides_default(self):
+        """Explicit selector param must be forwarded to save()."""
+        ctx = self._make_ctx(self._make_write_result())
+        custom = {"type": "my_type", "batch_id": "b-42"}
+        self.step_fn(ctx, selector=custom)
+        save_call = ctx.data.connection.return_value.save.call_args
+        self.assertEqual(save_call[1]["selector"], custom)
+
+    def test_metrics_include_couchdb_generated_doc_id_and_identity(self):
+        """doc_id, identity, and operation in metrics must reflect the write result."""
+        result = self._make_write_result(doc_id="couchdb-abc123")
+        ctx = self._make_ctx(result)
+        step_result = self.step_fn(ctx)
+        self.assertEqual(step_result.metrics["doc_id"], "couchdb-abc123")
+        self.assertEqual(step_result.metrics["write_status"], "created")
+        self.assertEqual(step_result.metrics["identity"], "selector")
+        self.assertEqual(step_result.metrics["operation"], "upsert")
 
     def test_raises_if_ctx_data_is_none(self):
         ctx = MagicMock()

--- a/yggdrasil/flow/data_access/__init__.py
+++ b/yggdrasil/flow/data_access/__init__.py
@@ -15,7 +15,7 @@ Usage::
 
     # Writes — pass a clean body dict (no _id or _rev)
     body = {"status": "complete", "updated_by": "yggdrasil"}
-    result = client.put("run_123", body, mode="upsert")
+    result = client.save(body, doc_id="run_123", mode="upsert")
 """
 
 from yggdrasil.flow.data_access.data_access import DataAccess

--- a/yggdrasil/flow/data_access/couchdb_data.py
+++ b/yggdrasil/flow/data_access/couchdb_data.py
@@ -683,25 +683,11 @@ class CouchDBExecutionClient:
 
     # --- Write ---
 
-    def put(
-        self,
-        doc_id: str,
-        doc: dict[str, Any],
-        *,
-        mode: Literal["create", "update", "upsert"] = "upsert",
-    ) -> DataAccessWriteResult:
-        """Thin compatibility wrapper around save(doc, doc_id=doc_id, mode=mode).
-
-        Prefer save() for new realm code. put() is kept for backward compatibility
-        only and may be removed in a future version.
-        """
-        return self.save(doc, doc_id=doc_id, mode=mode)
-
     def clean_doc(self, doc: dict[str, Any]) -> dict[str, Any]:
         """Return a shallow copy of doc with CouchDB metadata fields removed.
 
         Strips '_id' and '_rev', preserving all other fields. Use this before
-        passing a document obtained via get() or find() to save() or put().
+        passing a document obtained via get() or find() to save().
         """
         return {k: v for k, v in doc.items() if k not in {"_id", "_rev"}}
 

--- a/yggdrasil/flow/data_access/couchdb_data.py
+++ b/yggdrasil/flow/data_access/couchdb_data.py
@@ -128,6 +128,16 @@ class CouchDBPlanningClient:
 # ---------------------------------------------------------------------------
 
 
+def _validate_clean_doc(doc: dict[str, Any]) -> None:
+    reserved = {"_id", "_rev"} & doc.keys()
+    if reserved:
+        raise ValueError(
+            f"doc must not contain CouchDB metadata fields {sorted(reserved)!r}. "
+            "DataAccess manages _id and _rev internally. "
+            "Pass a clean body dict, or call client.clean_doc(doc) before save()."
+        )
+
+
 class _CouchDBWriteOps:
     """Internal CouchDB write helpers used only by CouchDBExecutionClient.
 
@@ -372,6 +382,195 @@ class _CouchDBWriteOps:
                 f"Network/transport error upserting '{doc_id}': {exc}"
             ) from exc
 
+    def _post_new(
+        self, doc: dict[str, Any]
+    ) -> tuple[str, Literal["created"], None, str | None]:
+        """Create a document via HTTP POST, letting CouchDB generate the ID.
+
+        Returns a 4-tuple (resolved_doc_id, "created", None, new_rev).
+
+        Raises:
+            DataAccessWriteError: On any backend failure.
+        """
+        try:
+            result = self._handler.post_document(doc)
+            return result["id"], "created", None, result.get("rev")
+        except _WRITE_EXCEPTIONS as exc:
+            raise DataAccessWriteError(
+                f"CouchDB error creating document via POST: {exc}"
+            ) from exc
+
+    def _find_for_write(
+        self, selector: dict[str, Any], *, limit: int
+    ) -> list[dict[str, Any]]:
+        """Run a Mango selector query as part of a write operation.
+
+        Wraps failures as DataAccessWriteError (not DataAccessQueryError) because
+        the failure occurs in a write operation context.
+        """
+        try:
+            return self._handler.find_documents(selector, limit=limit)
+        except _WRITE_EXCEPTIONS as exc:
+            raise DataAccessWriteError(
+                f"Mango query failed during save: {exc}"
+            ) from exc
+
+    def _view_for_write(
+        self,
+        document: str,
+        view_name: str,
+        *,
+        key: Any,
+        limit: int,
+        include_docs: bool,
+    ) -> list[dict[str, Any]]:
+        """Query a CouchDB view as part of a write operation.
+
+        Wraps failures as DataAccessWriteError. Always passes reduce=False to
+        ensure individual map rows with 'id' fields are returned.
+        """
+        try:
+            result = self._handler.query_view(
+                document,
+                view_name,
+                key=key,
+                limit=limit,
+                include_docs=include_docs,
+                reduce=False,
+            )
+            return result.get("rows", [])
+        except _WRITE_EXCEPTIONS as exc:
+            raise DataAccessWriteError(
+                f"View query '{document}/{view_name}' failed during save: {exc}"
+            ) from exc
+
+    def _save_by_selector(
+        self,
+        doc: dict[str, Any],
+        selector: dict[str, Any],
+        *,
+        mode: Literal["create", "update", "upsert"],
+        logger: logging.Logger,
+    ) -> tuple[str, Literal["created", "updated"], str | None, str | None]:
+        """Save a document identified by a Mango selector.
+
+        Finds documents matching selector with limit=2, then applies mode:
+
+        create:  0 matches → create via POST; 1+ matches → DataAccessWriteError.
+        update:  0 matches → DataAccessWriteError; 1 match → update; >1 → error.
+        upsert:  0 matches → create via POST; 1 match → update; >1 → error.
+
+        Returns a 4-tuple (resolved_doc_id, status, old_rev, new_rev).
+
+        Retry on 409 (update path): inherited from _upsert_present, which
+        refetches by doc_id. The selector is not re-run on retry; this is
+        acceptable because the document's identity is already known from the
+        initial match.
+        """
+        matches = self._find_for_write(selector, limit=2)
+        count = len(matches)
+        if count > 1:
+            raise DataAccessWriteError(
+                f"save() by selector matched {count} documents (limit=2); "
+                "expected 0 or 1. Refine the selector to match at most one document."
+            )
+        if count == 0:
+            if mode == "update":
+                raise DataAccessWriteError(
+                    "save() mode='update' by selector: no matching document found."
+                )
+            return self._post_new(doc)
+        # count == 1
+        if mode == "create":
+            raise DataAccessWriteError(
+                "save() mode='create' by selector: a matching document already exists."
+            )
+        existing = matches[0]
+        doc_id: str = existing["_id"]
+        old_rev: str | None = existing.get("_rev")
+        status, result_old_rev, new_rev = self._upsert_present(
+            doc_id, doc, old_rev, logger=logger
+        )
+        return doc_id, status, result_old_rev, new_rev
+
+    def _save_by_view(
+        self,
+        doc: dict[str, Any],
+        view_spec: dict[str, Any],
+        *,
+        mode: Literal["create", "update", "upsert"],
+        logger: logging.Logger,
+    ) -> tuple[str, Literal["created", "updated"], str | None, str | None]:
+        """Save a document identified by a CouchDB view row.
+
+        Queries the view with limit=2, then applies mode:
+
+        create:  0 rows → create via POST; 1+ rows → DataAccessWriteError.
+        update:  0 rows → DataAccessWriteError; 1 row → update; >1 → error.
+        upsert:  0 rows → create via POST; 1 row → update; >1 → error.
+
+        The target view must be a map-only view; reduce=False is always enforced.
+
+        view_spec keys:
+            "design":       Design document name (required).
+            "view":         View name (required).
+            "key":          View key to filter rows (required, must not be None).
+            "include_docs": If True (default), embed full docs in rows to avoid
+                            an extra fetch per update. If False, _rev is fetched
+                            separately.
+
+        Returns a 4-tuple (resolved_doc_id, status, old_rev, new_rev).
+        """
+        design = view_spec["design"]
+        view_name = view_spec["view"]
+        key = view_spec["key"]
+        include_docs = view_spec.get("include_docs", True)
+
+        rows = self._view_for_write(
+            design, view_name, key=key, limit=2, include_docs=include_docs
+        )
+        count = len(rows)
+        if count > 1:
+            raise DataAccessWriteError(
+                f"save() by view '{design}/{view_name}' matched {count} rows (limit=2); "
+                "expected 0 or 1."
+            )
+        if count == 0:
+            if mode == "update":
+                raise DataAccessWriteError(
+                    f"save() mode='update' by view '{design}/{view_name}': no matching row found."
+                )
+            return self._post_new(doc)
+        # count == 1
+        if mode == "create":
+            raise DataAccessWriteError(
+                f"save() mode='create' by view '{design}/{view_name}': a matching row already exists."
+            )
+        row = rows[0]
+        doc_id = row["id"]
+        row_doc = row.get("doc")
+        if include_docs and isinstance(row_doc, dict):
+            old_rev = row_doc.get("_rev")
+        else:
+            existing = self._fetch_existing_for_write(doc_id)
+            if existing is None:
+                if mode == "update":
+                    raise DataAccessWriteError(
+                        f"save() mode='update' by view: row referenced doc '{doc_id}' "
+                        "but it no longer exists."
+                    )
+                logger.warning(
+                    "View row referenced doc '%s' but it no longer exists; creating new document.",
+                    doc_id,
+                )
+                return self._post_new(doc)
+            old_rev = existing.get("_rev")
+
+        status, result_old_rev, new_rev = self._upsert_present(
+            doc_id, doc, old_rev, logger=logger
+        )
+        return doc_id, status, result_old_rev, new_rev
+
 
 # ---------------------------------------------------------------------------
 # Execution client — sync reads + writes
@@ -454,7 +653,6 @@ class CouchDBExecutionClient:
         """
         if self._trace is None or self._trace.emitter is None:
             return
-        doc_id: str = extra.get("doc_id", "")
         event: dict[str, Any] = {
             "type": type_,
             "realm": self._trace.realm,
@@ -470,10 +668,7 @@ class CouchDBExecutionClient:
                 "plan_id": self._trace.plan_id or "unknown",
                 "step_id": self._trace.step_id or "unknown",
                 "run_id": self._trace.run_id,
-                "filename": (
-                    f"data_access_write_{doc_id[:12].replace('/', '_')}"
-                    f"_{uuid4().hex[:8]}.json"
-                ),
+                "filename": f"data_access_write_{uuid4().hex}.json",
             },
             **extra,
         }
@@ -495,45 +690,124 @@ class CouchDBExecutionClient:
         *,
         mode: Literal["create", "update", "upsert"] = "upsert",
     ) -> DataAccessWriteResult:
-        """Write a document to the CouchDB database.
+        """Thin compatibility wrapper around save(doc, doc_id=doc_id, mode=mode).
+
+        Prefer save() for new realm code. put() is kept for backward compatibility
+        only and may be removed in a future version.
+        """
+        return self.save(doc, doc_id=doc_id, mode=mode)
+
+    def clean_doc(self, doc: dict[str, Any]) -> dict[str, Any]:
+        """Return a shallow copy of doc with CouchDB metadata fields removed.
+
+        Strips '_id' and '_rev', preserving all other fields. Use this before
+        passing a document obtained via get() or find() to save() or put().
+        """
+        return {k: v for k, v in doc.items() if k not in {"_id", "_rev"}}
+
+    def save(
+        self,
+        doc: dict[str, Any],
+        *,
+        doc_id: str | None = None,
+        selector: dict[str, Any] | None = None,
+        view: dict[str, Any] | None = None,
+        mode: Literal["create", "update", "upsert"] = "upsert",
+    ) -> DataAccessWriteResult:
+        """Write a document using one of three identity modes.
+
+        Exactly one of doc_id, selector, or view must be provided.
 
         Args:
-            doc_id: Target document ID.
-            doc: Document body. Must NOT contain '_id' or '_rev' — DataAccess
-                manages document identity and revision internally. Pass a clean
-                body dict only. If you obtained a document via get(), strip the
-                CouchDB metadata fields before passing it here.
-            mode: Write mode:
-                "create"  — fail if document exists (409).
+            doc: Document body. Must NOT contain '_id' or '_rev'. Call
+                clean_doc(doc) to strip metadata before passing here.
+            doc_id: Write by explicit CouchDB document ID.
+            selector: Write by Mango selector. Finds with limit=2.
+            view: Write by CouchDB view row. Required keys: "design", "view",
+                "key" (must not be None). Optional: "include_docs" (default True).
+                The target view must be a map-only view; reduce=False is always
+                enforced internally. Null-key view lookups are not supported.
+            mode: Write intent:
+                "create"  — fail if document already exists.
                 "update"  — fail if document does not exist.
-                "upsert"  — create if missing, update if present; retries once on 409.
+                "upsert"  — create if absent, update if present (default).
+
+        Mode × identity semantics:
+
+            doc_id + create  → create with provided _id; fail if exists (409).
+            doc_id + update  → fetch _rev, update; fail if absent.
+            doc_id + upsert  → create if absent, update if present; retry once on 409.
+
+            selector + create  → 0 matches → POST; 1+ matches → DataAccessWriteError.
+            selector + update  → 0 matches → DataAccessWriteError; 1 match → update.
+            selector + upsert  → 0 matches → POST; 1 match → update; >1 → error.
+
+            view + create/update/upsert → same semantics as selector, via view query.
 
         Returns:
-            DataAccessWriteResult with status, revisions, and context.
+            DataAccessWriteResult with the resolved doc_id, requested operation,
+            and identity indicating which argument was used.
 
         Raises:
-            ValueError: doc contains '_id' or '_rev' (caller contract violation).
-            ValueError: mode is not one of 'create', 'update', 'upsert'.
+            ValueError: mode is invalid, identity count != 1, doc is dirty,
+                or view dict is malformed.
             DataAccessDeniedError: Realm lacks 'write' permission.
-            DataAccessWriteError: Backend conflict or write failure, including
-                internal _rev fetch failures.
+            DataAccessWriteError: Constraint violation, backend conflict, or failure.
+
+        Warning — non-atomic operation:
+            All three identity modes perform a lookup followed by a write. A
+            concurrent writer may create a document between the lookup and the
+            write (selector/view modes) or modify the document's revision
+            (doc_id mode). The retry-on-409 path handles revision conflicts for
+            the update case. For the upsert/create path in selector/view modes,
+            a race between two "no match" observations produces two documents; a
+            subsequent save() call will detect this via the limit=2 check and
+            raise DataAccessWriteError. This is safe when Yggdrasil is the only
+            writer for the logical document, or when concurrent creation is rare
+            and operationally detectable.
         """
         if mode not in {"create", "update", "upsert"}:
             raise ValueError(
                 f"Invalid mode '{mode}'. Must be one of: 'create', 'update', 'upsert'."
             )
 
-        reserved = {"_id", "_rev"} & doc.keys()
-        if reserved:
+        modes_given = sum(x is not None for x in (doc_id, selector, view))
+        if modes_given != 1:
             raise ValueError(
-                f"doc must not contain {sorted(reserved)!r}. "
-                "DataAccess manages document identity and revision internally. "
-                "Pass a clean body dict without CouchDB metadata fields."
+                f"save() requires exactly one of: doc_id, selector, view. Got {modes_given}."
             )
 
-        common: dict[str, Any] = {"operation": mode, "doc_id": doc_id}
+        _validate_clean_doc(doc)
 
-        # Permission check — raise immediately; Phase 6 event emission is in _emit()
+        if view is not None:
+            missing = {k for k in ("design", "view", "key") if k not in view}
+            if missing:
+                raise ValueError(
+                    f"view dict is missing required keys: {sorted(missing)!r}. "
+                    "Expected 'design', 'view', and 'key' keys."
+                )
+            if view["key"] is None:
+                raise ValueError(
+                    "'key' in view dict must not be None for save(). "
+                    "save() requires a specific key to identify a single document. "
+                    "Use save(doc, doc_id=..., mode=...) for operations without a view lookup."
+                )
+
+        identity: Literal["doc_id", "selector", "view"] = (
+            "doc_id"
+            if doc_id is not None
+            else "selector" if selector is not None else "view"
+        )
+        common: dict[str, Any] = {
+            "operation": mode,
+            "doc_id": doc_id,
+            "identity": identity,
+        }
+        if selector is not None:
+            common["selector"] = selector
+        elif view is not None:
+            common["view"] = view
+
         if "write" not in self._permissions:
             self._emit(
                 "data_access.write.denied",
@@ -545,14 +819,27 @@ class CouchDBExecutionClient:
                 f"for connection '{self._connection_name}'."
             )
 
-        dispatch = {
-            "create": self._write_ops._create,
-            "update": self._write_ops._update,
-            "upsert": lambda did, d: self._write_ops._upsert(did, d, logger=_logger),
-        }
-
         try:
-            status, old_rev, new_rev = dispatch[mode](doc_id, doc)
+            if doc_id is not None:
+                dispatch = {
+                    "create": lambda: self._write_ops._create(doc_id, doc),
+                    "update": lambda: self._write_ops._update(doc_id, doc),
+                    "upsert": lambda: self._write_ops._upsert(
+                        doc_id, doc, logger=_logger
+                    ),
+                }
+                status, old_rev, new_rev = dispatch[mode]()
+                resolved_doc_id: str = doc_id
+            elif selector is not None:
+                resolved_doc_id, status, old_rev, new_rev = (
+                    self._write_ops._save_by_selector(
+                        doc, selector, mode=mode, logger=_logger
+                    )
+                )
+            elif view is not None:
+                resolved_doc_id, status, old_rev, new_rev = (
+                    self._write_ops._save_by_view(doc, view, mode=mode, logger=_logger)
+                )
         except DataAccessWriteError as exc:
             self._emit("data_access.write.failed", error=str(exc), **common)
             raise
@@ -562,18 +849,17 @@ class CouchDBExecutionClient:
             connection_name=self._connection_name,
             resource=self._resource,
             operation=mode,
-            doc_id=doc_id,
+            identity=identity,
+            doc_id=resolved_doc_id,
             status=status,
             old_rev=old_rev,
             new_rev=new_rev,
         )
-
         self._emit(
             "data_access.write.succeeded",
             status=status,
             old_rev=old_rev,
             new_rev=new_rev,
-            **common,
+            **{**common, "doc_id": resolved_doc_id},
         )
-
         return result

--- a/yggdrasil/flow/data_access/models.py
+++ b/yggdrasil/flow/data_access/models.py
@@ -42,8 +42,9 @@ class DataAccessWriteResult:
         backend: Backend type (e.g. "couchdb").
         connection_name: Connection name from config.
         resource: Backend resource identifier (db name for CouchDB).
-        operation: Write mode used: "create", "update", or "upsert".
-        doc_id: Document ID that was written.
+        operation: Requested write mode: "create", "update", or "upsert".
+        identity: Identity resolution method used: "doc_id", "selector", or "view".
+        doc_id: Document ID that was written (existing, provided, or CouchDB-generated).
         status: "created" if the document was new; "updated" if it existed.
         old_rev: Previous CouchDB revision, or None if document was created.
         new_rev: New CouchDB revision after the write, or None if unavailable.
@@ -52,7 +53,8 @@ class DataAccessWriteResult:
     backend: str
     connection_name: str
     resource: str
-    operation: str
+    operation: Literal["create", "update", "upsert"]
+    identity: Literal["doc_id", "selector", "view"]
     doc_id: str
     status: Literal["created", "updated"]
     old_rev: str | None


### PR DESCRIPTION
In this PR the `put()` method has been replaced with a more flexible `save()` method. The new `save()` method supports multiple identity modes (by `doc_id`, `selector`, or `view`), which better accommodates legacy CouchDB use cases and improves clarity. The documentation, code examples, and test references have all been updated to use `save()` instead of `put()`, and new result fields and behaviors are described. This change ensures the API is more expressive and future-proof for different backend needs.

**API Changes and Rationale:**

- Replaced the realm-facing write method `put()` with `save()` throughout the documentation, reflecting the new API that supports document identification via `doc_id`, `selector`, or `view`. This makes the API more flexible and aligns with legacy CouchDB usage patterns, since it can now issue document generation without a specified `_id` (auto-generated by CouchDB). [[1]](diffhunk://#diff-5271ee34d0a98f204761f7e981bd9378786fe0a36802e077adee2e65f7a9398fL4-R10) [[2]](diffhunk://#diff-5271ee34d0a98f204761f7e981bd9378786fe0a36802e077adee2e65f7a9398fL294-R312) [[3]](diffhunk://#diff-5271ee34d0a98f204761f7e981bd9378786fe0a36802e077adee2e65f7a9398fL324-R325) [[4]](diffhunk://#diff-5271ee34d0a98f204761f7e981bd9378786fe0a36802e077adee2e65f7a9398fL352-R367) [[5]](diffhunk://#diff-5271ee34d0a98f204761f7e981bd9378786fe0a36802e077adee2e65f7a9398fL366-R392) [[6]](diffhunk://#diff-5271ee34d0a98f204761f7e981bd9378786fe0a36802e077adee2e65f7a9398fL438-R462) [[7]](diffhunk://#diff-5271ee34d0a98f204761f7e981bd9378786fe0a36802e077adee2e65f7a9398fL493-R506) [[8]](diffhunk://#diff-5271ee34d0a98f204761f7e981bd9378786fe0a36802e077adee2e65f7a9398fL527-R544) [[9]](diffhunk://#diff-5271ee34d0a98f204761f7e981bd9378786fe0a36802e077adee2e65f7a9398fR577-R605) [[10]](diffhunk://#diff-2d1c364eef7dbb68e87a4814b73ee5f4e9932b756436781e954321669501ea27L241-R241) [[11]](diffhunk://#diff-2d1c364eef7dbb68e87a4814b73ee5f4e9932b756436781e954321669501ea27L276-R295) [[12]](diffhunk://#diff-2d1c364eef7dbb68e87a4814b73ee5f4e9932b756436781e954321669501ea27L305-R327) [[13]](diffhunk://#diff-ed593359d6ddb121fad46dfa23edaf1c536251f3a868dc9427f98ac5dd8fcf47L184-R184) [[14]](diffhunk://#diff-ed593359d6ddb121fad46dfa23edaf1c536251f3a868dc9427f98ac5dd8fcf47L384-R384) [[15]](diffhunk://#diff-ed593359d6ddb121fad46dfa23edaf1c536251f3a868dc9427f98ac5dd8fcf47L393-R411) [[16]](diffhunk://#diff-ed593359d6ddb121fad46dfa23edaf1c536251f3a868dc9427f98ac5dd8fcf47L408-R420) [[17]](diffhunk://#diff-40afb11bbf1b60b3adab748b0719f84c9a83debcb159988b27d7d39624bb7413L36-R38) [[18]](diffhunk://#diff-40afb11bbf1b60b3adab748b0719f84c9a83debcb159988b27d7d39624bb7413L59-R61)

**Documentation and Example Updates:**

- Updated all code examples, method signatures, and API tables in the design PRD, flow API overview, realm authoring cookbook, and test realm references to use `save()` instead of `put()`. Examples now show how to use the new identity modes and describe the expected result fields. [[1]](diffhunk://#diff-5271ee34d0a98f204761f7e981bd9378786fe0a36802e077adee2e65f7a9398fL294-R312) [[2]](diffhunk://#diff-5271ee34d0a98f204761f7e981bd9378786fe0a36802e077adee2e65f7a9398fL324-R325) [[3]](diffhunk://#diff-5271ee34d0a98f204761f7e981bd9378786fe0a36802e077adee2e65f7a9398fL352-R367) [[4]](diffhunk://#diff-5271ee34d0a98f204761f7e981bd9378786fe0a36802e077adee2e65f7a9398fL366-R392) [[5]](diffhunk://#diff-5271ee34d0a98f204761f7e981bd9378786fe0a36802e077adee2e65f7a9398fL438-R462) [[6]](diffhunk://#diff-2d1c364eef7dbb68e87a4814b73ee5f4e9932b756436781e954321669501ea27L276-R295) [[7]](diffhunk://#diff-2d1c364eef7dbb68e87a4814b73ee5f4e9932b756436781e954321669501ea27R304-R314) [[8]](diffhunk://#diff-ed593359d6ddb121fad46dfa23edaf1c536251f3a868dc9427f98ac5dd8fcf47L393-R411)

**Result Model and Event Changes:**

- The result model for writes (`DataAccessWriteResult`) now includes `operation` (write intent), `identity` (how the document was resolved), and a `status` string ("created" or "updated"). Write events are updated to emit these fields. [[1]](diffhunk://#diff-5271ee34d0a98f204761f7e981bd9378786fe0a36802e077adee2e65f7a9398fL366-R392) [[2]](diffhunk://#diff-5271ee34d0a98f204761f7e981bd9378786fe0a36802e077adee2e65f7a9398fR435-R437)

**Test and Recipe Updates:**

- Test recipes and step definitions have been updated to use `save()`, including new tests for selector/view identity modes and for writing documents without an explicit `_id`. [[1]](diffhunk://#diff-5271ee34d0a98f204761f7e981bd9378786fe0a36802e077adee2e65f7a9398fL527-R544) [[2]](diffhunk://#diff-40afb11bbf1b60b3adab748b0719f84c9a83debcb159988b27d7d39624bb7413L36-R38) [[3]](diffhunk://#diff-40afb11bbf1b60b3adab748b0719f84c9a83debcb159988b27d7d39624bb7413L59-R61)

**Addendum and Migration Guidance:**

- Added a v0.3.1 addendum in the PRD explaining the motivation for the change, migration notes, and detailed examples of the new `save()` usage, including caveats about selector/view identity modes and concurrency.