### PR TITLE
Fix/add dynamic yggdrasil workspace configuration

### DIFF
--- a/docs/getting_started/configuration.md
+++ b/docs/getting_started/configuration.md
@@ -1,7 +1,11 @@
 # Configuration
 
-Yggdrasil reads configuration from files under `yggdrasil_workspace/common/configurations/`.
-That base path is set in `lib/core_utils/common.py` and can be overridden.
+Yggdrasil reads configuration files from the resolved workspace directory:
+
+- If `YGG_HOME` is set, configuration files are loaded from `$YGG_HOME/common/configurations/`.
+- If `YGG_HOME` is not set, Yggdrasil falls back to `yggdrasil_workspace/common/configurations/` beside the source tree.
+
+`YGG_HOME` must point to the root of the Yggdrasil workspace, not to the source checkout or the conda environment.
 
 Two key files:
 
@@ -115,6 +119,14 @@ Two key files:
 ---
 
 ## Environment variables
+
+### Configuration discovery
+
+| Variable | Purpose |
+|---|---|
+| `YGG_HOME` | Root of the Yggdrasil workspace. When set, config files are resolved under `$YGG_HOME/common/configurations/`. Use an absolute path in production and HPC deployments. |
+
+### Credentials and runtime paths
 
 Sensitive credentials should be set as environment variables, not stored in config files.
 

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -42,6 +42,14 @@ pip install -e .
 
 `requirements/lock.txt` is generated with `pip-compile --strip-extras` and pins exact versions.
 
+### Production / pip-installed
+
+For pip-installed deployments, choose a Yggdrasil workspace directory outside the source checkout and conda environment. Ensure `common/configurations/main.json` exists below it, then export `YGG_HOME` before starting Yggdrasil:
+
+```bash
+export YGG_HOME=/absolute/path/to/yggdrasil_workspace
+```
+
 ---
 
 ## Install an external realm (example: dataflow-dmx)

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -49,7 +49,7 @@ Credentials are resolved from `external_systems.endpoints.<name>.auth.user_env` 
 
 > **Note:** `ConfigLoader` returns `None` (silently) for any key that is absent from the config file. Mistakes that don't touch the two paths above will not surface until the code path that uses the value is actually exercised at runtime.
 
-**Resolution:** Ensure `yggdrasil_workspace/common/configurations/main.json` contains all required keys. See [configuration.md](../getting_started/configuration.md) for the full structure.
+**Resolution:** Check `main.json` in the resolved configuration directory. If `YGG_HOME` is set, Yggdrasil reads `$YGG_HOME/common/configurations/main.json`; otherwise it falls back to `yggdrasil_workspace/common/configurations/main.json`. See [configuration.md](../getting_started/configuration.md) for the full structure.
 
 ---
 

--- a/lib/core_utils/common.py
+++ b/lib/core_utils/common.py
@@ -14,14 +14,35 @@ class YggdrasilUtilities:
 
     Attributes:
         module_cache (Dict[str, Any]): Cache for loaded modules and classes.
-        CONFIG_DIR (Path): Directory containing configuration files.
+        CONFIG_DIR (Path): Default directory containing configuration files.
     """
 
     module_cache: dict[str, Any] = {}
-    CONFIG_DIR: Path = (
-        Path(__file__).parent.parent.parent
-        / "yggdrasil_workspace/common/configurations"
+    DEFAULT_WORKSPACE_PATH: Path = (
+        Path(__file__).parent.parent.parent / "yggdrasil_workspace"
     )
+    CONFIG_DIR: Path = DEFAULT_WORKSPACE_PATH / "common/configurations"
+
+    @staticmethod
+    def workspace_path() -> Path:
+        """Return the root path for the Yggdrasil workspace.
+
+        If YGG_HOME is set, it is treated as the workspace root. Otherwise,
+        return the local development workspace bundled beside the source tree.
+        """
+        ygg_home = os.environ.get("YGG_HOME")
+        if ygg_home:
+            return Path(ygg_home).expanduser()
+
+        return YggdrasilUtilities.DEFAULT_WORKSPACE_PATH
+
+    @staticmethod
+    def config_dir() -> Path:
+        """Return the directory containing Yggdrasil configuration files."""
+        if os.environ.get("YGG_HOME"):
+            return YggdrasilUtilities.workspace_path() / "common/configurations"
+
+        return YggdrasilUtilities.CONFIG_DIR
 
     @staticmethod
     def load_realm_class(module_path: str) -> type | None:
@@ -85,19 +106,21 @@ class YggdrasilUtilities:
         # Convert to Path object
         requested_path = Path(file_name)
 
-        # If file_name is absolute or tries to go outside CONFIG_DIR, return None immediately
+        # If file_name is absolute or tries to go outside config_dir, return None immediately
         if requested_path.is_absolute():
             logging.error(f"Absolute paths are not allowed: '{file_name}'")
             return None
 
-        # Construct the path within CONFIG_DIR
-        config_file = YggdrasilUtilities.CONFIG_DIR / requested_path
+        config_dir = YggdrasilUtilities.config_dir()
 
-        # Check if the constructed path is still within CONFIG_DIR (no directory traversal)
+        # Construct the path within config_dir
+        config_file = config_dir / requested_path
+
+        # Check if the constructed path is still within config_dir (no directory traversal)
         try:
-            # Resolve both paths to their absolute forms and ensure CONFIG_DIR is a parent of config_file
+            # Resolve both paths to their absolute forms and ensure config_dir is a parent of config_file
             config_file_resolved = config_file.resolve()
-            config_dir_resolved = YggdrasilUtilities.CONFIG_DIR.resolve()
+            config_dir_resolved = config_dir.resolve()
 
             if config_dir_resolved not in config_file_resolved.parents:
                 logging.error(

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
@@ -12,9 +13,11 @@ class TestYggdrasilUtilities(unittest.TestCase):
         # Backup original values
         self.original_module_cache = YggdrasilUtilities.module_cache.copy()
         self.original_config_dir = YggdrasilUtilities.CONFIG_DIR
+        self.original_ygg_home = os.environ.get("YGG_HOME")
 
         # Reset module cache
         YggdrasilUtilities.module_cache = {}
+        os.environ.pop("YGG_HOME", None)
 
         # Use a temporary config directory
         self.temp_config_dir = Path("/tmp/yggdrasil_test_config")
@@ -25,11 +28,43 @@ class TestYggdrasilUtilities(unittest.TestCase):
         # Restore original values
         YggdrasilUtilities.module_cache = self.original_module_cache
         YggdrasilUtilities.CONFIG_DIR = self.original_config_dir
+        if self.original_ygg_home is None:
+            os.environ.pop("YGG_HOME", None)
+        else:
+            os.environ["YGG_HOME"] = self.original_ygg_home
 
         # Clean up temporary config directory
         for item in self.temp_config_dir.glob("*"):
             item.unlink()
         self.temp_config_dir.rmdir()
+
+    def test_workspace_path_defaults_to_local_workspace(self):
+        expected = Path(__file__).parent.parent / "yggdrasil_workspace"
+
+        result = YggdrasilUtilities.workspace_path()
+
+        self.assertEqual(result, expected)
+
+    def test_workspace_path_uses_ygg_home(self):
+        ygg_home = "/tmp/yggdrasil_hpc_workspace"
+
+        with patch.dict(os.environ, {"YGG_HOME": ygg_home}):
+            result = YggdrasilUtilities.workspace_path()
+
+        self.assertEqual(result, Path(ygg_home))
+
+    def test_config_dir_uses_ygg_home(self):
+        ygg_home = "/tmp/yggdrasil_hpc_workspace"
+
+        with patch.dict(os.environ, {"YGG_HOME": ygg_home}):
+            result = YggdrasilUtilities.config_dir()
+
+        self.assertEqual(result, Path(ygg_home) / "common/configurations")
+
+    def test_config_dir_defaults_to_config_dir_attribute(self):
+        result = YggdrasilUtilities.config_dir()
+
+        self.assertEqual(result, self.temp_config_dir)
 
     @patch("importlib.import_module")
     def test_load_realm_class_success(self, mock_import_module):
@@ -125,6 +160,19 @@ class TestYggdrasilUtilities(unittest.TestCase):
         result = YggdrasilUtilities.get_path(file_name)
 
         self.assertIsNone(result)
+
+    def test_get_path_uses_ygg_home_config_dir(self):
+        with tempfile.TemporaryDirectory() as workspace:
+            ygg_home = Path(workspace)
+            config_dir = ygg_home / "common/configurations"
+            config_dir.mkdir(parents=True, exist_ok=True)
+            test_file = config_dir / "config.yaml"
+            test_file.touch()
+
+            with patch.dict(os.environ, {"YGG_HOME": workspace}):
+                result = YggdrasilUtilities.get_path("config.yaml")
+
+            self.assertEqual(result, test_file)
 
     def test_env_variable_exists(self):
         with patch.dict(os.environ, {"TEST_ENV_VAR": "test_value"}):


### PR DESCRIPTION
This PR improves how Yggdrasil discovers and loads its configuration files, making it easier to deploy in both development and production environments. The main change is the introduction of the `YGG_HOME` environment variable, which allows users to specify the root workspace directory. The documentation and tests have also been updated to reflect and verify this new behavior.

**Configuration discovery improvements:**

* Added support for the `YGG_HOME` environment variable to specify the root of the Yggdrasil workspace. If set, configuration files are loaded from `$YGG_HOME/common/configurations/`; otherwise, the default location beside the source tree is used. (`lib/core_utils/common.py`, `docs/getting_started/configuration.md`, `docs/getting_started/quickstart.md`, `docs/reference/troubleshooting.md`) [[1]](diffhunk://#diff-7e176ae4e89fe4a717de6037d44ce10b883bad5152813e3537ba1dd197ecf462L17-R45) [[2]](diffhunk://#diff-7e176ae4e89fe4a717de6037d44ce10b883bad5152813e3537ba1dd197ecf462L88-R123) [[3]](diffhunk://#diff-6af609a81d15b0302c76a9032958ea268e0820137f80e81a7696b1a17241a415L3-R8) [[4]](diffhunk://#diff-6af609a81d15b0302c76a9032958ea268e0820137f80e81a7696b1a17241a415R123-R130) [[5]](diffhunk://#diff-5d6489f129e1970e2aa86c08cd84e7989185eb30d41a564ba2e323e62e2321fdR45-R52) [[6]](diffhunk://#diff-cd8d0d196155087518a4d8b368224fec09974095bc89b24b70b16ab0996591e4L52-R52)

**Testing and reliability:**

* Added and updated tests to verify correct resolution of the workspace and configuration directory, both with and without `YGG_HOME` set. This includes new tests for the `workspace_path` and `config_dir` methods, and for loading config files from the correct location. (`tests/test_common.py`) [[1]](diffhunk://#diff-556812789bdf8b0b5fa491afe93530be33abb8fd41150bec1da8da6b7c43e064R2) [[2]](diffhunk://#diff-556812789bdf8b0b5fa491afe93530be33abb8fd41150bec1da8da6b7c43e064R16-R20) [[3]](diffhunk://#diff-556812789bdf8b0b5fa491afe93530be33abb8fd41150bec1da8da6b7c43e064R31-R68) [[4]](diffhunk://#diff-556812789bdf8b0b5fa491afe93530be33abb8fd41150bec1da8da6b7c43e064R164-R176)

**Documentation updates:**

* Improved and clarified documentation to explain the new configuration discovery mechanism, how to use `YGG_HOME`, and best practices for production deployments. (`docs/getting_started/configuration.md`, `docs/getting_started/quickstart.md`, `docs/reference/troubleshooting.md`) [[1]](diffhunk://#diff-6af609a81d15b0302c76a9032958ea268e0820137f80e81a7696b1a17241a415L3-R8) [[2]](diffhunk://#diff-6af609a81d15b0302c76a9032958ea268e0820137f80e81a7696b1a17241a415R123-R130) [[3]](diffhunk://#diff-5d6489f129e1970e2aa86c08cd84e7989185eb30d41a564ba2e323e62e2321fdR45-R52) [[4]](diffhunk://#diff-cd8d0d196155087518a4d8b368224fec09974095bc89b24b70b16ab0996591e4L52-R52)