### PR TITLE
Fix/concurrency

### DIFF
--- a/docs/getting_started/cli.md
+++ b/docs/getting_started/cli.md
@@ -51,6 +51,8 @@ yggdrasil --dev daemon
 
 Logs are written to the directory set in `main.json` → `yggdrasil.log_dir`.
 
+**Note**: Only one Yggdrasil daemon should run against a shared database environment at a time. Yggdrasil prevents duplicate daemon processes in the same local runtime with a process lock. If another machine or runtime is pointed at the same databases, checkpoint conflict warnings indicate that more than one daemon may be active, but this may lead to unexpected behaviour.
+
 ### `run-doc`
 
 **Warning**: `run-doc` used to be a core tool of an earlier version, but the core has now moved on. We've attempted to keep it afloat, but it might not work as expected anymore.

--- a/lib/core_utils/config_loader.py
+++ b/lib/core_utils/config_loader.py
@@ -27,6 +27,12 @@ class ConfigLoader:
 
     def __init__(self) -> None:
         self._config: Mapping[str, Any] | None = None
+        self._loaded_path: Path | None = None
+
+    @property
+    def loaded_path(self) -> Path | None:
+        """Resolved path for the most recently loaded config file."""
+        return self._loaded_path
 
     def __getitem__(self, key: str) -> Any:
         """
@@ -96,6 +102,7 @@ class ConfigLoader:
                 "Config file '%s' already loaded. Using cached version.",
                 base_file.name,
             )
+            self._loaded_path = key
             self._config = ConfigLoader._cache[key]
             return self._config
 
@@ -122,6 +129,7 @@ class ConfigLoader:
         # 5) wrap and cache
         mp = types.MappingProxyType(raw)
         ConfigLoader._cache[key] = mp
+        self._loaded_path = key
         self._config = mp
 
         return self._config

--- a/lib/core_utils/daemon_lock.py
+++ b/lib/core_utils/daemon_lock.py
@@ -92,11 +92,12 @@ class DaemonLock:
         Raises:
             DaemonLockError: If another process already holds the local daemon
                 lock.
-            OSError: If the lock file cannot be opened, locked, written, or
-                synced for reasons other than an already-held lock.
+            OSError: If the runtime directory or lock file cannot be prepared,
+                opened, locked, written, or synced for reasons other than an
+                already-held lock.
         """
         lock_dir = cls._runtime_dir()
-        lock_dir.mkdir(parents=True, exist_ok=True)
+        cls._prepare_runtime_dir(lock_dir)
         lock_path = lock_dir / cls.LOCK_FILENAME
 
         lock_file = lock_path.open("a+", encoding="utf-8")
@@ -139,7 +140,71 @@ class DaemonLock:
         )
         if runtime_dir:
             return Path(runtime_dir)
+        return DaemonLock._fallback_runtime_dir()
+
+    @staticmethod
+    def _fallback_runtime_dir() -> Path:
+        """
+        Return the fallback runtime directory for this user.
+
+        Returns:
+            Per-user fallback path under ``/tmp``.
+        """
         return Path("/tmp") / f"yggdrasil-{os.getuid()}"
+
+    @classmethod
+    def _is_fallback_runtime_dir(cls, path: Path) -> bool:
+        """
+        Check whether a path is the fallback runtime directory.
+
+        Args:
+            path: Runtime directory candidate.
+
+        Returns:
+            True when ``path`` resolves to Yggdrasil's fallback directory for
+            the current user.
+        """
+        return path == cls._fallback_runtime_dir()
+
+    @classmethod
+    def _prepare_runtime_dir(cls, lock_dir: Path) -> None:
+        """
+        Create and validate the runtime directory for lock files.
+
+        Fallback directories under ``/tmp`` are owned by Yggdrasil, so they are
+        created or tightened to ``0o700``. Runtime directories provided by the
+        OS or ``appdirs`` are not chmodded because their permissions may be
+        managed externally.
+
+        Args:
+            lock_dir: Runtime directory returned by :meth:`_runtime_dir`.
+
+        Raises:
+            OSError: If the directory cannot be created, if the fallback path is
+                a symlink, or if an existing fallback directory is not owned by
+                the current user.
+        """
+        if not cls._is_fallback_runtime_dir(lock_dir):
+            lock_dir.mkdir(parents=True, exist_ok=True)
+            return
+
+        lock_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        if lock_dir.is_symlink():
+            raise OSError(
+                errno.ELOOP,
+                "Fallback daemon lock directory must not be a symlink",
+                str(lock_dir),
+            )
+
+        stat_result = lock_dir.stat()
+        if stat_result.st_uid != os.getuid():
+            raise PermissionError(
+                errno.EACCES,
+                "Fallback daemon lock directory is not owned by the current user",
+                str(lock_dir),
+            )
+
+        os.chmod(lock_dir, 0o700)
 
     @staticmethod
     def _metadata(

--- a/lib/core_utils/daemon_lock.py
+++ b/lib/core_utils/daemon_lock.py
@@ -1,0 +1,230 @@
+"""Local process lock for Yggdrasil daemon invocations.
+
+The lock prevents two daemon processes from running in the same local runtime.
+It is implemented with an advisory ``fcntl.flock`` held on an open lock file
+for the lifetime of the daemon process.
+"""
+
+from __future__ import annotations
+
+import errno
+import fcntl
+import getpass
+import json
+import os
+import socket
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, cast
+
+import appdirs
+
+
+class DaemonLockError(RuntimeError):
+    """
+    Raised when the local daemon runtime lock is already held.
+
+    Attributes:
+        lock_path: Path to the lock file that could not be acquired.
+        existing_metadata: Best-effort metadata read from the lock file. This
+            is useful for logs because it can identify the process currently
+            holding the lock.
+    """
+
+    def __init__(self, lock_path: Path, existing_metadata: dict[str, Any] | None):
+        """
+        Initialize the lock acquisition error.
+
+        Args:
+            lock_path: Path to the lock file that is already locked.
+            existing_metadata: Metadata from the existing lock file, if it
+                could be parsed as JSON.
+        """
+        self.lock_path = lock_path
+        self.existing_metadata = existing_metadata or {}
+        super().__init__(f"Yggdrasil daemon lock is already held: {lock_path}")
+
+
+@dataclass
+class DaemonLock:
+    """
+    Represents a held local daemon lock.
+
+    A ``DaemonLock`` instance owns an open file handle. Keeping that handle open
+    keeps the advisory lock active; calling :meth:`release` or leaving the
+    context manager closes the handle and releases the lock.
+
+    Attributes:
+        lock_path: Path to the lock file.
+        _file: Open file object that owns the advisory lock.
+    """
+
+    lock_path: Path
+    _file: Any
+
+    LOCK_FILENAME = "daemon.lock"
+
+    @classmethod
+    def acquire(
+        cls,
+        *,
+        dev_mode: bool,
+        config_path: str | os.PathLike[str] | None = None,
+    ) -> DaemonLock:
+        """
+        Acquire the local daemon lock.
+
+        Creates the runtime directory if needed, opens the lock file, and takes
+        a non-blocking exclusive ``flock``. On success, writes metadata about
+        the current process to the lock file and returns a held ``DaemonLock``.
+
+        Args:
+            dev_mode: Whether the daemon was started with ``--dev``. Stored in
+                lock metadata for diagnostics only.
+            config_path: Resolved configuration path, if known. Stored in lock
+                metadata for diagnostics only.
+
+        Returns:
+            A held ``DaemonLock``. The caller must keep it alive for the daemon
+            lifetime, usually with a ``with`` block.
+
+        Raises:
+            DaemonLockError: If another process already holds the local daemon
+                lock.
+            OSError: If the lock file cannot be opened, locked, written, or
+                synced for reasons other than an already-held lock.
+        """
+        lock_dir = cls._runtime_dir()
+        lock_dir.mkdir(parents=True, exist_ok=True)
+        lock_path = lock_dir / cls.LOCK_FILENAME
+
+        lock_file = lock_path.open("a+", encoding="utf-8")
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            if exc.errno not in (errno.EACCES, errno.EAGAIN):
+                lock_file.close()
+                raise
+            existing_metadata = cls._read_metadata(lock_file)
+            lock_file.close()
+            raise DaemonLockError(lock_path, existing_metadata) from exc
+
+        metadata = cls._metadata(dev_mode=dev_mode, config_path=config_path)
+        lock_file.seek(0)
+        lock_file.truncate()
+        json.dump(metadata, lock_file, indent=2, sort_keys=True)
+        lock_file.write("\n")
+        lock_file.flush()
+        os.fsync(lock_file.fileno())
+
+        return cls(lock_path=lock_path, _file=lock_file)
+
+    @staticmethod
+    def _runtime_dir() -> Path:
+        """
+        Resolve the runtime directory used for daemon lock files.
+
+        Uses ``appdirs.user_runtime_dir("yggdrasil")`` when available. Some
+        supported ``appdirs`` versions do not expose that helper, so the method
+        falls back to a per-user directory under ``/tmp``.
+
+        Returns:
+            Directory path where daemon lock files should be stored.
+        """
+        runtime_dir_func = getattr(appdirs, "user_runtime_dir", None)
+        runtime_dir = cast(
+            str | os.PathLike[str] | None,
+            runtime_dir_func("yggdrasil") if callable(runtime_dir_func) else None,
+        )
+        if runtime_dir:
+            return Path(runtime_dir)
+        return Path("/tmp") / f"yggdrasil-{os.getuid()}"
+
+    @staticmethod
+    def _metadata(
+        *,
+        dev_mode: bool,
+        config_path: str | os.PathLike[str] | None,
+    ) -> dict[str, Any]:
+        """
+        Build diagnostic metadata for the process holding the lock.
+
+        Args:
+            dev_mode: Whether the daemon was started with ``--dev``.
+            config_path: Resolved configuration path, if known.
+
+        Returns:
+            JSON-serializable metadata describing the current process and
+            daemon invocation.
+        """
+        return {
+            "pid": os.getpid(),
+            "hostname": socket.gethostname(),
+            "username": getpass.getuser(),
+            "cwd": str(Path.cwd()),
+            "dev_mode": dev_mode,
+            "config_path": str(config_path) if config_path is not None else None,
+            "started_at": datetime.now(UTC).isoformat(),
+        }
+
+    @staticmethod
+    def _read_metadata(lock_file: Any) -> dict[str, Any] | None:
+        """
+        Read metadata from an already-open lock file.
+
+        This is a best-effort diagnostic helper used after lock acquisition
+        fails. Invalid, empty, or non-object JSON is treated as missing
+        metadata.
+
+        Args:
+            lock_file: Open lock file positioned anywhere.
+
+        Returns:
+            Parsed metadata dict, or ``None`` if no valid metadata is present.
+        """
+        try:
+            lock_file.seek(0)
+            content = lock_file.read()
+            if not content.strip():
+                return None
+            metadata = json.loads(content)
+            return metadata if isinstance(metadata, dict) else None
+        except Exception:
+            return None
+
+    def release(self) -> None:
+        """
+        Release the local daemon lock.
+
+        Unlocks and closes the underlying file handle. The method is idempotent
+        so cleanup paths can call it safely even if the lock was already
+        released.
+        """
+        if self._file is None:
+            return
+        try:
+            fcntl.flock(self._file.fileno(), fcntl.LOCK_UN)
+        finally:
+            self._file.close()
+            self._file = None
+
+    def __enter__(self) -> DaemonLock:
+        """
+        Enter the daemon-lock context manager.
+
+        Returns:
+            The held ``DaemonLock`` instance.
+        """
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        """
+        Exit the daemon-lock context manager and release the lock.
+
+        Args:
+            exc_type: Exception type from the ``with`` block, if any.
+            exc: Exception instance from the ``with`` block, if any.
+            tb: Traceback from the ``with`` block, if any.
+        """
+        self.release()

--- a/lib/watchers/backends/checkpoint_store.py
+++ b/lib/watchers/backends/checkpoint_store.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, cast
 
-from ibm_cloud_sdk_core.api_exception import ApiException
-
 from lib.core_utils.logging_utils import custom_logger
 from lib.watchers.backends.base import Checkpoint, CheckpointStore
 
@@ -125,13 +123,26 @@ class CouchDBCheckpointStore(CheckpointStore):
 
     @staticmethod
     def _is_conflict_error(exc: Exception) -> bool:
-        """Return True when the Cloudant exception is a CouchDB update conflict."""
-        if not isinstance(exc, ApiException):
-            return False
-        status_code = getattr(exc, "status_code", None)
-        if status_code is not None:
-            return status_code == 409
-        return getattr(exc, "code", None) == 409
+        """
+        Return True when an exception represents a CouchDB update conflict.
+
+        Args:
+            exc: Exception raised while writing a checkpoint document.
+
+        Returns:
+            True if the exception carries a CouchDB/HTTP conflict status, False
+            otherwise.
+
+        The IBM SDK exposes the HTTP status as ``status_code`` on current
+        versions, while older call paths and some test doubles expose it as
+        ``code``. Checking the status attributes keeps conflict handling tied
+        to the CouchDB response instead of a particular exception class.
+        """
+        for attr_name in ("status_code", "code"):
+            status = getattr(exc, attr_name, None)
+            if status == 409:
+                return True
+        return False
 
     def save(self, checkpoint: Checkpoint) -> None:
         """

--- a/lib/watchers/backends/checkpoint_store.py
+++ b/lib/watchers/backends/checkpoint_store.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, cast
 
+from ibm_cloud_sdk_core.api_exception import ApiException
+
 from lib.core_utils.logging_utils import custom_logger
 from lib.watchers.backends.base import Checkpoint, CheckpointStore
 
@@ -45,6 +47,12 @@ class CouchDBCheckpointStore(CheckpointStore):
 
     DOC_TYPE = "watcher_checkpoint"
     DOC_ID_PREFIX = "watcher_checkpoint:"
+    DEFAULT_SAVE_CONFLICT_RETRIES = 3
+    CONCURRENT_WRITER_WARNING = (
+        "Concurrent checkpoint writer detected; another Yggdrasil daemon may be "
+        "active against the same CouchDB environment. This deployment state is "
+        "unsupported."
+    )
 
     def __init__(
         self,
@@ -115,6 +123,16 @@ class CouchDBCheckpointStore(CheckpointStore):
             )
             return None
 
+    @staticmethod
+    def _is_conflict_error(exc: Exception) -> bool:
+        """Return True when the Cloudant exception is a CouchDB update conflict."""
+        if not isinstance(exc, ApiException):
+            return False
+        status_code = getattr(exc, "status_code", None)
+        if status_code is not None:
+            return status_code == 409
+        return getattr(exc, "code", None) == 409
+
     def save(self, checkpoint: Checkpoint) -> None:
         """
         Persist checkpoint.
@@ -123,53 +141,76 @@ class CouchDBCheckpointStore(CheckpointStore):
             checkpoint: The checkpoint to save. Will overwrite any existing
                         checkpoint with the same backend_key.
 
-        Raises:
-            Exception: If database write fails (logged but re-raised).
+        Non-409 database errors are logged and re-raised. 409 conflicts are
+        retried with a fresh _rev. If conflicts persist, the checkpoint is left
+        unsaved and the caller can continue with its in-memory position.
         """
         doc_id = self._make_doc_id(checkpoint.backend_key)
+        total_attempts = self.DEFAULT_SAVE_CONFLICT_RETRIES + 1
 
-        doc: dict[str, Any] = {
-            "_id": doc_id,
-            "type": self.DOC_TYPE,
-            "backend_key": checkpoint.backend_key,
-            "value": checkpoint.value,
-            "updated_at": checkpoint.updated_at,
-        }
+        for retry_count in range(total_attempts):
+            attempt = retry_count + 1
+            doc: dict[str, Any] = {
+                "_id": doc_id,
+                "type": self.DOC_TYPE,
+                "backend_key": checkpoint.backend_key,
+                "value": checkpoint.value,
+                "updated_at": checkpoint.updated_at,
+            }
 
-        try:
-            # Check if document exists to get _rev for update
-            existing = self.dbm.fetch_document_by_id(doc_id)
-            if existing and existing.get("value") == checkpoint.value:
+            try:
+                # Check if document exists to get _rev for update
+                existing = self.dbm.fetch_document_by_id(doc_id)
+                if existing and existing.get("value") == checkpoint.value:
+                    self._logger.debug(
+                        "Checkpoint unchanged for '%s'; skipping save",
+                        checkpoint.backend_key,
+                    )
+                    return
+                if existing and "_rev" in existing:
+                    doc["_rev"] = existing["_rev"]
+
+                # Use put_document for upsert semantics
+                # Cast to Any to satisfy Pylance (SDK expects Document | BinaryIO)
+                self.dbm.server.put_document(
+                    db=self.dbm.db_name,
+                    doc_id=doc_id,
+                    document=cast(Any, doc),
+                ).get_result()
+
                 self._logger.debug(
-                    "Checkpoint unchanged for '%s'; skipping save",
+                    "Saved checkpoint for '%s': value='%s'",
                     checkpoint.backend_key,
+                    checkpoint.value,
                 )
                 return
-            if existing and "_rev" in existing:
-                doc["_rev"] = existing["_rev"]
 
-            # Use put_document for upsert semantics
-            # Cast to Any to satisfy Pylance (SDK expects Document | BinaryIO)
-            self.dbm.server.put_document(
-                db=self.dbm.db_name,
-                doc_id=doc_id,
-                document=cast(Any, doc),
-            ).get_result()
+            except Exception as e:
+                if self._is_conflict_error(e):
+                    self._logger.warning(
+                        "%s backend_key='%s', attempt=%d/%d",
+                        self.CONCURRENT_WRITER_WARNING,
+                        checkpoint.backend_key,
+                        attempt,
+                        total_attempts,
+                    )
+                    continue
 
-            self._logger.debug(
-                "Saved checkpoint for '%s': value='%s'",
-                checkpoint.backend_key,
-                checkpoint.value,
-            )
+                self._logger.error(
+                    "Error saving checkpoint for '%s': %s",
+                    checkpoint.backend_key,
+                    e,
+                    exc_info=True,
+                )
+                raise
 
-        except Exception as e:
-            self._logger.error(
-                "Error saving checkpoint for '%s': %s",
-                checkpoint.backend_key,
-                e,
-                exc_info=True,
-            )
-            raise
+        self._logger.error(
+            "Failed to save checkpoint for '%s' after %d conflict retries; "
+            "continuing without persisting checkpoint value='%s'",
+            checkpoint.backend_key,
+            self.DEFAULT_SAVE_CONFLICT_RETRIES,
+            checkpoint.value,
+        )
 
 
 class InMemoryCheckpointStore(CheckpointStore):

--- a/lib/watchers/plan_watcher.py
+++ b/lib/watchers/plan_watcher.py
@@ -151,13 +151,22 @@ class PlanWatcher(AbstractWatcher):
                 new_seq = change.get("seq")
                 if new_seq is not None:
                     current_seq = str(new_seq)
-                    self.checkpoint_store.save(
-                        Checkpoint(
-                            backend_key=self.CHECKPOINT_KEY,
-                            value=current_seq,
-                            updated_at=datetime.now(UTC).isoformat(),
+                    try:
+                        self.checkpoint_store.save(
+                            Checkpoint(
+                                backend_key=self.CHECKPOINT_KEY,
+                                value=current_seq,
+                                updated_at=datetime.now(UTC).isoformat(),
+                            )
                         )
-                    )
+                    except Exception as e:
+                        self._logger.error(
+                            "Failed to save PlanWatcher checkpoint for change id=%r seq=%r; continuing: %s",
+                            change.get("id"),
+                            current_seq,
+                            e,
+                            exc_info=True,
+                        )
         except Exception as e:
             # stream_changes_continuously handles transient retry/backoff internally.
             # Unexpected errors are logged and terminate start().

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,10 @@
 import sys
 import unittest
 from io import StringIO
-from unittest.mock import Mock, call, patch
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, call, patch
 
+from lib.core_utils.daemon_lock import DaemonLockError
 from yggdrasil.cli import main
 
 
@@ -93,6 +95,82 @@ class TestYggdrasilCLI(unittest.TestCase):
             mock_core.setup_watchers.assert_called_once()
             mock_asyncio_run.assert_called_once_with(mock_core.start())
 
+    def test_daemon_mode_acquires_local_lock(self):
+        """Test daemon mode acquires the local runtime lock before watchers start."""
+        sys.argv = ["yggdrasil", "daemon"]
+
+        with (
+            patch("yggdrasil.cli.ConfigLoader") as mock_config_loader,
+            patch("yggdrasil.cli.YggdrasilCore") as mock_core_class,
+            patch("yggdrasil.cli.DaemonLock.acquire") as mock_acquire,
+            patch("asyncio.run"),
+        ):
+            mock_loader = mock_config_loader.return_value
+            mock_loader.load_config.return_value = self.mock_config
+            mock_loader.loaded_path = Path("/tmp/main.json")
+            mock_lock = MagicMock()
+            mock_acquire.return_value = mock_lock
+            mock_core = Mock()
+            mock_core_class.return_value = mock_core
+
+            main()
+
+            mock_acquire.assert_called_once_with(
+                dev_mode=False,
+                config_path=Path("/tmp/main.json"),
+            )
+            mock_lock.__enter__.assert_called_once()
+            mock_core.setup_watchers.assert_called_once()
+
+    def test_dev_daemon_mode_acquires_same_local_lock(self):
+        """Test --dev daemon also acquires the coarse local runtime lock."""
+        sys.argv = ["yggdrasil", "--dev", "daemon"]
+
+        with (
+            patch("yggdrasil.cli.ConfigLoader") as mock_config_loader,
+            patch("yggdrasil.cli.YggdrasilCore") as mock_core_class,
+            patch("yggdrasil.cli.DaemonLock.acquire") as mock_acquire,
+            patch("asyncio.run"),
+        ):
+            mock_loader = mock_config_loader.return_value
+            mock_loader.load_config.return_value = self.mock_config
+            mock_loader.loaded_path = Path("/tmp/dev_main.json")
+            mock_acquire.return_value = MagicMock()
+            mock_core_class.return_value = Mock()
+
+            main()
+
+            mock_acquire.assert_called_once_with(
+                dev_mode=True,
+                config_path=Path("/tmp/dev_main.json"),
+            )
+
+    def test_daemon_lock_failure_exits_before_watcher_setup(self):
+        """Test a held local lock exits before watchers are configured."""
+        sys.argv = ["yggdrasil", "daemon"]
+
+        with (
+            patch("yggdrasil.cli.ConfigLoader") as mock_config_loader,
+            patch("yggdrasil.cli.YggdrasilCore") as mock_core_class,
+            patch("yggdrasil.cli.DaemonLock.acquire") as mock_acquire,
+            patch("asyncio.run") as mock_asyncio_run,
+        ):
+            mock_config_loader.return_value.load_config.return_value = self.mock_config
+            mock_core = Mock()
+            mock_core_class.return_value = mock_core
+            mock_acquire.side_effect = DaemonLockError(
+                Path("/tmp/yggdrasil/daemon.lock"),
+                {"pid": 12345},
+            )
+
+            with self.assertRaises(SystemExit) as context:
+                main()
+
+            self.assertEqual(context.exception.code, 1)
+            mock_core.setup_realms.assert_called_once()
+            mock_core.setup_watchers.assert_not_called()
+            mock_asyncio_run.assert_not_called()
+
     def test_daemon_mode_with_dev_flag(self):
         """Test daemon mode with development flag."""
         sys.argv = ["yggdrasil", "--dev", "daemon"]
@@ -136,6 +214,25 @@ class TestYggdrasilCLI(unittest.TestCase):
                 force_overwrite=False,
             )
             mock_session.init_manual_submit.assert_called_once_with(False)
+
+    def test_run_doc_mode_does_not_acquire_daemon_lock(self):
+        """Test one-off run-doc mode does not take the daemon runtime lock."""
+        sys.argv = ["yggdrasil", "run-doc", "test_doc_id", "--plan-only"]
+
+        with (
+            patch("yggdrasil.cli.ConfigLoader") as mock_config_loader,
+            patch("yggdrasil.cli.YggdrasilCore") as mock_core_class,
+            patch("yggdrasil.cli.DaemonLock.acquire") as mock_acquire,
+        ):
+            mock_config_loader.return_value.load_config.return_value = self.mock_config
+            mock_core = Mock()
+            mock_core.create_plan_from_doc.return_value = "pln_test_123"
+            mock_core_class.return_value = mock_core
+
+            main()
+
+            mock_acquire.assert_not_called()
+            mock_core.create_plan_from_doc.assert_called_once()
 
     def test_run_doc_mode_with_manual_submit(self):
         """Test run-doc mode with manual submit flag uses plan-only."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -109,9 +109,14 @@ class TestYggdrasilCLI(unittest.TestCase):
             mock_loader.load_config.return_value = self.mock_config
             mock_loader.loaded_path = Path("/tmp/main.json")
             mock_lock = MagicMock()
-            mock_acquire.return_value = mock_lock
             mock_core = Mock()
             mock_core_class.return_value = mock_core
+
+            def acquire_lock(*args, **kwargs):
+                mock_core_class.assert_not_called()
+                return mock_lock
+
+            mock_acquire.side_effect = acquire_lock
 
             main()
 
@@ -120,6 +125,7 @@ class TestYggdrasilCLI(unittest.TestCase):
                 config_path=Path("/tmp/main.json"),
             )
             mock_lock.__enter__.assert_called_once()
+            mock_core.setup_realms.assert_called_once()
             mock_core.setup_watchers.assert_called_once()
 
     def test_dev_daemon_mode_acquires_same_local_lock(self):
@@ -156,8 +162,6 @@ class TestYggdrasilCLI(unittest.TestCase):
             patch("asyncio.run") as mock_asyncio_run,
         ):
             mock_config_loader.return_value.load_config.return_value = self.mock_config
-            mock_core = Mock()
-            mock_core_class.return_value = mock_core
             mock_acquire.side_effect = DaemonLockError(
                 Path("/tmp/yggdrasil/daemon.lock"),
                 {"pid": 12345},
@@ -167,8 +171,7 @@ class TestYggdrasilCLI(unittest.TestCase):
                 main()
 
             self.assertEqual(context.exception.code, 1)
-            mock_core.setup_realms.assert_called_once()
-            mock_core.setup_watchers.assert_not_called()
+            mock_core_class.assert_not_called()
             mock_asyncio_run.assert_not_called()
 
     def test_daemon_mode_with_dev_flag(self):

--- a/tests/test_daemon_lock.py
+++ b/tests/test_daemon_lock.py
@@ -1,4 +1,6 @@
 import json
+import os
+import stat
 import tempfile
 import unittest
 from pathlib import Path
@@ -57,3 +59,74 @@ class TestDaemonLock(unittest.TestCase):
                     dev_path = dev.lock_path
 
                 self.assertEqual(normal_path, dev_path)
+
+    def test_fallback_runtime_dir_is_created_with_restrictive_permissions(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fallback_dir = Path(tmpdir) / "yggdrasil-lock"
+            with (
+                patch(
+                    "lib.core_utils.daemon_lock.appdirs.user_runtime_dir",
+                    return_value=None,
+                    create=True,
+                ),
+                patch.object(
+                    DaemonLock,
+                    "_fallback_runtime_dir",
+                    return_value=fallback_dir,
+                ),
+            ):
+                with DaemonLock.acquire(dev_mode=False, config_path=None):
+                    pass
+
+            mode = stat.S_IMODE(fallback_dir.stat().st_mode)
+            self.assertEqual(mode, 0o700)
+
+    def test_existing_fallback_runtime_dir_is_chmodded_to_restrictive_permissions(
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fallback_dir = Path(tmpdir) / "yggdrasil-lock"
+            fallback_dir.mkdir(mode=0o755)
+            fallback_dir.chmod(0o755)
+
+            with patch.object(
+                DaemonLock,
+                "_fallback_runtime_dir",
+                return_value=fallback_dir,
+            ):
+                DaemonLock._prepare_runtime_dir(fallback_dir)
+
+            mode = stat.S_IMODE(fallback_dir.stat().st_mode)
+            self.assertEqual(mode, 0o700)
+
+    def test_appdirs_runtime_dir_permissions_are_not_mutated(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runtime_dir = Path(tmpdir)
+            runtime_dir.chmod(0o755)
+            with patch(
+                "lib.core_utils.daemon_lock.appdirs.user_runtime_dir",
+                return_value=runtime_dir,
+                create=True,
+            ):
+                with DaemonLock.acquire(dev_mode=False, config_path=None):
+                    pass
+
+            mode = stat.S_IMODE(runtime_dir.stat().st_mode)
+            self.assertEqual(mode, 0o755)
+
+    def test_existing_fallback_runtime_dir_owned_by_other_user_raises(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fallback_dir = Path(tmpdir) / "yggdrasil-lock"
+            fallback_dir.mkdir()
+            other_uid = os.getuid() + 1
+
+            with (
+                patch.object(
+                    DaemonLock,
+                    "_fallback_runtime_dir",
+                    return_value=fallback_dir,
+                ),
+                patch("lib.core_utils.daemon_lock.os.getuid", return_value=other_uid),
+            ):
+                with self.assertRaises(PermissionError):
+                    DaemonLock._prepare_runtime_dir(fallback_dir)

--- a/tests/test_daemon_lock.py
+++ b/tests/test_daemon_lock.py
@@ -1,0 +1,59 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from lib.core_utils.daemon_lock import DaemonLock, DaemonLockError
+
+
+class TestDaemonLock(unittest.TestCase):
+    def test_acquire_writes_metadata(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch(
+                "lib.core_utils.daemon_lock.appdirs.user_runtime_dir",
+                return_value=tmpdir,
+                create=True,
+            ):
+                with DaemonLock.acquire(
+                    dev_mode=True,
+                    config_path="/tmp/dev_main.json",
+                ) as lock:
+                    metadata = json.loads(lock.lock_path.read_text())
+
+                self.assertEqual(lock.lock_path, Path(tmpdir) / "daemon.lock")
+                self.assertTrue(metadata["dev_mode"])
+                self.assertEqual(metadata["config_path"], "/tmp/dev_main.json")
+                self.assertIn("pid", metadata)
+                self.assertIn("hostname", metadata)
+
+    def test_second_acquire_fails_with_existing_metadata(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch(
+                "lib.core_utils.daemon_lock.appdirs.user_runtime_dir",
+                return_value=tmpdir,
+                create=True,
+            ):
+                with DaemonLock.acquire(dev_mode=False, config_path=None):
+                    with self.assertRaises(DaemonLockError) as context:
+                        DaemonLock.acquire(dev_mode=False, config_path=None)
+
+                self.assertEqual(
+                    context.exception.lock_path, Path(tmpdir) / "daemon.lock"
+                )
+                self.assertIn("pid", context.exception.existing_metadata)
+
+    def test_dev_and_normal_use_same_local_lock_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch(
+                "lib.core_utils.daemon_lock.appdirs.user_runtime_dir",
+                return_value=tmpdir,
+                create=True,
+            ):
+                with DaemonLock.acquire(dev_mode=False, config_path=None) as normal:
+                    normal_path = normal.lock_path
+
+                with DaemonLock.acquire(dev_mode=True, config_path=None) as dev:
+                    dev_path = dev.lock_path
+
+                self.assertEqual(normal_path, dev_path)

--- a/tests/test_plan_watcher.py
+++ b/tests/test_plan_watcher.py
@@ -289,6 +289,45 @@ class TestPlanWatcher(unittest.TestCase):
         # Checkpoint should have been retrieved
         self.mock_checkpoint.load.assert_called_once_with("watcher:PlanWatcher")
 
+    def test_checkpoint_save_failure_does_not_stop_watcher_loop(self):
+        """Test checkpoint save errors are logged and do not terminate PlanWatcher."""
+        changes = [
+            {
+                "id": "pln_dmx_ASDFGG",
+                "seq": "101-aaa",
+                "doc": {
+                    "_id": "pln_dmx_ASDFGG",
+                    "status": "draft",
+                    "run_token": 0,
+                    "executed_run_token": -1,
+                    "execution_authority": "daemon",
+                },
+            },
+            {
+                "id": "pln_dmx_ASDFGG_2",
+                "seq": "102-bbb",
+                "doc": {
+                    "_id": "pln_dmx_ASDFGG_2",
+                    "status": "draft",
+                    "run_token": 0,
+                    "executed_run_token": -1,
+                    "execution_authority": "daemon",
+                },
+            },
+        ]
+
+        async def mock_stream_changes_continuously(since=None, poll_interval_sec=5.0):
+            for change in changes:
+                yield change
+
+        self.mock_fetcher.stream_changes_continuously = mock_stream_changes_continuously
+        self.mock_checkpoint.save.side_effect = [RuntimeError("conflict"), None]
+
+        asyncio.run(self.watcher.start())
+
+        self.assertEqual(self.mock_checkpoint.save.call_count, 2)
+        self.mock_on_event.assert_not_called()
+
     def test_stop_sets_running_false(self):
         """Test that stop() sets _running to False."""
         self.watcher._running = True

--- a/tests/watchers/backends/test_checkpoint_store.py
+++ b/tests/watchers/backends/test_checkpoint_store.py
@@ -107,6 +107,37 @@ class TestCouchDBCheckpointStore(unittest.TestCase):
         doc_id = store._make_doc_id("couchdb:projects")
         self.assertEqual(doc_id, "watcher_checkpoint:couchdb:projects")
 
+    def test_is_conflict_error_accepts_status_duck_typing(self):
+        """Test 409 conflict detection without depending on SDK exception identity."""
+
+        class StatusConflictError(Exception):
+            """Exception carrying a CouchDB-style conflict status."""
+
+            status_code = 409
+
+        class CodeConflictError(Exception):
+            """Exception carrying a legacy/mock conflict code."""
+
+            code = 409
+
+        self.assertTrue(
+            CouchDBCheckpointStore._is_conflict_error(StatusConflictError())
+        )
+        self.assertTrue(CouchDBCheckpointStore._is_conflict_error(CodeConflictError()))
+
+    def test_is_conflict_error_rejects_non_conflicts(self):
+        """Test non-409 errors are not classified as checkpoint conflicts."""
+
+        class ServerError(Exception):
+            """Exception carrying a non-conflict CouchDB status."""
+
+            status_code = 500
+
+        self.assertFalse(CouchDBCheckpointStore._is_conflict_error(ServerError()))
+        self.assertFalse(
+            CouchDBCheckpointStore._is_conflict_error(RuntimeError("boom"))
+        )
+
     def test_load_existing_checkpoint(self):
         """Test load() returns checkpoint from CouchDB."""
         store = CouchDBCheckpointStore(db_manager=self.mock_dbm)
@@ -291,9 +322,14 @@ class TestCouchDBCheckpointStore(unittest.TestCase):
         self.assertEqual(self.mock_dbm.server.put_document.call_count, 2)
         retry_doc = self.mock_dbm.server.put_document.call_args.kwargs["document"]
         self.assertEqual(retry_doc["_rev"], "2-newrev")
-        self.assertIn(
-            CouchDBCheckpointStore.CONCURRENT_WRITER_WARNING,
-            mock_logger.warning.call_args.args,
+        warning_args = [
+            arg for call in mock_logger.warning.call_args_list for arg in call.args
+        ]
+        self.assertTrue(
+            any(
+                CouchDBCheckpointStore.CONCURRENT_WRITER_WARNING in str(arg)
+                for arg in warning_args
+            )
         )
 
     def test_save_conflict_target_value_already_persisted_succeeds(self):

--- a/tests/watchers/backends/test_checkpoint_store.py
+++ b/tests/watchers/backends/test_checkpoint_store.py
@@ -254,6 +254,107 @@ class TestCouchDBCheckpointStore(unittest.TestCase):
         doc = call_args.kwargs["document"]
         self.assertEqual(doc["value"], 12345)
 
+    def test_save_retries_on_conflict_and_logs_concurrent_writer_warning(self):
+        """Test save() retries 409 conflicts with a fresh _rev."""
+        mock_logger = MagicMock()
+        store = CouchDBCheckpointStore(db_manager=self.mock_dbm, logger=mock_logger)
+
+        self.mock_dbm.fetch_document_by_id.side_effect = [
+            {
+                "_id": "watcher_checkpoint:couchdb:projects",
+                "_rev": "1-oldrev",
+                "backend_key": "couchdb:projects",
+                "value": "old_value",
+            },
+            {
+                "_id": "watcher_checkpoint:couchdb:projects",
+                "_rev": "2-newrev",
+                "backend_key": "couchdb:projects",
+                "value": "old_value",
+            },
+        ]
+
+        mock_result = MagicMock()
+        mock_result.get_result.return_value = {"ok": True}
+        self.mock_dbm.server.put_document.side_effect = [
+            ApiException(code=409, message="conflict"),
+            mock_result,
+        ]
+
+        cp = Checkpoint(
+            backend_key="couchdb:projects",
+            value="new_value",
+            updated_at="2024-01-15T14:00:00Z",
+        )
+        store.save(cp)
+
+        self.assertEqual(self.mock_dbm.server.put_document.call_count, 2)
+        retry_doc = self.mock_dbm.server.put_document.call_args.kwargs["document"]
+        self.assertEqual(retry_doc["_rev"], "2-newrev")
+        self.assertIn(
+            CouchDBCheckpointStore.CONCURRENT_WRITER_WARNING,
+            mock_logger.warning.call_args.args,
+        )
+
+    def test_save_conflict_target_value_already_persisted_succeeds(self):
+        """Test a conflict is successful if refetch shows the desired value."""
+        store = CouchDBCheckpointStore(db_manager=self.mock_dbm)
+
+        self.mock_dbm.fetch_document_by_id.side_effect = [
+            {
+                "_id": "watcher_checkpoint:couchdb:projects",
+                "_rev": "1-oldrev",
+                "backend_key": "couchdb:projects",
+                "value": "old_value",
+            },
+            {
+                "_id": "watcher_checkpoint:couchdb:projects",
+                "_rev": "2-newrev",
+                "backend_key": "couchdb:projects",
+                "value": "new_value",
+            },
+        ]
+        self.mock_dbm.server.put_document.side_effect = ApiException(
+            code=409, message="conflict"
+        )
+
+        cp = Checkpoint(
+            backend_key="couchdb:projects",
+            value="new_value",
+            updated_at="2024-01-15T14:00:00Z",
+        )
+        store.save(cp)
+
+        self.mock_dbm.server.put_document.assert_called_once()
+
+    def test_save_conflict_retries_exhausted_does_not_raise(self):
+        """Test repeated 409 conflicts are non-fatal."""
+        mock_logger = MagicMock()
+        store = CouchDBCheckpointStore(db_manager=self.mock_dbm, logger=mock_logger)
+
+        self.mock_dbm.fetch_document_by_id.return_value = {
+            "_id": "watcher_checkpoint:couchdb:projects",
+            "_rev": "1-oldrev",
+            "backend_key": "couchdb:projects",
+            "value": "old_value",
+        }
+        self.mock_dbm.server.put_document.side_effect = ApiException(
+            code=409, message="conflict"
+        )
+
+        cp = Checkpoint(
+            backend_key="couchdb:projects",
+            value="new_value",
+            updated_at="2024-01-15T14:00:00Z",
+        )
+        store.save(cp)
+
+        self.assertEqual(
+            self.mock_dbm.server.put_document.call_count,
+            CouchDBCheckpointStore.DEFAULT_SAVE_CONFLICT_RETRIES + 1,
+        )
+        mock_logger.error.assert_called()
+
     def test_custom_db_manager(self):
         """Test CouchDBCheckpointStore can use custom db manager."""
         custom_dbm = MagicMock()

--- a/yggdrasil/cli.py
+++ b/yggdrasil/cli.py
@@ -132,11 +132,9 @@ Examples:
 
     logger.debug("Yggdrasil: Starting up...")
 
-    # 4) Prepare core (load config, init core, discover realms)
+    # 4) Load config before dispatching to the selected mode
     config_loader = ConfigLoader()
     config = config_loader.load_config("main.json")
-    core = YggdrasilCore(config)
-    core.setup_realms()
 
     if args.mode == "daemon":
         if getattr(args, "manual_submit", False):
@@ -147,7 +145,8 @@ Examples:
                 dev_mode=args.dev,
                 config_path=config_loader.loaded_path,
             ):
-                # (future)Daemon: set up watchers and run forever
+                core = YggdrasilCore(config)
+                core.setup_realms()
                 core.setup_watchers()
                 try:
                     asyncio.run(core.start())
@@ -172,6 +171,9 @@ Examples:
             raise SystemExit(1) from e
 
     elif args.mode == "run-doc":
+        core = YggdrasilCore(config)
+        core.setup_realms()
+
         # Validate mode selection
         if not args.plan_only and not args.run_once:
             # Default to plan-only with notice

--- a/yggdrasil/cli.py
+++ b/yggdrasil/cli.py
@@ -2,6 +2,7 @@ import argparse
 import asyncio
 
 from lib.core_utils.config_loader import ConfigLoader
+from lib.core_utils.daemon_lock import DaemonLock, DaemonLockError
 from lib.core_utils.logging_utils import configure_logging, custom_logger
 from lib.core_utils.ygg_session import YggSession
 from lib.core_utils.yggdrasil_core import YggdrasilCore
@@ -132,7 +133,8 @@ Examples:
     logger.debug("Yggdrasil: Starting up...")
 
     # 4) Prepare core (load config, init core, discover realms)
-    config = ConfigLoader().load_config("main.json")
+    config_loader = ConfigLoader()
+    config = config_loader.load_config("main.json")
     core = YggdrasilCore(config)
     core.setup_realms()
 
@@ -140,19 +142,34 @@ Examples:
         if getattr(args, "manual_submit", False):
             parser.error("The --manual-submit flag is only valid in run-doc mode.")
 
-        # (future)Daemon: set up watchers and run forever
-        core.setup_watchers()
         try:
-            asyncio.run(core.start())
-        except KeyboardInterrupt:
-            logger.warning("[bold red blink] Shutting down Yggdrasil daemon... [/]")
-            try:
-                asyncio.run(core.stop())
-            except (asyncio.CancelledError, RuntimeError) as e:
-                # CancelledError: Tasks were cancelled during shutdown (expected)
-                # RuntimeError: Event loop issues during cleanup (can be ignored)
-                logger.debug(f"Shutdown exception (expected): {e}")
-            logger.info("Yggdrasil daemon stopped.")
+            with DaemonLock.acquire(
+                dev_mode=args.dev,
+                config_path=config_loader.loaded_path,
+            ):
+                # (future)Daemon: set up watchers and run forever
+                core.setup_watchers()
+                try:
+                    asyncio.run(core.start())
+                except KeyboardInterrupt:
+                    logger.warning(
+                        "[bold red blink] Shutting down Yggdrasil daemon... [/]"
+                    )
+                    try:
+                        asyncio.run(core.stop())
+                    except (asyncio.CancelledError, RuntimeError) as e:
+                        # CancelledError: Tasks were cancelled during shutdown (expected)
+                        # RuntimeError: Event loop issues during cleanup (can be ignored)
+                        logger.debug(f"Shutdown exception (expected): {e}")
+                    logger.info("Yggdrasil daemon stopped.")
+        except DaemonLockError as e:
+            logger.error(
+                "Another local Yggdrasil daemon is already running. "
+                "Lock path: %s. Existing metadata: %s",
+                e.lock_path,
+                e.existing_metadata,
+            )
+            raise SystemExit(1) from e
 
     elif args.mode == "run-doc":
         # Validate mode selection


### PR DESCRIPTION
This PR introduces a local process lock to prevent multiple Yggdrasil daemon processes from running in the same environment, improves checkpoint conflict handling in CouchDB-backed watchers, prevents PlanWatcher from failing and shutting down the daemon, and enhances tests for these behaviors. The main changes are grouped below.

**Daemon Process Locking**

* Added `lib/core_utils/daemon_lock.py`, implementing a local advisory lock using `fcntl.flock` to prevent multiple Yggdrasil daemons from running concurrently in the same runtime. This includes diagnostic metadata and robust error handling.
* Updated CLI documentation to warn users that only one daemon should run per shared database environment, describing how the new lock and checkpoint conflict warnings work.

**CouchDB Checkpoint Conflict Handling**

* Improved `CouchDBCheckpointStore.save()` to detect and retry on CouchDB update conflicts (HTTP 409), logging warnings if concurrent writers are detected and failing gracefully after several retries instead of raising. Added a helper to identify conflict errors and a warning message for concurrent writers. [[1]](diffhunk://#diff-c16be3e2bc55af500ec20660cb1a3f083d66ca0a8c3a1c5da9d0db1757e2338bR48-R53) [[2]](diffhunk://#diff-c16be3e2bc55af500ec20660cb1a3f083d66ca0a8c3a1c5da9d0db1757e2338bR124-R146) [[3]](diffhunk://#diff-c16be3e2bc55af500ec20660cb1a3f083d66ca0a8c3a1c5da9d0db1757e2338bL126-R163) [[4]](diffhunk://#diff-c16be3e2bc55af500ec20660cb1a3f083d66ca0a8c3a1c5da9d0db1757e2338bR197-R209) [[5]](diffhunk://#diff-c16be3e2bc55af500ec20660cb1a3f083d66ca0a8c3a1c5da9d0db1757e2338bR218-R225)
* Updated `PlanWatcher` to log and continue if checkpoint saving fails, instead of crashing.

**Config Loader Enhancements**

* Extended `ConfigLoader` to track the resolved path of the most recently loaded config file, exposing it as a property for use in lock diagnostics. [[1]](diffhunk://#diff-d82d38ac5095e854f9e5a8867b9db9e0b13eb06a881278d030fc3289f346bcc0R30-R35) [[2]](diffhunk://#diff-d82d38ac5095e854f9e5a8867b9db9e0b13eb06a881278d030fc3289f346bcc0R105) [[3]](diffhunk://#diff-d82d38ac5095e854f9e5a8867b9db9e0b13eb06a881278d030fc3289f346bcc0R132)

**Test Coverage**

* Added and expanded tests in `tests/test_cli.py` to verify that the daemon acquires the local lock, handles lock acquisition failures, and does not acquire the lock in run-doc mode. [[1]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eL4-R7) [[2]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eR98-R176) [[3]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eR221-R239)

---

**References:**  
[[1]](diffhunk://#diff-96caa0671eb75796cb230ce9cf48077035ad400fdfabaf6287cde3873e77e966R1-R295) [[2]](diffhunk://#diff-1464d4e80b51b66c2c15abe25e12dde94cd5db7e4a11b12eab60b48156d644ebR54-R55) [[3]](diffhunk://#diff-c16be3e2bc55af500ec20660cb1a3f083d66ca0a8c3a1c5da9d0db1757e2338bR48-R53) [[4]](diffhunk://#diff-c16be3e2bc55af500ec20660cb1a3f083d66ca0a8c3a1c5da9d0db1757e2338bR124-R146) [[5]](diffhunk://#diff-c16be3e2bc55af500ec20660cb1a3f083d66ca0a8c3a1c5da9d0db1757e2338bL126-R163) [[6]](diffhunk://#diff-c16be3e2bc55af500ec20660cb1a3f083d66ca0a8c3a1c5da9d0db1757e2338bR197-R209) [[7]](diffhunk://#diff-c16be3e2bc55af500ec20660cb1a3f083d66ca0a8c3a1c5da9d0db1757e2338bR218-R225) [[8]](diffhunk://#diff-4e64280b95aae01beda4e186562cb4df6a4f40b073f784c3aefabde1fc20fac3R154-R169) [[9]](diffhunk://#diff-d82d38ac5095e854f9e5a8867b9db9e0b13eb06a881278d030fc3289f346bcc0R30-R35) [[10]](diffhunk://#diff-d82d38ac5095e854f9e5a8867b9db9e0b13eb06a881278d030fc3289f346bcc0R105) [[11]](diffhunk://#diff-d82d38ac5095e854f9e5a8867b9db9e0b13eb06a881278d030fc3289f346bcc0R132) [[12]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eL4-R7) [[13]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eR98-R176) [[14]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eR221-R239)