### PR TITLE
Feature/watcher validation

### DIFF
--- a/lib/core_utils/yggdrasil_core.py
+++ b/lib/core_utils/yggdrasil_core.py
@@ -46,13 +46,21 @@ class YggdrasilCore:
     - (future) Semi-automatic (CLI) calls that bypass watchers
     """
 
-    def __init__(self, config: Mapping[str, Any], logger: logging.Logger | None = None):
+    def __init__(
+        self,
+        config: Mapping[str, Any],
+        logger: logging.Logger | None = None,
+        *,
+        config_path: str | Path | None = None,
+    ):
         """
         Args:
             config: A dictionary of global Yggdrasil settings.
             logger: If not provided, a default named logger is created.
+            config_path: Optional path to the loaded config file for diagnostics.
         """
         self.config = config
+        self.config_path = Path(config_path) if config_path is not None else None
         self._logger = logger or custom_logger(f"{__name__}.{type(self).__name__}")
         self._running = False
 
@@ -513,6 +521,7 @@ class YggdrasilCore:
             on_event=self.handle_event,
             logger=self._logger,
             watcher_policy=self.config.get("watchers", {}),
+            config_path=self.config_path,
         )
 
         for bound_spec in bound_specs:
@@ -609,6 +618,8 @@ class YggdrasilCore:
         WatchSpecs in setup_realms() and handled by WatcherManager.
         """
         self._logger.info("Setting up watchers...")
+        if self.watcher_manager:
+            self.watcher_manager.validate_configuration()
         self._setup_plan_watcher()
         self._logger.info("Watchers setup done.")
 

--- a/lib/watchers/__init__.py
+++ b/lib/watchers/__init__.py
@@ -50,6 +50,11 @@ from lib.watchers.backends.checkpoint_store import (
     InMemoryCheckpointStore,
 )
 from lib.watchers.backends.couchdb import CouchDBBackend
+from lib.watchers.config_validation import (
+    WatcherConfigurationError,
+    WatcherConfigValidationIssue,
+    validate_watcher_config_wiring,
+)
 from lib.watchers.filter_eval import FilterResult, evaluate_filter
 from lib.watchers.manager import WatcherBackendGroup, WatcherManager
 from lib.watchers.watchspec import BoundWatchSpec, WatchSpec
@@ -74,4 +79,8 @@ __all__ = [
     # Manager
     "WatcherManager",
     "WatcherBackendGroup",
+    # Config validation
+    "WatcherConfigValidationIssue",
+    "WatcherConfigurationError",
+    "validate_watcher_config_wiring",
 ]

--- a/lib/watchers/config_validation.py
+++ b/lib/watchers/config_validation.py
@@ -1,0 +1,176 @@
+"""Validation helpers for watcher-to-config wiring.
+
+This module intentionally validates only the narrow contract between
+WatchSpecs, watcher backend registration, and ``external_systems`` config.
+It is small and reusable so broader startup/config validators can call into it
+without duplicating watcher-specific checks.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from lib.core_utils.external_systems_resolver import resolve_connection
+from lib.watchers.backends.base import WatcherBackend
+from lib.watchers.watchspec import BoundWatchSpec
+
+
+@dataclass(frozen=True)
+class WatcherConfigValidationIssue:
+    """One watcher/config wiring validation issue."""
+
+    kind: str
+    realms: tuple[str, ...]
+    backend: str
+    connection: str
+    detail: str
+
+    def format(self) -> str:
+        """Format this issue for operator-facing startup logs."""
+        if len(self.realms) == 1:
+            realm_text = f"realm '{self.realms[0]}'"
+        else:
+            realm_text = "realms " + ", ".join(f"'{realm}'" for realm in self.realms)
+
+        return (
+            f"{realm_text} uses backend '{self.backend}' with connection "
+            f"'{self.connection}': {self.detail}"
+        )
+
+
+class WatcherConfigurationError(RuntimeError):
+    """Raised when daemon watcher config wiring is invalid."""
+
+    def __init__(
+        self,
+        issues: Iterable[WatcherConfigValidationIssue],
+        *,
+        config_path: str | Path | None = None,
+    ) -> None:
+        self.issues = tuple(issues)
+        self.config_path = Path(config_path) if config_path is not None else None
+        super().__init__(self._format_message())
+
+    def _format_message(self) -> str:
+        location = f" in {self.config_path}" if self.config_path else ""
+        header = f"Watcher configuration error{location}"
+
+        if not self.issues:
+            return header
+
+        if len(self.issues) == 1:
+            return f"{header}: {self.issues[0].format()}"
+
+        formatted_issues = "\n".join(f"- {issue.format()}" for issue in self.issues)
+        return f"{header}: {len(self.issues)} issue(s)\n{formatted_issues}"
+
+
+def validate_watcher_config_wiring(
+    bound_specs: Iterable[BoundWatchSpec],
+    external_systems: Mapping[str, Any],
+    backend_registry: Mapping[str, type[WatcherBackend]],
+    *,
+    config_path: str | Path | None = None,
+) -> None:
+    """Validate WatchSpecs against watcher backend and connection config.
+
+    Args:
+        bound_specs: WatchSpecs bound to their owning realm.
+        external_systems: The ``external_systems`` config slice.
+        backend_registry: Registered watcher backend classes keyed by backend name.
+        config_path: Optional path to the loaded config file for diagnostics.
+
+    Raises:
+        WatcherConfigurationError: If any wiring issue is found.
+    """
+    available_backends = _format_available(backend_registry.keys())
+    raw_connections = external_systems.get("connections") or {}
+    connections = raw_connections if isinstance(raw_connections, Mapping) else {}
+    available_connections = _format_available(connections.keys())
+    issues: list[WatcherConfigValidationIssue] = []
+
+    for (backend, connection), realms in _group_specs(bound_specs).items():
+        if backend not in backend_registry:
+            issues.append(
+                WatcherConfigValidationIssue(
+                    kind="unknown_backend",
+                    realms=realms,
+                    backend=backend,
+                    connection=connection,
+                    detail=(
+                        "watcher backend is not registered. "
+                        f"Available backends: {available_backends}"
+                    ),
+                )
+            )
+
+        try:
+            resolved_conn = resolve_connection(connection, dict(external_systems))
+        except KeyError as exc:
+            if connection not in connections:
+                detail = (
+                    "connection is not configured. "
+                    f"Available connections: {available_connections}"
+                )
+            else:
+                detail = f"connection could not be resolved: {_exception_message(exc)}"
+
+            issues.append(
+                WatcherConfigValidationIssue(
+                    kind="invalid_connection",
+                    realms=realms,
+                    backend=backend,
+                    connection=connection,
+                    detail=detail,
+                )
+            )
+            continue
+
+        endpoint_backend = resolved_conn.endpoint.backend_type
+        if endpoint_backend and endpoint_backend != backend:
+            issues.append(
+                WatcherConfigValidationIssue(
+                    kind="backend_mismatch",
+                    realms=realms,
+                    backend=backend,
+                    connection=connection,
+                    detail=(
+                        f"WatchSpec backend is '{backend}' but configured endpoint "
+                        f"backend is '{endpoint_backend}'"
+                    ),
+                )
+            )
+
+    if issues:
+        raise WatcherConfigurationError(issues, config_path=config_path)
+
+
+def _group_specs(
+    bound_specs: Iterable[BoundWatchSpec],
+) -> dict[tuple[str, str], tuple[str, ...]]:
+    grouped: dict[tuple[str, str], list[str]] = {}
+
+    for bound_spec in bound_specs:
+        key = (bound_spec.spec.backend, bound_spec.spec.connection)
+        realms = grouped.setdefault(key, [])
+        if bound_spec.realm_id not in realms:
+            realms.append(bound_spec.realm_id)
+
+    return {
+        key: tuple(sorted(realms))
+        for key, realms in sorted(grouped.items(), key=lambda item: item[0])
+    }
+
+
+def _format_available(names: Iterable[str]) -> str:
+    formatted = ", ".join(sorted(str(name) for name in names))
+    return formatted or "none"
+
+
+def _exception_message(exc: KeyError) -> str:
+    if exc.args:
+        return str(exc.args[0])
+    return str(exc)

--- a/lib/watchers/config_validation.py
+++ b/lib/watchers/config_validation.py
@@ -20,7 +20,16 @@ from lib.watchers.watchspec import BoundWatchSpec
 
 @dataclass(frozen=True)
 class WatcherConfigValidationIssue:
-    """One watcher/config wiring validation issue."""
+    """
+    One watcher/config wiring validation issue.
+
+    Attributes:
+        kind: Short machine-readable issue category (e.g. "unknown_backend").
+        realms: Realm IDs sharing this backend/connection pair.
+        backend: The watcher backend name declared in the WatchSpec.
+        connection: The external_systems connection name declared in the WatchSpec.
+        detail: Human-readable explanation of the problem.
+    """
 
     kind: str
     realms: tuple[str, ...]
@@ -29,7 +38,12 @@ class WatcherConfigValidationIssue:
     detail: str
 
     def format(self) -> str:
-        """Format this issue for operator-facing startup logs."""
+        """
+        Format this issue for operator-facing startup logs.
+
+        Returns:
+            A single-line human-readable description of the issue.
+        """
         if len(self.realms) == 1:
             realm_text = f"realm '{self.realms[0]}'"
         else:
@@ -42,7 +56,13 @@ class WatcherConfigValidationIssue:
 
 
 class WatcherConfigurationError(RuntimeError):
-    """Raised when daemon watcher config wiring is invalid."""
+    """
+    Raised when daemon watcher config wiring is invalid.
+
+    Attributes:
+        issues: The wiring issues that caused validation to fail.
+        config_path: Path to the config file being validated, if known.
+    """
 
     def __init__(
         self,
@@ -50,11 +70,19 @@ class WatcherConfigurationError(RuntimeError):
         *,
         config_path: str | Path | None = None,
     ) -> None:
+        """
+        Initialize the configuration error.
+
+        Args:
+            issues: The wiring issues that caused validation to fail.
+            config_path: Optional path to the loaded config file for diagnostics.
+        """
         self.issues = tuple(issues)
         self.config_path = Path(config_path) if config_path is not None else None
         super().__init__(self._format_message())
 
     def _format_message(self) -> str:
+        """Build the exception message from self.issues."""
         location = f" in {self.config_path}" if self.config_path else ""
         header = f"Watcher configuration error{location}"
 
@@ -151,6 +179,7 @@ def validate_watcher_config_wiring(
 def _group_specs(
     bound_specs: Iterable[BoundWatchSpec],
 ) -> dict[tuple[str, str], tuple[str, ...]]:
+    """Group bound specs by (backend, connection), with sorted, deduped realm ids."""
     grouped: dict[tuple[str, str], list[str]] = {}
 
     for bound_spec in bound_specs:
@@ -166,11 +195,13 @@ def _group_specs(
 
 
 def _format_available(names: Iterable[str]) -> str:
+    """Return a comma-separated, sorted list of names, or "none" if empty."""
     formatted = ", ".join(sorted(str(name) for name in names))
     return formatted or "none"
 
 
 def _exception_message(exc: KeyError) -> str:
+    """Return the KeyError's message without its repr-style quoting."""
     if exc.args:
         return str(exc.args[0])
     return str(exc)

--- a/lib/watchers/manager.py
+++ b/lib/watchers/manager.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from lib.core_utils.external_systems_resolver import resolve_connection
@@ -22,6 +23,7 @@ from lib.core_utils.logging_utils import custom_logger
 from lib.watchers.abstract_watcher import YggdrasilEvent
 from lib.watchers.backends.base import CheckpointStore, RawWatchEvent, WatcherBackend
 from lib.watchers.backends.checkpoint_store import CouchDBCheckpointStore
+from lib.watchers.config_validation import validate_watcher_config_wiring
 from lib.watchers.filter_eval import FilterResult, evaluate_filter, raw_event_to_dict
 
 if TYPE_CHECKING:
@@ -120,6 +122,7 @@ class WatcherManager:
         checkpoint_store: CheckpointStore | None = None,
         logger: logging.Logger | None = None,
         watcher_policy: dict[str, Any] | None = None,
+        config_path: str | Path | None = None,
     ):
         """
         Initialize the WatcherManager.
@@ -155,12 +158,14 @@ class WatcherManager:
                             ``observation_retry_delay_s`` (float, default 1.0).
                             If None or empty, hardcoded defaults are used.
                             Typically ``main_config.get("watchers", {})``.
+            config_path: Optional path to the loaded config file for diagnostics.
         """
         self.config = config
         self._on_event = on_event
         self.checkpoint_store = checkpoint_store or CouchDBCheckpointStore()
         self._logger = logger or custom_logger(f"{__name__}.{type(self).__name__}")
         self._watcher_policy_override = watcher_policy
+        self.config_path = Path(config_path) if config_path is not None else None
 
         self._watcher_groups: dict[tuple[str, str], WatcherBackendGroup] = {}
         # BoundWatchSpecs grouped by backend group key
@@ -273,6 +278,18 @@ class WatcherManager:
         """Return a copy of the bound specs dict."""
         return {k: list(v) for k, v in self._bound_specs.items()}
 
+    def validate_configuration(self) -> None:
+        """Validate registered WatchSpecs against watcher/config wiring."""
+        bound_specs = [
+            bound_spec for specs in self._bound_specs.values() for bound_spec in specs
+        ]
+        validate_watcher_config_wiring(
+            bound_specs=bound_specs,
+            external_systems=self.config,
+            backend_registry=self._backend_registry,
+            config_path=self.config_path,
+        )
+
     # -------------------------------------------------------------------------
     # Configuration Resolution
     # -------------------------------------------------------------------------
@@ -377,10 +394,11 @@ class WatcherManager:
         group.backend_type.
 
         Raises:
-            ValueError: If backend type is unknown or mismatched
-            KeyError: If connection config is invalid
+            WatcherConfigurationError: If watcher/config wiring is invalid
+            KeyError: If connection config is invalid after validation
             RuntimeError: If env var resolution fails
         """
+        self.validate_configuration()
         policy = self._resolve_watcher_policy()
 
         for key, group in self._watcher_groups.items():

--- a/lib/watchers/manager.py
+++ b/lib/watchers/manager.py
@@ -279,7 +279,12 @@ class WatcherManager:
         return {k: list(v) for k, v in self._bound_specs.items()}
 
     def validate_configuration(self) -> None:
-        """Validate registered WatchSpecs against watcher/config wiring."""
+        """
+        Validate registered WatchSpecs against watcher/config wiring.
+
+        Raises:
+            WatcherConfigurationError: If any wiring issue is found.
+        """
         bound_specs = [
             bound_spec for specs in self._bound_specs.values() for bound_spec in specs
         ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,10 @@ from pathlib import Path
 from unittest.mock import MagicMock, Mock, call, patch
 
 from lib.core_utils.daemon_lock import DaemonLockError
+from lib.watchers.config_validation import (
+    WatcherConfigurationError,
+    WatcherConfigValidationIssue,
+)
 from yggdrasil.cli import main
 
 
@@ -173,6 +177,53 @@ class TestYggdrasilCLI(unittest.TestCase):
             self.assertEqual(context.exception.code, 1)
             mock_core_class.assert_not_called()
             mock_asyncio_run.assert_not_called()
+
+    def test_daemon_watcher_config_error_exits_cleanly(self):
+        """Watcher config errors are logged without starting the daemon."""
+        sys.argv = ["yggdrasil", "daemon"]
+
+        issue = WatcherConfigValidationIssue(
+            kind="invalid_connection",
+            realms=("dmx_realm",),
+            backend="couchdb",
+            connection="demux_sample_info_db",
+            detail="connection is not configured",
+        )
+        error = WatcherConfigurationError(
+            [issue],
+            config_path=Path("/tmp/main.json"),
+        )
+
+        with (
+            patch("yggdrasil.cli.ConfigLoader") as mock_config_loader,
+            patch("yggdrasil.cli.YggdrasilCore") as mock_core_class,
+            patch("yggdrasil.cli.DaemonLock.acquire") as mock_acquire,
+            patch("yggdrasil.cli.custom_logger") as mock_custom_logger,
+            patch("asyncio.run") as mock_asyncio_run,
+        ):
+            mock_loader = mock_config_loader.return_value
+            mock_loader.load_config.return_value = self.mock_config
+            mock_loader.loaded_path = Path("/tmp/main.json")
+            mock_acquire.return_value = MagicMock()
+            mock_logger = Mock()
+            mock_custom_logger.return_value = mock_logger
+            mock_core = Mock()
+            mock_core.setup_watchers.side_effect = error
+            mock_core_class.return_value = mock_core
+
+            with self.assertRaises(SystemExit) as context:
+                main()
+
+            self.assertEqual(context.exception.code, 1)
+            self.assertIsNone(context.exception.__cause__)
+            mock_core_class.assert_called_once_with(
+                self.mock_config,
+                config_path=Path("/tmp/main.json"),
+            )
+            mock_core.setup_realms.assert_called_once()
+            mock_core.setup_watchers.assert_called_once()
+            mock_asyncio_run.assert_not_called()
+            mock_logger.error.assert_called_once_with("%s", error)
 
     def test_daemon_mode_with_dev_flag(self):
         """Test daemon mode with development flag."""

--- a/tests/test_setup_realms.py
+++ b/tests/test_setup_realms.py
@@ -384,6 +384,36 @@ class TestSetupRealms(unittest.TestCase):
             ("valid_target", "couchdb_handler"), core._handler_identity_registry
         )
 
+    @patch("importlib.metadata.entry_points", return_value=[])
+    @patch("lib.core_utils.yggdrasil_core.discover_realms")
+    @patch("lib.realms.test_realm.is_test_realm_enabled", return_value=False)
+    def test_setup_realms_does_not_validate_watcher_connections(
+        self, _test_enabled, mock_discover, _mock_eps
+    ):
+        """setup_realms wires WatchSpecs but leaves daemon config validation to setup_watchers."""
+        spec = WatchSpec(
+            backend="couchdb",
+            connection="missing_daemon_only_db",
+            event_type=EventType.COUCHDB_DOC_CHANGED,
+            build_scope=lambda e: {"kind": "doc", "id": e.id},
+            build_payload=lambda e: {"doc": e.doc},
+            target_handlers=["couchdb_handler"],
+        )
+        desc = RealmDescriptor(
+            realm_id="daemon_only",
+            handler_classes=[_CouchDBDocHandler],
+            watchspecs=[spec],
+        )
+        mock_discover.return_value = [desc]
+
+        core = self._make_core()
+        core.setup_realms()
+
+        self.assertIsNotNone(core.watcher_manager)
+        self.assertIn(
+            ("daemon_only", "couchdb_handler"), core._handler_identity_registry
+        )
+
     # --- Legacy handler wrapping ---
 
     @patch("lib.core_utils.yggdrasil_core.discover_realms")

--- a/tests/test_yggdrasil_core.py
+++ b/tests/test_yggdrasil_core.py
@@ -8,6 +8,10 @@ from lib.core_utils.event_types import EventType
 from lib.core_utils.singleton_decorator import SingletonMeta
 from lib.core_utils.yggdrasil_core import YggdrasilCore
 from lib.watchers.abstract_watcher import YggdrasilEvent
+from lib.watchers.config_validation import (
+    WatcherConfigurationError,
+    WatcherConfigValidationIssue,
+)
 
 
 class TestYggdrasilCore(unittest.TestCase):
@@ -218,6 +222,31 @@ class TestYggdrasilCore(unittest.TestCase):
         mock_setup_plan.assert_called_once()
         expected_calls = [call("Setting up watchers..."), call("Watchers setup done.")]
         self.mock_logger.info.assert_has_calls(expected_calls, any_order=True)
+
+    @patch("lib.core_utils.yggdrasil_core.YggdrasilCore._setup_plan_watcher")
+    @patch("lib.core_utils.yggdrasil_core.YggdrasilCore._init_db_managers")
+    def test_setup_watchers_validates_watcher_manager_before_plan_watcher(
+        self, mock_init_db, mock_setup_plan
+    ):
+        """WatcherManager config validation happens before PlanWatcher setup."""
+        core = YggdrasilCore(self.test_config, self.mock_logger)
+        core.watcher_manager = Mock()
+        issue = WatcherConfigValidationIssue(
+            kind="invalid_connection",
+            realms=("dmx_realm",),
+            backend="couchdb",
+            connection="demux_sample_info_db",
+            detail="connection is not configured",
+        )
+        core.watcher_manager.validate_configuration.side_effect = (
+            WatcherConfigurationError([issue])
+        )
+
+        with self.assertRaises(WatcherConfigurationError):
+            core.setup_watchers()
+
+        core.watcher_manager.validate_configuration.assert_called_once()
+        mock_setup_plan.assert_not_called()
 
     # =====================================================
     # HANDLER REGISTRATION AND SETUP TESTS
@@ -820,15 +849,24 @@ class TestYggdrasilCore(unittest.TestCase):
             core.engine = Mock()
             core.engine.run = Mock()
 
-            with patch(
-                "lib.core_utils.yggdrasil_core.is_plan_eligible", return_value=True
+            with (
+                patch(
+                    "lib.core_utils.yggdrasil_core.is_plan_eligible",
+                    return_value=True,
+                ),
+                patch(
+                    "lib.core_utils.yggdrasil_core.asyncio.to_thread",
+                    new_callable=AsyncMock,
+                ) as mock_to_thread,
             ):
                 # Act
                 await core._execute_approved_plan("pln_test_123")
 
                 # Assert
                 core.plan_dbm.fetch_plan.assert_called_once_with("pln_test_123")
-                core.engine.run.assert_called_once_with(mock_plan_model)
+                mock_to_thread.assert_awaited_once_with(
+                    core.engine.run, mock_plan_model
+                )
                 core.plan_dbm.update_executed_token.assert_called_once_with(
                     "pln_test_123", 1
                 )
@@ -894,10 +932,18 @@ class TestYggdrasilCore(unittest.TestCase):
             }
             core.plan_dbm.fetch_plan_as_model.return_value = Mock()
             core.engine = Mock()
-            core.engine.run = Mock(side_effect=Exception("Engine failed"))
+            core.engine.run = Mock()
 
-            with patch(
-                "lib.core_utils.yggdrasil_core.is_plan_eligible", return_value=True
+            with (
+                patch(
+                    "lib.core_utils.yggdrasil_core.is_plan_eligible",
+                    return_value=True,
+                ),
+                patch(
+                    "lib.core_utils.yggdrasil_core.asyncio.to_thread",
+                    new_callable=AsyncMock,
+                    side_effect=Exception("Engine failed"),
+                ),
             ):
                 # Act
                 await core._execute_approved_plan("pln_test_123")

--- a/tests/watchers/test_config_validation.py
+++ b/tests/watchers/test_config_validation.py
@@ -1,0 +1,152 @@
+"""Tests for watcher/config wiring validation."""
+
+import unittest
+from pathlib import Path
+
+from lib.core_utils.event_types import EventType
+from lib.watchers.backends.base import WatcherBackend
+from lib.watchers.config_validation import (
+    WatcherConfigurationError,
+    validate_watcher_config_wiring,
+)
+from lib.watchers.watchspec import BoundWatchSpec, WatchSpec
+
+
+def _bound_spec(
+    *,
+    realm_id: str = "test_realm",
+    backend: str = "couchdb",
+    connection: str = "projects_db",
+) -> BoundWatchSpec:
+    return BoundWatchSpec(
+        spec=WatchSpec(
+            backend=backend,
+            connection=connection,
+            event_type=EventType.COUCHDB_DOC_CHANGED,
+            build_scope=lambda event: {"kind": "doc", "id": event.id},
+            build_payload=lambda event: {"doc": event.doc},
+        ),
+        realm_id=realm_id,
+    )
+
+
+def _external_systems(*, endpoint_backend: str = "couchdb") -> dict:
+    return {
+        "endpoints": {
+            "main_endpoint": {
+                "backend": endpoint_backend,
+                "url": "https://couch.example.org",
+                "auth": {},
+            }
+        },
+        "connections": {
+            "projects_db": {
+                "endpoint": "main_endpoint",
+                "resource": {"db": "projects"},
+            }
+        },
+    }
+
+
+class TestWatcherConfigValidation(unittest.TestCase):
+    def test_missing_connection_reports_realm_available_connections_and_path(self):
+        spec = _bound_spec(
+            realm_id="dmx_realm",
+            connection="demux_sample_info_db",
+        )
+
+        with self.assertRaises(WatcherConfigurationError) as ctx:
+            validate_watcher_config_wiring(
+                bound_specs=[spec],
+                external_systems=_external_systems(),
+                backend_registry={"couchdb": WatcherBackend},
+                config_path=Path("/tmp/main.json"),
+            )
+
+        msg = str(ctx.exception)
+        self.assertIn("/tmp/main.json", msg)
+        self.assertIn("realm 'dmx_realm'", msg)
+        self.assertIn("demux_sample_info_db", msg)
+        self.assertIn("connection is not configured", msg)
+        self.assertIn("Available connections: projects_db", msg)
+        self.assertEqual(ctx.exception.issues[0].kind, "invalid_connection")
+
+    def test_invalid_endpoint_is_reported_as_connection_resolution_issue(self):
+        cfg = _external_systems()
+        cfg["connections"]["projects_db"]["endpoint"] = "missing_endpoint"
+
+        with self.assertRaises(WatcherConfigurationError) as ctx:
+            validate_watcher_config_wiring(
+                bound_specs=[_bound_spec()],
+                external_systems=cfg,
+                backend_registry={"couchdb": WatcherBackend},
+            )
+
+        msg = str(ctx.exception)
+        self.assertIn("connection could not be resolved", msg)
+        self.assertIn("missing_endpoint", msg)
+
+    def test_missing_resource_db_is_reported_as_connection_resolution_issue(self):
+        cfg = _external_systems()
+        cfg["connections"]["projects_db"]["resource"] = {}
+
+        with self.assertRaises(WatcherConfigurationError) as ctx:
+            validate_watcher_config_wiring(
+                bound_specs=[_bound_spec()],
+                external_systems=cfg,
+                backend_registry={"couchdb": WatcherBackend},
+            )
+
+        self.assertIn("missing required 'db' field", str(ctx.exception))
+
+    def test_unknown_backend_reports_available_backends(self):
+        cfg = _external_systems(endpoint_backend="fs")
+
+        with self.assertRaises(WatcherConfigurationError) as ctx:
+            validate_watcher_config_wiring(
+                bound_specs=[_bound_spec(backend="fs")],
+                external_systems=cfg,
+                backend_registry={"couchdb": WatcherBackend},
+            )
+
+        msg = str(ctx.exception)
+        self.assertIn("watcher backend is not registered", msg)
+        self.assertIn("Available backends: couchdb", msg)
+        self.assertEqual(ctx.exception.issues[0].kind, "unknown_backend")
+
+    def test_backend_mismatch_reports_watchspec_and_endpoint_backends(self):
+        with self.assertRaises(WatcherConfigurationError) as ctx:
+            validate_watcher_config_wiring(
+                bound_specs=[_bound_spec(backend="postgres")],
+                external_systems=_external_systems(endpoint_backend="couchdb"),
+                backend_registry={"postgres": WatcherBackend},
+            )
+
+        msg = str(ctx.exception)
+        self.assertIn("WatchSpec backend is 'postgres'", msg)
+        self.assertIn("configured endpoint backend is 'couchdb'", msg)
+        self.assertEqual(ctx.exception.issues[0].kind, "backend_mismatch")
+
+    def test_multiple_issues_are_aggregated(self):
+        specs = [
+            _bound_spec(realm_id="dmx_realm", connection="missing_db"),
+            _bound_spec(realm_id="fs_realm", backend="fs"),
+        ]
+        cfg = _external_systems(endpoint_backend="fs")
+
+        with self.assertRaises(WatcherConfigurationError) as ctx:
+            validate_watcher_config_wiring(
+                bound_specs=specs,
+                external_systems=cfg,
+                backend_registry={"couchdb": WatcherBackend},
+            )
+
+        msg = str(ctx.exception)
+        self.assertIn("2 issue(s)", msg)
+        self.assertIn("missing_db", msg)
+        self.assertIn("watcher backend is not registered", msg)
+        self.assertEqual(len(ctx.exception.issues), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/watchers/test_manager.py
+++ b/tests/watchers/test_manager.py
@@ -8,11 +8,16 @@ grouping/deduplication, and config resolution.
 import asyncio
 import unittest
 from collections.abc import AsyncIterator
+from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
+from lib.core_utils.event_types import EventType
 from lib.watchers.backends.base import CheckpointStore, RawWatchEvent, WatcherBackend
 from lib.watchers.backends.checkpoint_store import InMemoryCheckpointStore
+from lib.watchers.config_validation import WatcherConfigurationError
 from lib.watchers.manager import WatcherBackendGroup, WatcherManager
+from lib.watchers.watchspec import BoundWatchSpec, WatchSpec
 
 
 class MockWatcherBackend(WatcherBackend):
@@ -45,6 +50,24 @@ class MockWatcherBackend(WatcherBackend):
     async def stop(self) -> None:
         await super().stop()
         self._stopped = True
+
+
+def _make_bound_spec(
+    *,
+    realm_id: str = "test_realm",
+    backend: str = "couchdb",
+    connection: str = "projects_db",
+) -> BoundWatchSpec:
+    return BoundWatchSpec(
+        spec=WatchSpec(
+            backend=backend,
+            connection=connection,
+            event_type=EventType.COUCHDB_DOC_CHANGED,
+            build_scope=lambda event: {"kind": "doc", "id": event.id},
+            build_payload=lambda event: {"doc": event.doc},
+        ),
+        realm_id=realm_id,
+    )
 
 
 class TestWatcherBackendGroup(unittest.TestCase):
@@ -355,6 +378,71 @@ class TestWatcherManagerConfigResolution(unittest.TestCase):
         resolved = manager._resolve_connection_config("my_db")
         self.assertNotIn("start_seq", resolved)
         self.assertNotIn("poll_interval", resolved)
+
+
+class TestWatcherManagerConfigValidation(unittest.TestCase):
+    """Tests for WatcherManager watcher/config validation adapter."""
+
+    def setUp(self):
+        WatcherManager._backend_registry.clear()
+        WatcherManager.register_backend("couchdb", MockWatcherBackend)
+        self.config = {
+            "endpoints": {
+                "couchdb": {
+                    "backend": "couchdb",
+                    "url": "https://couch.example.org",
+                    "auth": {},
+                }
+            },
+            "connections": {
+                "projects_db": {
+                    "endpoint": "couchdb",
+                    "resource": {"db": "projects"},
+                },
+            },
+        }
+        self.store = InMemoryCheckpointStore()
+
+    def tearDown(self):
+        WatcherManager._backend_registry.clear()
+
+    def test_validate_configuration_delegates_to_helper(self):
+        """validate_configuration passes registered BoundWatchSpecs to helper."""
+        manager = WatcherManager(
+            config=self.config,
+            checkpoint_store=self.store,
+            config_path=Path("/tmp/main.json"),
+        )
+        bound_spec = _make_bound_spec()
+        manager.add_watchspec(bound_spec)
+
+        with patch(
+            "lib.watchers.manager.validate_watcher_config_wiring"
+        ) as mock_validate:
+            manager.validate_configuration()
+
+        mock_validate.assert_called_once()
+        kwargs = mock_validate.call_args.kwargs
+        self.assertEqual(kwargs["bound_specs"], [bound_spec])
+        self.assertEqual(kwargs["external_systems"], self.config)
+        self.assertEqual(kwargs["backend_registry"], WatcherManager._backend_registry)
+        self.assertEqual(kwargs["config_path"], Path("/tmp/main.json"))
+
+    def test_instantiate_watcher_backends_raises_watcher_config_error(self):
+        """Instantiation defensively validates registered WatchSpecs first."""
+        manager = WatcherManager(
+            config=self.config,
+            checkpoint_store=self.store,
+        )
+        manager.add_watchspec(_make_bound_spec(connection="missing_db"))
+
+        with self.assertRaises(WatcherConfigurationError) as ctx:
+            manager._instantiate_watcher_backends()
+
+        self.assertIn("missing_db", str(ctx.exception))
+        self.assertIsNone(
+            manager.get_watcher_groups()[("couchdb", "missing_db")].backend_instance
+        )
 
 
 class TestWatcherManagerBackendTypeValidation(unittest.TestCase):

--- a/yggdrasil/cli.py
+++ b/yggdrasil/cli.py
@@ -1,11 +1,13 @@
 import argparse
 import asyncio
+from pathlib import Path
 
 from lib.core_utils.config_loader import ConfigLoader
 from lib.core_utils.daemon_lock import DaemonLock, DaemonLockError
 from lib.core_utils.logging_utils import configure_logging, custom_logger
 from lib.core_utils.ygg_session import YggSession
 from lib.core_utils.yggdrasil_core import YggdrasilCore
+from lib.watchers.config_validation import WatcherConfigurationError
 from yggdrasil.logo_utils import print_logo
 
 try:
@@ -135,6 +137,9 @@ Examples:
     # 4) Load config before dispatching to the selected mode
     config_loader = ConfigLoader()
     config = config_loader.load_config("main.json")
+    config_path = config_loader.loaded_path
+    if not isinstance(config_path, str | Path):
+        config_path = None
 
     if args.mode == "daemon":
         if getattr(args, "manual_submit", False):
@@ -143,9 +148,12 @@ Examples:
         try:
             with DaemonLock.acquire(
                 dev_mode=args.dev,
-                config_path=config_loader.loaded_path,
+                config_path=config_path,
             ):
-                core = YggdrasilCore(config)
+                if config_path is not None:
+                    core = YggdrasilCore(config, config_path=config_path)
+                else:
+                    core = YggdrasilCore(config)
                 core.setup_realms()
                 core.setup_watchers()
                 try:
@@ -161,6 +169,9 @@ Examples:
                         # RuntimeError: Event loop issues during cleanup (can be ignored)
                         logger.debug(f"Shutdown exception (expected): {e}")
                     logger.info("Yggdrasil daemon stopped.")
+        except WatcherConfigurationError as e:
+            logger.error("%s", e)
+            raise SystemExit(1) from None
         except DaemonLockError as e:
             logger.error(
                 "Another local Yggdrasil daemon is already running. "
@@ -171,7 +182,10 @@ Examples:
             raise SystemExit(1) from e
 
     elif args.mode == "run-doc":
-        core = YggdrasilCore(config)
+        if config_path is not None:
+            core = YggdrasilCore(config, config_path=config_path)
+        else:
+            core = YggdrasilCore(config)
         core.setup_realms()
 
         # Validate mode selection


### PR DESCRIPTION
This PR introduces a robust validation layer for watcher configuration wiring and integrates it into the daemon startup sequence. The main focus is to ensure that watcher backends and their connections are correctly specified in the configuration, with clear error reporting and test coverage for invalid setups. Additionally, related tests and imports have been updated to support and verify the new validation logic.

**Watcher Configuration Validation**

* Added a new module, `lib/watchers/config_validation.py`, which provides:
  - The `WatcherConfigValidationIssue` dataclass for describing specific configuration problems.
  - The `WatcherConfigurationError` exception for aggregating and reporting validation failures.
  - The `validate_watcher_config_wiring` function, which checks that all watcher backends and connections are valid and correctly wired.
* Exposed the above types and functions in the `lib/watchers/__init__.py` public API. [[1]](diffhunk://#diff-19610a8559d5af9115261175d0810098c75aeaad95a6c71a8e3cb6dce4feabbfR53-R57) [[2]](diffhunk://#diff-19610a8559d5af9115261175d0810098c75aeaad95a6c71a8e3cb6dce4feabbfR82-R85)

**Integration into Core and Manager**

* Updated `YggdrasilCore` and `WatcherManager` to accept an optional `config_path` for improved diagnostics, and to invoke watcher config validation during watcher setup and instantiation. [[1]](diffhunk://#diff-8894e90d51d2db81e0022509453f00f2d42b0a1f5b858bded7496f840361efd4L49-R63) [[2]](diffhunk://#diff-8894e90d51d2db81e0022509453f00f2d42b0a1f5b858bded7496f840361efd4R524) [[3]](diffhunk://#diff-f772d90432a0396987cb2236379fa1acb2f3373b95965c056eefb8d2478428d9R125) [[4]](diffhunk://#diff-f772d90432a0396987cb2236379fa1acb2f3373b95965c056eefb8d2478428d9R161-R168) [[5]](diffhunk://#diff-f772d90432a0396987cb2236379fa1acb2f3373b95965c056eefb8d2478428d9R281-R297) [[6]](diffhunk://#diff-f772d90432a0396987cb2236379fa1acb2f3373b95965c056eefb8d2478428d9L380-R406) [[7]](diffhunk://#diff-8894e90d51d2db81e0022509453f00f2d42b0a1f5b858bded7496f840361efd4R621-R622)
* The watcher manager now validates all registered specs before starting watcher backends, raising a clear error if any wiring issues are found. [[1]](diffhunk://#diff-f772d90432a0396987cb2236379fa1acb2f3373b95965c056eefb8d2478428d9R281-R297) [[2]](diffhunk://#diff-f772d90432a0396987cb2236379fa1acb2f3373b95965c056eefb8d2478428d9L380-R406)

**Testing and Error Handling**

* Added and updated tests to ensure watcher configuration errors are raised and handled as expected, including:
  - Tests that the daemon exits cleanly with a clear error log if watcher config is invalid.
  - Tests that watcher config validation is performed at the correct point in the startup sequence.
  - A test that `setup_realms` does not perform watcher config validation, leaving it to `setup_watchers`.
* Updated imports in test and core files to use the new validation types and functions. [[1]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eR8-R11) [[2]](diffhunk://#diff-c99b77880c36f5b680453dae214a5c57327228eed199b3754448ff57cf8408bdR11-R14)

**Other Improvements**

* Minor refactoring in tests to improve async mocking and assertion accuracy.

These changes improve the reliability of watcher configuration, provide better diagnostics for operators, and ensure that misconfigurations are caught early and reported clearly.