### PR TITLE
Feature/internal storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,8 @@ trashcan
 configurations
 yggdrasil_workspace
 implementation_plans
+
+# Local developer-only utilities (not part of the distributed project)
+tools/
+tests/test_dev_plan_approval_tool.py
+tests/test_internal_storage_smoke_tool.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Event flow, end to end:
 3. **WatcherManager** (`lib/watchers/manager.py`) consumes BoundWatchSpecs, resolves connection config, deduplicates backends per `(backend, connection)`, evaluates each spec's `filter_expr`, builds payload/scope, and fans out `YggdrasilEvent`s to core. Startup wiring is validated by `lib/watchers/config_validation.py` (raises `WatcherConfigurationError`).
 4. **Watcher backends** (`lib/watchers/backends/`) produce backend-agnostic `RawWatchEvent`s and persist resume positions via `CheckpointStore` (`InMemoryCheckpointStore` available for tests). Realm logic stays out of backends; the architecture is one-way — no ack/return path from realms back to backends.
 5. **Handlers** (subclass `yggdrasil.flow.base_handler.BaseHandler`) declare `event_type: ClassVar[EventType]`, implement `derive_scope()` and async `generate_plan_drafts()`. Handlers generate plan *intent* (`PlanDraft`), never execute work directly.
-6. Core persists plans in the `yggdrasil_plans` CouchDB database; **PlanWatcher** triggers execution, and the **Engine** (`yggdrasil.flow`) runs plans with per-step workdirs, fingerprint-based caching, `@step`-decorated functions receiving a `StepContext`, and event emission to `$YGG_EVENT_SPOOL`.
+6. Core persists plans through the injected `InternalStorageBundle` (CouchDB in production; SQLite only when explicitly configured and running in dev mode or tests). **PlanWatcher** consumes the bundle's backend-neutral change source, and the **Engine** (`yggdrasil.flow`) runs plans with per-step workdirs, fingerprint-based caching, `@step`-decorated functions receiving a `StepContext`, and event emission to `$YGG_EVENT_SPOOL`.
 
 Namespacing: `yggdrasil/*` is the public API, `lib/*` is internal implementation. External code imports from `yggdrasil.*` only.
 
@@ -40,6 +40,7 @@ Namespacing: `yggdrasil/*` is the public API, `lib/*` is internal implementation
 
 - `ConfigLoader` resolves config files from `yggdrasil_workspace/common/configurations/` or the current dir; the daemon loads `main.json`.
 - Watcher/connection wiring lives under `main.json → external_systems` (endpoints + connections), resolved by `lib/core_utils/external_systems_resolver.py`.
+- `main.json → internal_storage` selects internal persistence; explicit CouchDB roles reference named `external_systems` connections.
 - DB managers get CouchDB params through `resolve_couchdb_params` (`lib/couchdb/couchdb_defaults.py`).
 - `YggSession` singleton tracks dev-mode / manual-submission flags set by CLI flags.
 

--- a/docs/design/prds/internal_storage.md
+++ b/docs/design/prds/internal_storage.md
@@ -1,0 +1,265 @@
+# PRD: Backend-Neutral Internal Storage with Explicit Dev SQLite
+
+**Status:** Implemented
+**Branch:** `feature/internal-storage`
+
+## Summary
+
+Add a narrow internal-storage boundary so Yggdrasil Core uses the same
+capabilities regardless of database backend.
+
+- Preserve CouchDB as the existing and production backend.
+- Add SQLite only through explicit configuration in effective dev mode or
+  tests.
+- Preserve the plan, checkpoint, event-spool, and operations-snapshot
+  contracts across backends. The explicit run-once recovery and prod/dev
+  machine-local isolation changes are documented below.
+- Store SQLite records as JSON documents, not a second relational domain
+  model.
+- Do not redesign execution claims, events, or external data access in this
+  branch.
+
+### Amendments over the original draft (review outcomes)
+
+1. **Daemon lock split included** (originally deferred): without it, the dev
+   daemon could never run beside production on one machine, which was the
+   motivating problem. See "Concurrent prod/dev daemons" below.
+2. **SQLite threading model specified**: one connection per operation
+   (see "SQLite bundle").
+3. **Approval remains external**: Yggdrasil does not add a plan-approval UI,
+   CLI command, or supported SQLite administration tool in this branch.
+   Operators that require manual approval provide their own integration with
+   the selected plan store (see "Plan approval in SQLite mode").
+4. **`YggdrasilStateStore` dropped from the bundle**: the coordination
+   database's only live internal consumer in the modern daemon path is
+   checkpoint persistence, which `CheckpointStore` covers.
+   `YggdrasilDocument` operations are used only by dead code
+   (`ScenarioDocWatcher`, `BestPracticeAnalysisHandler` — flagged in
+   `docs/TECH_DEBT_LEDGER.md` #15 for the deprecation cleanup). A state
+   store protocol is added only when a live consumer exists.
+
+## Configuration
+
+### Explicit CouchDB
+
+`internal_storage` assigns one named `external_systems` connection to each
+logical database role:
+
+```json
+{
+  "internal_storage": {
+    "backend": "couchdb",
+    "couchdb": {
+      "connections": {
+        "coordination": "yggdrasil_db",
+        "plans": "yggdrasil_plans_db",
+        "operations": "yggdrasil_ops_db"
+      }
+    }
+  }
+}
+```
+
+Resolution rules (implemented in `lib/storage/config.py`, reusing
+`lib/core_utils/external_systems_resolver.py`):
+
+- Every role resolves through the existing connection resolver; the
+  database name comes from `connection.resource.db`, URL and auth env-var
+  names from the referenced endpoint.
+- Credentials, URLs, and database names are never duplicated under
+  `internal_storage`.
+- The three connections may share an endpoint but must resolve to CouchDB
+  endpoints.
+- Realm `data_access` policies do not control Core's internal-storage
+  access.
+
+### Explicit SQLite
+
+```json
+{
+  "internal_storage": {
+    "backend": "sqlite",
+    "sqlite": { "path": null }
+  }
+}
+```
+
+- Accepted only when effective dev mode is active (tests may pass an
+  explicit `dev_mode` override or inject a bundle).
+- `null` selects `$YGG_HOME/internal_state/dev/yggdrasil.sqlite3`; an
+  explicit path must be absolute.
+- Invalid explicit configuration is fatal
+  (`InternalStorageConfigurationError`); never fall back to another
+  backend.
+
+### Compatibility
+
+- Absence of `internal_storage` preserves the implicit CouchDB
+  construction exactly, with a deprecation warning.
+- `OPS_DB` is honored only by the implicit legacy path (deprecation
+  warning); explicit configuration ignores it.
+- An installation's workspace configuration should explicitly select
+  CouchDB in `main.json` (adding the plans/ops connections); its complete
+  `dev_main.json` should select SQLite while retaining any external
+  connections realms require. These workspace config files are
+  operator-managed under the gitignored `yggdrasil_workspace/`; the Python
+  package does not install them, so a clean deployment without an
+  `internal_storage` block falls through to the deprecated implicit CouchDB
+  path (with a warning) until the operator adds the block.
+
+## Storage interfaces (`lib/storage/protocols.py`)
+
+```python
+@dataclass(frozen=True)
+class InternalStorageBundle:
+    backend: str          # "couchdb" | "sqlite" — logging/tests only
+    plans: PlanStore
+    plan_changes: PlanChangeSource
+    checkpoints: CheckpointStore   # reused ABC from watchers.backends.base
+    ops_snapshots: OpsSnapshotSink
+```
+
+- `PlanStore` mirrors the `PlanDBManager` contract exactly (8 methods);
+  `PlanDBManager` satisfies it structurally.
+- `PlanChangeSource.stream_changes_continuously(*, since, poll_interval_sec)`
+  yields `RawWatchEvent` (id = plan ID, doc = current document or `None`
+  for deletion, seq = opaque cursor, deleted = tombstone flag). Core and
+  PlanWatcher never inspect Couch change-response fields or SQLite rows.
+- `OpsSnapshotSink.write(plan_dir, snapshot)` preserves the
+  `FileSpoolConsumer` writer interface.
+- Plan document shapes are built by one shared module
+  (`lib/storage/plan_documents.py`) used by both backends — no drift.
+
+## Backend implementations
+
+### CouchDB bundle (`lib/storage/couch.py`)
+
+Wraps the existing implementations (`PlanDBManager`, `ChangesFetcher`,
+`CouchDBCheckpointStore`, `OpsWriter`); the only adapter code is
+`CouchPlanChangeSource`, translating change dicts to `RawWatchEvent`.
+Database/document IDs, plan JSON and `_rev`, `_changes` semantics,
+eligibility/token behavior, checkpoint documents, snapshot upserts, and
+the filesystem event spool are unchanged.
+
+### SQLite bundle (`lib/storage/sqlite.py`)
+
+One SQLite file with `store_metadata` and `documents(namespace,
+document_id, revision, change_seq, deleted, body_json, updated_at)`;
+namespaces `plans`, `checkpoints`, `operations_snapshots`.
+
+- Canonical JSON as `TEXT`; revisions and change cursors are opaque.
+- Every plan mutation increments a global plan-change counter and writes
+  the new `change_seq` in the same transaction; polls return rows with
+  `change_seq > cursor` ordered by sequence. Mutations between polls
+  coalesce to the latest state (current eligibility, not an audit feed).
+  `since="now"` resolves to the current counter; deletions are tombstones.
+- Recovery eligibility is evaluated in Python with the existing
+  `is_plan_eligible`.
+- **Threading model:** consumers are asyncio tasks whose sync calls run on
+  `asyncio.to_thread` worker threads; `sqlite3` connections are
+  thread-bound, so the store opens a **fresh connection per operation**
+  (WAL + bounded busy timeout) and never caches connections.
+- Short transactions, WAL, busy timeout; reliable host-local storage
+  required (network filesystems unsupported for WAL).
+
+### SQLite lifecycle
+
+- Missing parents of the database path are created `0700`; the database is
+  created `0600`.
+- Symlinked, wrong-owner, malformed, or unrelated existing files are
+  rejected (`application_id` marks Yggdrasil files); creation of a new
+  disposable dev database is logged; a deleted database is recreated
+  fresh at next startup.
+- `application_id` + `user_version` gate schema compatibility: newer
+  schemas fail with upgrade guidance; unsupported older schemas fail with
+  reset guidance; future migrations run transactionally and never
+  auto-delete.
+- No marker files, storage-administration CLI, backups, or retention.
+
+## Core integration
+
+- `YggdrasilCore(..., storage=None)` resolves one `InternalStorageBundle`
+  at construction (`build_internal_storage`).
+- PlanWatcher receives `plan_store`, `change_source`, and
+  `checkpoint_store` (bare construction keeps the legacy CouchDB defaults
+  for compatibility); it consumes `RawWatchEvent`.
+- WatcherManager receives the bundle's checkpoint store.
+- `OpsConsumerService(..., writer=...)` and run-once's final spool drain
+  write through `ops_snapshots`.
+- Run-once now performs an **eligible-plan recovery pass before starting
+  its scoped watcher**. It fetches only the plan IDs created by that
+  invocation, so plans saved before watcher startup are observed without
+  scanning the whole CouchDB plans database.
+- `ProjectDBManager` is external (projects DB), not part of the bundle: it
+  is a lazy property constructed only by the run-doc paths; normal daemon
+  initialization never constructs it. The dead `self.ydm` construction was
+  removed.
+
+## Plan approval in SQLite mode
+
+Yggdrasil does not ship a plan-approval interface. An operator-provided
+integration approves a draft by setting `status="approved"` in the selected
+plan store and requests a later re-run by incrementing `run_token`. For
+SQLite, the integration must advance the plan change sequence transactionally;
+editing only the stored JSON does not notify PlanWatcher.
+
+With no PlanWatcher checkpoint, a plan approved before daemon startup may be
+missed (Tech Debt #17). Once PlanWatcher is running, an operator integration
+can re-emit an observable change for an approved-and-pending plan. It must not
+do this while the plan may already be executing because duplicate scheduling
+is possible.
+
+## Concurrent prod/dev daemons (pulled in from the deferred list)
+
+The daemon lock is scoped by effective mode: `daemon.lock` (prod) vs
+`daemon-dev.lock` (dev), same runtime directory and security checks. Prod
+and dev daemons coexist on one machine; duplicates of the same mode are
+rejected, and lock errors name the mode. To keep coexistence from
+polluting production state, machine-local *defaults* are mode-scoped too
+(`lib/core_utils/runtime_paths.py`): dev defaults become
+`/tmp/ygg_work_dev` and `/tmp/ygg_events_dev` (explicit config/env values
+are never rewritten), and log filenames gain a mode marker + PID
+(`yggdrasil[_dev]_<timestamp>_<pid>.log`). Without this, a shared spool
+would cross-feed the two ops sinks — dev events would be written into the
+production ops database — and shared `success.fingerprint` caches could
+cross-skip steps.
+
+The lock still does not coordinate across users, containers, or hosts,
+and is not database-aware; shared-database detection remains out of scope
+(documentation is the safeguard).
+
+## External database direction
+
+Unchanged from the original draft: external `WatcherBackend`
+implementations own acquisition mechanics and emit `RawWatchEvent`; realm
+queries stay behind `DataAccess` providers; PostgreSQL and other external
+providers need a separate RFC; internal-storage connections do not grant
+realm access.
+
+## Known limitations
+
+- Multiple SQLite-mode instances sharing one stage CouchDB each keep
+  private internal state (no checkpoint conflicts — the point of this
+  change) but will each independently observe and execute the same
+  watched scenario documents.
+- A dev SQLite daemon still requires its configured external CouchDB
+  endpoints to be reachable; SQLite mode isolates internal state, it is
+  not an offline mode.
+- Run-once scoped watchers share the daemon's checkpoint key
+  (pre-existing; `docs/TECH_DEBT_LEDGER.md` #16).
+- Daemon startup recovery is not wired (Tech Debt #17). The remaining
+  full eligible-plan scan has no active production caller.
+- SQLite plan mutations that read and then rewrite a whole document do
+  not use compare-and-swap (Tech Debt #18). Do not race an external approval
+  update or plan regeneration against a daemon update to the same plan.
+
+## Deferred
+
+- SQLite in normal or production operation
+- Couch/SQLite import, synchronization, or automatic switching
+- Execution claims, fencing, retries, or status redesign
+- Event ledger, outbox, retention, or broker integration
+- Plan-management API or supported storage-administration CLI
+- General external-database provider architecture
+- Removal of deprecated project realms, `run-doc`, and the dead classes
+  flagged in the tech-debt ledger

--- a/docs/getting_started/cli.md
+++ b/docs/getting_started/cli.md
@@ -20,7 +20,7 @@ python -m yggdrasil.cli [--dev] {daemon | run-doc} [OPTIONS]
 
 | Flag    | Description |
 |---------|-------------|
-| `--dev` | Enable *development mode*: DEBUG-level logging, dev-mode configuration overrides (loads `dev_main.json` on top of `main.json`), enables the test realm |
+| `--dev` | Enable *development mode*: DEBUG-level logging, dev configuration (`main.json` is replaced by `dev_main.json` when present), enables the test realm |
 
 `--dev` must come **before** the subcommand:
 
@@ -49,9 +49,9 @@ yggdrasil daemon
 yggdrasil --dev daemon
 ```
 
-Logs are written to the directory set in `main.json` → `yggdrasil.log_dir`.
+Logs are written to the directory set in `main.json` → `yggdrasil.log_dir`, one file per process: `yggdrasil_<timestamp>_<pid>.log` (`yggdrasil_dev_<timestamp>_<pid>.log` in dev mode).
 
-**Note**: Only one Yggdrasil daemon should run against a shared database environment at a time. Yggdrasil prevents duplicate daemon processes in the same local runtime with a process lock. If another machine or runtime is pointed at the same databases, checkpoint conflict warnings indicate that more than one daemon may be active, but this may lead to unexpected behaviour.
+**Note**: One daemon may run **per mode** per user per host: a production daemon holds `daemon.lock` and a dev daemon holds `daemon-dev.lock` (advisory locks in the user runtime directory), so `yggdrasil daemon` and `yggdrasil --dev daemon` can run side by side while duplicates of the same mode are rejected. **Coexistence is only safe when the two daemons use different internal storage** (see [Running prod and dev side by side](configuration.md#running-prod-and-dev-side-by-side)) — the lock is intentionally not database-aware, and only one daemon should run against a shared database environment at a time. If another machine or runtime is pointed at the same databases, checkpoint conflict warnings indicate that more than one daemon may be active, but this may lead to unexpected behaviour.
 
 ### `run-doc`
 

--- a/docs/getting_started/configuration.md
+++ b/docs/getting_started/configuration.md
@@ -11,8 +11,8 @@ Two key files:
 
 | File | Purpose |
 |---|---|
-| `main.json` | Global settings: logging, external systems, polling intervals |
-| `dev_main.json` | Dev-mode overrides (merged on top of `main.json` when `--dev` is passed) |
+| `main.json` | Global settings: logging, internal storage, external systems, polling intervals |
+| `dev_main.json` | Dev-mode configuration. When `--dev` is passed, it **replaces `main.json`**. Any config file with a `dev_` twin is swapped the same way. |
 
 ---
 
@@ -134,16 +134,98 @@ Sensitive credentials should be set as environment variables, not stored in conf
 |---|---|
 | `YGG_COUCH_USER` | CouchDB username |
 | `YGG_COUCH_PASS` | CouchDB password |
-| `YGG_WORK_ROOT` | Central workspace root for all plan and step working directories (default: `/tmp/ygg_work`). Set by the operator before starting the daemon. |
-| `YGG_EVENT_SPOOL` | Root directory where `FileSpoolEmitter` writes structured event JSON files (default: `/tmp/ygg_events`). Set by the operator before starting the daemon. |
-| `OPS_DB` | Operations database name for event consumers (default: `yggdrasil_ops`) |
+| `YGG_WORK_ROOT` | Central workspace root for all plan and step working directories (default: `/tmp/ygg_work`; `/tmp/ygg_work_dev` under `--dev`). Set by the operator before starting the daemon. Precedence: `main.json → work_root` → `$YGG_WORK_ROOT` → mode default. |
+| `YGG_EVENT_SPOOL` | Root directory where `FileSpoolEmitter` writes structured event JSON files (default: `/tmp/ygg_events`; `/tmp/ygg_events_dev` under `--dev`). Set by the operator before starting the daemon. |
+| `OPS_DB` | **Deprecated.** Operations database name (default: `yggdrasil_ops`). Honored only when `main.json` has no `internal_storage` block; explicit configuration ignores it. |
 
-`YGG_WORK_ROOT` and `YGG_EVENT_SPOOL` are resolved once at daemon startup and apply to all realms. Realm code does not read these variables — step functions receive the resolved paths via `ctx.workdir` and `ctx.scope_dir`, and emit events via `ctx.emitter`.
+`YGG_WORK_ROOT` and `YGG_EVENT_SPOOL` are resolved once at daemon startup and apply to all realms. Realm code does not read these variables — step functions receive the resolved paths via `ctx.workdir` and `ctx.scope_dir`, and emit events via `ctx.emitter`. Explicit values are exact overrides and are never rewritten; only the *defaults* differ by mode so that a *prod* and a *dev* daemon on the same machine do not share caches or spools.
+
+---
+
+## Internal storage
+
+Yggdrasil Core keeps its *internal* state — plan documents, watcher
+checkpoints, and operations snapshots — behind a backend-neutral storage
+boundary configured by the top-level `internal_storage` block.
+
+**Production (CouchDB, explicit).** Each logical database role, names one
+`external_systems` connection; the URL, credentials env-var names, and
+database name all come from the referenced connection — never duplicated
+here:
+
+```json
+"internal_storage": {
+    "backend": "couchdb",
+    "couchdb": {
+        "connections": {
+            "coordination": "yggdrasil_db",
+            "plans": "yggdrasil_plans_db",
+            "operations": "yggdrasil_ops_db"
+        }
+    }
+}
+```
+
+**Dev and testing (SQLite, explicit).** Accepted only in dev mode
+(`--dev`). All internal state lives in one disposable local file; deleting
+it yields fresh state at the next startup:
+
+```json
+"internal_storage": {
+    "backend": "sqlite",
+    "sqlite": { "path": null }
+}
+```
+
+`"path": null` selects `$YGG_HOME/internal_state/dev/yggdrasil.sqlite3`
+(or the bundled workspace when `YGG_HOME` is unset); an explicit path must
+be absolute. Invalid configuration is fatal — Yggdrasil never silently
+falls back to another backend. Network filesystems are unsupported for the
+SQLite file (WAL requires reliable host-local storage).
+
+If the block is absent, the legacy implicit CouchDB construction applies
+(deprecated; a warning is logged, and explicit configuration will be
+required in a future release).
+
+**Manual plan approval.** Plans created with `auto_run=False` remain in
+`status="draft"` until an external actor approves them. Yggdrasil does not
+currently ship an approval UI or command. Operators who need manual
+approval must provide their own integration with the configured plan
+store.
+
+Approval changes `status` to `"approved"`. Requesting another execution
+increments `run_token`; a plan is eligible only while `run_token` is
+greater than `executed_run_token`. A SQLite integration must also advance
+the plan change sequence transactionally so PlanWatcher observes the
+update. Editing only the stored JSON is insufficient, and SQLite tooling
+must be kept compatible with Yggdrasil's internal schema.
+
+External data sources are unaffected by the storage backend. Realm watch
+sources and realm `data_access` providers still resolve through
+`external_systems`. A dev SQLite daemon therefore still needs the external
+systems required by its enabled realms to be reachable.
+
+### Running prod and dev side by side
+
+One daemon may run **per mode** per user per host (`daemon.lock` /
+`daemon-dev.lock`). For safe coexistence on one machine:
+
+- **Internal state**: point dev at SQLite (above), or at a *different*
+  CouchDB server. Database names (`yggdrasil`,
+  `yggdrasil_plans`, `yggdrasil_ops`) are fixed, so distinct endpoints —
+  not renamed connections — are the reliable boundary. Yggdrasil does not
+  detect a shared database; running two daemons against the same CouchDB
+  environment is unsupported.
+- **Work root and event spool**: isolated automatically via the
+  `_dev`-suffixed mode defaults. If you set `YGG_WORK_ROOT` /
+  `YGG_EVENT_SPOOL` explicitly, use distinct values per daemon.
+- **Logs**: the shared log directory is safe — filenames carry a mode
+  marker and the PID.
 
 ---
 
 ## Logging
 
-- CLI `--dev` enables DEBUG logging and uses the dev config (if present).
+- CLI `--dev` enables DEBUG logging and loads `dev_<name>.json` in place of `<name>.json` (if present).
 - Default is INFO.
-- Logs are written to the directory configured as `yggdrasil.log_dir` in `main.json` (one file per run), and optionally to console.
+- Logs are written to the directory configured as `yggdrasil.log_dir` in `main.json` (one file per process: `yggdrasil_<timestamp>_<pid>.log`, with a `dev_` marker in dev mode), and optionally to console.

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -77,7 +77,8 @@ See [Configuration](configuration.md) for required config files.
 # Start the daemon (watches CouchDB and file-system sources)
 yggdrasil daemon
 
-# Or in dev mode (DEBUG logging, dev config overrides)
+# Or in dev mode (DEBUG logging; dev_main.json replaces main.json;
+# safe alongside a prod daemon when internal storage differs)
 yggdrasil --dev daemon
 ```
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -102,14 +102,19 @@ Credentials are resolved from `external_systems.endpoints.<name>.auth.user_env` 
 
 **Explanation:** `auto_run=False` in the `PlanDraft` sets initial status to `"draft"`. The plan waits for manual approval.
 
-**Resolution:** Approve manually (no UI is provided for this action yet, it has to be done directly into the database or implement your own solution)
+**Resolution:** Yggdrasil does not currently ship an approval UI or command.
+Use an operator-provided integration with the configured plan store to set
+`status="approved"`. For SQLite, that integration must also advance the
+plan change sequence transactionally; editing only the stored JSON will
+not notify PlanWatcher.
 
 ### Plan is `status="approved"` but Engine never runs it
 
 **Checks:**
 1. Confirm PlanWatcher is started: `grep "PlanWatcher" yggdrasil.log`
 2. Check `run_token > executed_run_token` in the plan document
-3. Verify `yggdrasil_plans` database exists and is accessible
+3. Verify the configured internal plan store (`yggdrasil_plans` database) exists and is accessible: the CouchDB
+   plans connection in production, or the SQLite file in dev mode.
 
 ---
 
@@ -193,12 +198,68 @@ def my_step(ctx: StepContext, **params) -> StepResult:
 
 ---
 
+## Daemon lock
+
+### "Another local Yggdrasil daemon is already running in … mode"
+
+One daemon may run **per mode** per user per host: `daemon.lock` (prod)
+and `daemon-dev.lock` (dev) in the user runtime directory. The error
+message and the lock metadata (pid, hostname, user, started_at) identify
+the holder.
+
+**Resolution:**
+
+1. Identify the holding process from the metadata in the error message.
+2. Stop it, or run your daemon in the other mode / on another machine.
+3. **Never delete a lock file while a daemon is running** — the advisory
+   `flock` dies with the process, and deleting a *held* file lets a second
+   daemon start. Stale lock files from exited daemons are harmless and can
+   stay.
+
+**Limits:** the lock does not coordinate across OS users, containers, or
+hosts, and it is intentionally not database-aware — it cannot detect two
+daemons sharing a CouchDB environment (the documentation and checkpoint
+conflict warnings are the safeguard there).
+
+---
+
+## Internal storage (dev SQLite)
+
+### Daemon refuses to start: invalid `internal_storage` configuration
+
+Explicit configuration errors are fatal by design; Yggdrasil never falls
+back to another storage backend. The message names the offending role,
+connection, or path.
+
+### "not an Yggdrasil internal-storage database" / schema version errors
+
+The SQLite file failed lifecycle validation (unrelated file, malformed
+content, or unsupported schema version). The dev database is disposable:
+move the file aside — or delete it — and restart to create fresh state.
+Never point the config at a file you care about; Yggdrasil refuses
+symlinks and foreign-owned files.
+
+### Approved a plan but the dev daemon does nothing
+
+Check that the stored plan has `status="approved"` and
+`run_token > executed_run_token`. Also confirm that PlanWatcher is
+running and that the approval was recorded as an observable change by
+the configured backend.
+
+A daemon with no checkpoint can miss a plan approved before it started.
+After confirming PlanWatcher is running, the operator-provided storage
+integration can re-emit an observable change for that plan. Do this only
+when the plan is definitely not already executing, because re-emitting
+an in-flight plan may schedule it twice.
+
+---
+
 ## Event spool
 
 ### No event files appearing in `$YGG_EVENT_SPOOL`
 
 **Checks:**
-1. Confirm `YGG_EVENT_SPOOL` is set (defaults to `/tmp/ygg_events`)
+1. Confirm `YGG_EVENT_SPOOL` is set (defaults to `/tmp/ygg_events`, or `/tmp/ygg_events_dev` under `--dev`)
 2. Verify the directory is writable: `ls -la $YGG_EVENT_SPOOL`
 
 ### Finding events for a specific plan

--- a/lib/core_utils/daemon_lock.py
+++ b/lib/core_utils/daemon_lock.py
@@ -1,8 +1,15 @@
 """Local process lock for Yggdrasil daemon invocations.
 
-The lock prevents two daemon processes from running in the same local runtime.
-It is implemented with an advisory ``fcntl.flock`` held on an open lock file
-for the lifetime of the daemon process.
+One lock exists **per effective mode**: a production daemon holds
+``daemon.lock`` and a dev daemon (``--dev``) holds ``daemon-dev.lock``, so
+the two may run side by side on one machine while duplicate daemons in the
+same mode are rejected. The lock is implemented with an advisory
+``fcntl.flock`` held on an open lock file for the lifetime of the daemon
+process.
+
+The lock does not coordinate across OS users, containers, or hosts, and is
+intentionally not database-aware: pointing a prod and a dev daemon at the
+same CouchDB environment remains unsupported.
 """
 
 from __future__ import annotations
@@ -32,7 +39,13 @@ class DaemonLockError(RuntimeError):
             holding the lock.
     """
 
-    def __init__(self, lock_path: Path, existing_metadata: dict[str, Any] | None):
+    def __init__(
+        self,
+        lock_path: Path,
+        existing_metadata: dict[str, Any] | None,
+        *,
+        dev_mode: bool | None = None,
+    ):
         """
         Initialize the lock acquisition error.
 
@@ -40,10 +53,20 @@ class DaemonLockError(RuntimeError):
             lock_path: Path to the lock file that is already locked.
             existing_metadata: Metadata from the existing lock file, if it
                 could be parsed as JSON.
+            dev_mode: Effective mode of the failed acquisition, if known;
+                names the mode in the error message.
         """
         self.lock_path = lock_path
         self.existing_metadata = existing_metadata or {}
-        super().__init__(f"Yggdrasil daemon lock is already held: {lock_path}")
+        self.dev_mode = dev_mode
+        if dev_mode is None:
+            message = f"Yggdrasil daemon lock is already held: {lock_path}"
+        else:
+            mode = "dev" if dev_mode else "prod"
+            message = (
+                f"Yggdrasil daemon lock ({mode} mode) is already held: {lock_path}"
+            )
+        super().__init__(message)
 
 
 @dataclass
@@ -64,6 +87,12 @@ class DaemonLock:
     _file: Any
 
     LOCK_FILENAME = "daemon.lock"
+    DEV_LOCK_FILENAME = "daemon-dev.lock"
+
+    @classmethod
+    def _lock_filename(cls, dev_mode: bool) -> str:
+        """Return the per-mode lock filename."""
+        return cls.DEV_LOCK_FILENAME if dev_mode else cls.LOCK_FILENAME
 
     @classmethod
     def acquire(
@@ -80,8 +109,9 @@ class DaemonLock:
         the current process to the lock file and returns a held ``DaemonLock``.
 
         Args:
-            dev_mode: Whether the daemon was started with ``--dev``. Stored in
-                lock metadata for diagnostics only.
+            dev_mode: Whether the daemon was started with ``--dev``. Selects
+                the per-mode lock file (``daemon.lock`` vs
+                ``daemon-dev.lock``) and is stored in lock metadata.
             config_path: Resolved configuration path, if known. Stored in lock
                 metadata for diagnostics only.
 
@@ -98,7 +128,7 @@ class DaemonLock:
         """
         lock_dir = cls._runtime_dir()
         cls._prepare_runtime_dir(lock_dir)
-        lock_path = lock_dir / cls.LOCK_FILENAME
+        lock_path = lock_dir / cls._lock_filename(dev_mode)
 
         lock_file = lock_path.open("a+", encoding="utf-8")
         try:
@@ -109,7 +139,9 @@ class DaemonLock:
                 raise
             existing_metadata = cls._read_metadata(lock_file)
             lock_file.close()
-            raise DaemonLockError(lock_path, existing_metadata) from exc
+            raise DaemonLockError(
+                lock_path, existing_metadata, dev_mode=dev_mode
+            ) from exc
 
         metadata = cls._metadata(dev_mode=dev_mode, config_path=config_path)
         lock_file.seek(0)

--- a/lib/core_utils/errors.py
+++ b/lib/core_utils/errors.py
@@ -11,6 +11,19 @@ clients, watcher backends) and handled centrally (the CLI).
 from __future__ import annotations
 
 
+class InternalStorageConfigurationError(RuntimeError):
+    """The ``internal_storage`` configuration block is invalid.
+
+    Raised during startup configuration resolution (``lib/storage/config.py``)
+    when an explicit ``internal_storage`` block references unknown connections,
+    a non-CouchDB endpoint, requests SQLite outside dev mode, or supplies an
+    invalid SQLite path. Explicit configuration errors are fatal by design —
+    Yggdrasil never silently falls back to another storage backend. The CLI
+    catches this at startup to print a concise operator message instead of a
+    full traceback.
+    """
+
+
 class ExternalSystemUnavailableError(ConnectionError):
     """An external system required by Yggdrasil could not be reached.
 

--- a/lib/core_utils/logging_utils.py
+++ b/lib/core_utils/logging_utils.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import re
 from collections.abc import Mapping
 from datetime import datetime
@@ -6,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from lib.core_utils.config_loader import ConfigLoader
+from lib.core_utils.ygg_session import YggSession
 
 try:
     from rich.logging import RichHandler
@@ -177,8 +179,10 @@ def configure_logging(debug: bool = False, console: bool = True) -> None:
     log_dir = Path(configs["yggdrasil"]["log_dir"])
     log_dir.mkdir(parents=True, exist_ok=True)
 
+    # Per-mode marker + PID keep concurrent processes in separate log files.
     timestamp = datetime.now().strftime("%Y-%m-%d_%H.%M.%S")
-    log_file = log_dir / f"yggdrasil_{timestamp}.log"
+    mode_marker = "dev_" if YggSession.is_dev() else ""
+    log_file = log_dir / f"yggdrasil_{mode_marker}{timestamp}_{os.getpid()}.log"
 
     log_level = logging.DEBUG if debug else logging.INFO
 

--- a/lib/core_utils/runtime_paths.py
+++ b/lib/core_utils/runtime_paths.py
@@ -1,0 +1,62 @@
+"""Mode-aware defaults for machine-local runtime paths.
+
+A production daemon and a dev daemon (``--dev``) may run on the same
+machine. Their machine-local state — the engine work root and the event
+spool — must not collide: shared ``success.fingerprint`` caches would
+cross-skip steps, and each ops consumer would ingest the other
+environment's events. These helpers keep production defaults exactly as
+they were and give dev mode ``_dev``-suffixed defaults.
+
+Explicit values (config key or environment variable) are exact overrides
+and are never rewritten. Resolution precedence:
+
+- work root: ``config["work_root"]`` → ``$YGG_WORK_ROOT`` → mode default
+- event spool: ``$YGG_EVENT_SPOOL`` → mode default
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from lib.core_utils.ygg_session import YggSession
+
+
+def default_work_root() -> Path:
+    """Return the mode default for the engine work root."""
+    return Path("/tmp/ygg_work_dev" if YggSession.is_dev() else "/tmp/ygg_work")
+
+
+def default_event_spool() -> Path:
+    """Return the mode default for the event spool."""
+    return Path("/tmp/ygg_events_dev" if YggSession.is_dev() else "/tmp/ygg_events")
+
+
+def resolve_work_root(config: Mapping[str, Any] | None = None) -> Path:
+    """Resolve the engine work root.
+
+    Args:
+        config: Optional main configuration; its ``work_root`` key (when
+            truthy) takes precedence over the environment.
+
+    Returns:
+        The resolved work root path.
+    """
+    if config:
+        configured = config.get("work_root")
+        if configured:
+            return Path(configured)
+    env_value = os.environ.get("YGG_WORK_ROOT")
+    if env_value:
+        return Path(env_value)
+    return default_work_root()
+
+
+def resolve_event_spool() -> Path:
+    """Resolve the event spool root (``$YGG_EVENT_SPOOL`` → mode default)."""
+    env_value = os.environ.get("YGG_EVENT_SPOOL")
+    if env_value:
+        return Path(env_value)
+    return default_event_spool()

--- a/lib/core_utils/yggdrasil_core.py
+++ b/lib/core_utils/yggdrasil_core.py
@@ -1,7 +1,6 @@
 import asyncio
 import importlib.metadata
 import logging
-import os
 import uuid
 from collections.abc import Mapping
 from pathlib import Path
@@ -10,11 +9,12 @@ from typing import Any
 from lib.core_utils.event_types import EventType
 from lib.core_utils.logging_utils import custom_logger
 from lib.core_utils.plan_eligibility import is_plan_eligible
+from lib.core_utils.runtime_paths import resolve_event_spool, resolve_work_root
 from lib.core_utils.singleton_decorator import singleton
-from lib.couchdb.plan_db_manager import PlanDBManager
 from lib.couchdb.project_db_manager import ProjectDBManager
 from lib.handlers.base_handler import BaseHandler
 from lib.ops.consumer_service import OpsConsumerService
+from lib.storage import InternalStorageBundle, build_internal_storage
 from lib.watchers.abstract_watcher import YggdrasilEvent
 from lib.watchers.manager import WatcherManager
 from lib.watchers.plan_watcher import PlanWatcher
@@ -52,17 +52,28 @@ class YggdrasilCore:
         logger: logging.Logger | None = None,
         *,
         config_path: str | Path | None = None,
+        storage: InternalStorageBundle | None = None,
     ):
         """
         Args:
             config: A dictionary of global Yggdrasil settings.
             logger: If not provided, a default named logger is created.
             config_path: Optional path to the loaded config file for diagnostics.
+            storage: Optional internal-storage bundle injection (tests).
+                Defaults to resolving the ``internal_storage`` config block.
         """
         self.config = config
         self.config_path = Path(config_path) if config_path is not None else None
         self._logger = logger or custom_logger(f"{__name__}.{type(self).__name__}")
         self._running = False
+
+        # Internal storage boundary (plans, plan changes, checkpoints, ops
+        # snapshots). Resolved once; all internal persistence goes through it.
+        self.storage = storage or build_internal_storage(config)
+
+        # ProjectDBManager is external (projects DB) and NOT part of internal
+        # storage; it is constructed lazily and only used by run-doc paths.
+        self._pdm: ProjectDBManager | None = None
 
         # Watchers: a list of classes that inherit from AbstractWatcher
         self.watchers: list = []
@@ -84,15 +95,21 @@ class YggdrasilCore:
         # WatcherManager (Phase 2; set by setup_realms)
         self.watcher_manager: Any = None
 
-        # Ops consumer service (for writing plan_status to CouchDB)
-        self.ops_consumer = OpsConsumerService(interval_sec=2.0)
+        # Ops consumer service (writes plan_status snapshots via the bundle)
+        self.ops_consumer = OpsConsumerService(
+            interval_sec=2.0, writer=self.storage.ops_snapshots
+        )
+
+        # Machine-local runtime paths, resolved once and reused everywhere
+        # (engine, planning contexts, spool drain) so one process cannot
+        # split across two roots.
+        self.work_root = resolve_work_root(config)
+        self.event_spool = resolve_event_spool()
 
         # Engine for plan execution (handlers now return plans; core executes them)
         self.engine = Engine(
-            work_root=config.get("work_root") or os.environ.get("YGG_WORK_ROOT"),
-            emitter=FileSpoolEmitter(
-                spool_dir=os.environ.get("YGG_EVENT_SPOOL", "/tmp/ygg_events")
-            ),
+            work_root=self.work_root,
+            emitter=FileSpoolEmitter(spool_dir=self.event_spool),
         )
 
         self._init_db_managers()
@@ -143,25 +160,34 @@ class YggdrasilCore:
 
         return plan_doc_id
 
+    @property
+    def pdm(self) -> ProjectDBManager:
+        """Lazily constructed ProjectDBManager (external 'projects' DB).
+
+        Only the run-doc paths use it; normal daemon operation never
+        constructs it. It is not part of internal storage.
+        """
+        if self._pdm is None:
+            self._logger.info("Initializing ProjectDBManager (run-doc path)...")
+            self._pdm = ProjectDBManager()
+        return self._pdm
+
+    @pdm.setter
+    def pdm(self, value: ProjectDBManager) -> None:
+        """Allow explicit injection (tests)."""
+        self._pdm = value
+
     def _init_db_managers(self):
         """
-        Initializes database managers or other central resources.
+        Wire database access for Core.
 
-        Managers initialized:
-        - pdm: ProjectDBManager for 'projects' database
-        - ydm: YggdrasilDBManager for 'yggdrasil' database
-        - plan_dbm: PlanDBManager for 'yggdrasil_plans' database
-
-        Each manager reads CouchDB connection config from main.json and
-        creates its own CloudantV1 client via CouchDBClientFactory.
+        - plan_dbm: PlanStore from the internal-storage bundle
+        - pdm: ProjectDBManager is lazy (see the ``pdm`` property) and only
+          constructed by the run-doc paths.
         """
         self._logger.info("Initializing DB managers...")
 
-        from lib.couchdb.yggdrasil_db_manager import YggdrasilDBManager
-
-        self.pdm = ProjectDBManager()
-        self.ydm = YggdrasilDBManager()
-        self.plan_dbm = PlanDBManager()
+        self.plan_dbm = self.storage.plans
 
         self._logger.info("DB managers initialized.")
 
@@ -195,11 +221,8 @@ class YggdrasilCore:
     def _make_planning_ctx(
         self, handler, scope: dict[str, Any], *, doc: dict[str, Any], reason: str
     ) -> PlanningContext:
-        work_root = Path(os.getenv("YGG_WORK_ROOT", "/tmp/ygg_work"))
-        scope_dir = work_root / handler.realm_id / scope["id"]
-        emitter = FileSpoolEmitter(
-            spool_dir=os.getenv("YGG_EVENT_SPOOL", "/tmp/ygg_events")
-        )
+        scope_dir = self.work_root / handler.realm_id / scope["id"]
+        emitter = FileSpoolEmitter(spool_dir=self.event_spool)
         # ops_db = os.getenv("OPS_DB", "yggdrasil_ops")
         return handler.build_planning_context(
             scope=scope,
@@ -519,6 +542,7 @@ class YggdrasilCore:
         self.watcher_manager = WatcherManager(
             config=self.config.get("external_systems", {}),
             on_event=self.handle_event,
+            checkpoint_store=self.storage.checkpoints,
             logger=self._logger,
             watcher_policy=self.config.get("watchers", {}),
             config_path=self.config_path,
@@ -639,6 +663,9 @@ class YggdrasilCore:
         plan_watcher = PlanWatcher(
             on_event=self._handle_plan_execution_event,
             poll_interval_sec=poll_interval,
+            plan_store=self.storage.plans,
+            change_source=self.storage.plan_changes,
+            checkpoint_store=self.storage.checkpoints,
             execution_authority_filter="daemon",  # Skip run_once plans
         )
         self.register_watcher(plan_watcher)
@@ -760,19 +787,13 @@ class YggdrasilCore:
             # Token NOT updated → plan remains eligible for retry
 
     async def _recover_approved_plans(self) -> None:
-        """
-        Startup recovery: execute any approved plans that were missed.
+        """Queue all eligible plans through the configured daemon watcher.
 
-        This is called when the PlanWatcher checkpoint is missing or invalid.
-        It queries all eligible plans and executes them.
-
-        The recovery process:
-        1. Query all approved pending plans
-        2. Execute each via _execute_approved_plan()
-        3. Initialize checkpoint after recovery
-
-        Note: This is a fallback mechanism. Normal operation uses the
-        _changes feed via PlanWatcher for incremental updates.
+        This helper is not currently called by :meth:`start` (see Tech Debt
+        #17). The watcher's recovery scan emits callbacks, which queue
+        execution; this method neither inspects nor initializes a checkpoint.
+        A future startup caller must coordinate the scan with the live change
+        cursor and deduplicate any overlap.
         """
         if not hasattr(self, "_plan_watcher") or self._plan_watcher is None:
             self._logger.warning("No PlanWatcher configured; skipping recovery")
@@ -967,7 +988,7 @@ class YggdrasilCore:
         Create and persist a plan from a project document (no execution).
 
         This is the --plan-only mode: creates a plan with execution_authority='daemon'
-        for later approval via Genstat and execution by the daemon.
+        for later approval by an external actor and execution by the daemon.
 
         Args:
             doc_id: Project document ID
@@ -1043,7 +1064,7 @@ class YggdrasilCore:
                     )
                     self._logger.info(
                         "✓ Plan '%s' created (status=draft, authority=daemon). "
-                        "Awaiting approval via Genstat.",
+                        "Awaiting external approval.",
                         plan_doc_id,
                     )
                     persisted_ids.append(plan_doc_id)
@@ -1084,7 +1105,6 @@ class YggdrasilCore:
             int: Exit code (0=success, 1=error, 130=interrupted)
         """
         from lib.ops.consumer import FileSpoolConsumer
-        from lib.ops.sinks.couch import OpsWriter
 
         # Generate unique owner token for this entire session
         execution_owner = _generate_run_once_owner()
@@ -1147,12 +1167,8 @@ class YggdrasilCore:
         # ─────────────────────────────────────────────────────────────────
         # Phase 3: Consume event spool
         # ─────────────────────────────────────────────────────────────────
-        spool_root = Path(os.environ.get("YGG_EVENT_SPOOL", "/tmp/ygg_events"))
-        self._logger.info("Consuming event spool at %s", spool_root)
-        FileSpoolConsumer(
-            spool_root,
-            OpsWriter(db_name=os.environ.get("OPS_DB", "yggdrasil_ops")),
-        ).consume()
+        self._logger.info("Consuming event spool at %s", self.event_spool)
+        FileSpoolConsumer(self.event_spool, self.storage.ops_snapshots).consume()
 
         return exit_code
 
@@ -1287,6 +1303,14 @@ class YggdrasilCore:
             """
             nonlocal error_occurred
 
+            # Stop launching new plans once interrupted. The plan already
+            # running (if any) finishes; subsequent recovered/live plans are
+            # skipped and left pending in the DB for manual handling. Matters
+            # most for the synchronous recovery pass, which would otherwise
+            # execute every recovered plan before the interrupt is observed.
+            if interrupted:
+                return
+
             payload = event.payload or {}
             plan_doc_id = payload.get("plan_doc_id")
             plan_doc = payload.get("plan_doc")
@@ -1314,7 +1338,7 @@ class YggdrasilCore:
                 _check_all_completed()
                 return
 
-            # Check if ownership was transferred (Genstat changed execution_authority)
+            # Check whether an external actor transferred execution ownership.
             if plan_doc.get("execution_authority") != "run_once":
                 self._logger.info(
                     "Plan '%s' transferred to daemon; marking completed (no action)",
@@ -1355,6 +1379,8 @@ class YggdrasilCore:
                     return
 
                 run_token = plan_doc.get("run_token", 0)
+                if interrupted:
+                    return
                 self.engine.run(plan)
                 self._logger.info("✓ Plan '%s' execution completed", plan_doc_id)
 
@@ -1380,6 +1406,9 @@ class YggdrasilCore:
         scoped_watcher = PlanWatcher(
             on_event=on_plan_eligible,
             poll_interval_sec=2.0,  # Responsive for interactive use
+            plan_store=self.storage.plans,
+            change_source=self.storage.plan_changes,
+            checkpoint_store=self.storage.checkpoints,
             execution_owner_filter=execution_owner,
             # NOTE: No execution_authority_filter; we check origin in callback
         )
@@ -1393,6 +1422,15 @@ class YggdrasilCore:
         original_handler = signal.signal(signal.SIGINT, handle_interrupt)
 
         try:
+            # Recovery pass before the live watcher starts: plans were saved
+            # in Phase 1, so a fresh change cursor (resolved at "now") would
+            # never observe them. Explicit IDs avoid a whole-database scan;
+            # the owner filter remains a defense-in-depth boundary. Kept
+            # inside the try (after the interrupt handler is installed) so
+            # Ctrl+C during recovered execution still routes to the
+            # controlled shutdown + spool drain below.
+            await scoped_watcher.recover_pending_plans(plan_ids=pending_plan_ids)
+
             # Start watcher task
             watcher_task = asyncio.create_task(scoped_watcher.start())
 

--- a/lib/couchdb/plan_db_manager.py
+++ b/lib/couchdb/plan_db_manager.py
@@ -9,8 +9,6 @@ separate from operational data (yggdrasil_ops) and project data (projects).
 """
 
 import logging
-from datetime import UTC, datetime
-from pathlib import Path
 from typing import Any, cast
 
 from ibm_cloud_sdk_core.api_exception import ApiException
@@ -19,46 +17,26 @@ from ibmcloudant.cloudant_v1 import Document
 from lib.core_utils.logging_utils import custom_logger
 from lib.couchdb.couchdb_connection import CouchDBHandler
 from lib.couchdb.couchdb_defaults import DEFAULT_ENDPOINT, resolve_couchdb_params
+from lib.storage.plan_documents import (
+    VALID_EXECUTION_AUTHORITIES,
+    build_plan_document,
+    json_safe,
+    plan_model_from_document,
+    plan_summary_from_document,
+    utc_now_iso,
+    validate_execution_authority,
+)
 from yggdrasil.flow.model import Plan
 
 logger = custom_logger(__name__)
 
-# Valid values for execution_authority field
-VALID_EXECUTION_AUTHORITIES = frozenset({"daemon", "run_once"})
+__all__ = ["PlanDBManager", "VALID_EXECUTION_AUTHORITIES"]
 
-
-def _json_safe(value: Any) -> Any:
-    """Recursively coerce plan documents into JSON-serializable structures.
-
-    CouchDB client calls ``json.dumps`` under the hood. Realm planners can
-    sometimes return pathlib.Path (or other non-JSON types) inside params or
-    preview payloads. This helper walks the structure and converts:
-    - Path -> str
-    - set/tuple -> list
-    - dict/list elements recursively
-    """
-
-    if isinstance(value, Path):
-        return str(value)
-    if isinstance(value, dict):
-        return {k: _json_safe(v) for k, v in value.items()}
-    if isinstance(value, (list, tuple, set)):
-        return [_json_safe(v) for v in value]
-    return value
-
-
-def _validate_execution_authority(authority: str) -> None:
-    """Raise ValueError if execution_authority is invalid."""
-    if authority not in VALID_EXECUTION_AUTHORITIES:
-        raise ValueError(
-            f"Invalid execution_authority: {authority!r}. "
-            f"Must be one of: {sorted(VALID_EXECUTION_AUTHORITIES)}"
-        )
-
-
-def _utc_now_iso() -> str:
-    """Return current UTC timestamp in ISO-8601 format."""
-    return datetime.now(UTC).isoformat(timespec="seconds")
+# Backwards-compatible aliases; canonical definitions live in
+# lib/storage/plan_documents.py, shared with the SQLite backend.
+_json_safe = json_safe
+_validate_execution_authority = validate_execution_authority
+_utc_now_iso = utc_now_iso
 
 
 class PlanDBManager(CouchDBHandler):
@@ -94,9 +72,10 @@ class PlanDBManager(CouchDBHandler):
         url: str | None = None,
         user_env: str | None = None,
         pass_env: str | None = None,
+        db_name: str = "yggdrasil_plans",
         logger: logging.Logger | None = None,
     ) -> None:
-        """Initialize connection to yggdrasil_plans database."""
+        """Initialize connection to the plans database."""
         self._logger = logger or custom_logger(f"{__name__}.{type(self).__name__}")
         params = resolve_couchdb_params(
             endpoint=endpoint,
@@ -106,7 +85,7 @@ class PlanDBManager(CouchDBHandler):
         )
 
         super().__init__(
-            "yggdrasil_plans",
+            db_name,
             url=params.url,
             user_env=params.user_env,
             pass_env=params.pass_env,
@@ -156,8 +135,8 @@ class PlanDBManager(CouchDBHandler):
             ValueError: If execution_authority is invalid or plan.plan_id is missing
             ApiException: On database errors
         """
-        # Validate inputs
-        _validate_execution_authority(execution_authority)
+        # Validate inputs before touching the database
+        validate_execution_authority(execution_authority)
         doc_id = plan.plan_id
         if not doc_id:
             raise ValueError("plan.plan_id is required for persistence")
@@ -166,38 +145,28 @@ class PlanDBManager(CouchDBHandler):
         existing = self.fetch_document_by_id(doc_id)
         rev = existing.get("_rev") if existing else None
 
-        now = _utc_now_iso()
+        # Canonical document shape shared with the SQLite backend
+        plan_doc = build_plan_document(
+            plan,
+            realm,
+            scope,
+            auto_run=auto_run,
+            execution_authority=execution_authority,
+            execution_owner=execution_owner,
+            preview=preview,
+            source_doc_id=source_doc_id,
+            source_doc_rev=source_doc_rev,
+            notes=notes,
+            existing=existing,
+        )
 
-        plan_doc: dict[str, Any] = {
-            "_id": doc_id,
-            "realm": realm,
-            "scope": scope,
-            "status": "approved" if auto_run else "draft",
-            "plan": plan.to_dict(),
-            "preview": preview or {},
-            "run_token": 0,
-            "executed_run_token": -1,
-            "execution_authority": execution_authority,
-            "execution_owner": execution_owner,
-            "created_at": existing.get("created_at", now) if existing else now,
-            "updated_at": now,
-        }
-
-        # Include _rev for conflict-safe update
+        # Include _rev for conflict-safe update (backend-specific field)
         if rev:
             plan_doc["_rev"] = rev
 
-        # Optional fields
-        if source_doc_id:
-            plan_doc["source_doc_id"] = source_doc_id
-        if source_doc_rev:
-            plan_doc["source_doc_rev"] = source_doc_rev
-        if notes:
-            plan_doc["notes"] = notes
-
-        # Persist to database (after ensuring JSON-serializable payload)
+        # Persist to database (build_plan_document returns JSON-safe content)
         try:
-            serializable_doc = cast(Document, _json_safe(plan_doc))
+            serializable_doc = cast(Document, plan_doc)
             self.server.put_document(
                 db=self.db_name,
                 doc_id=doc_id,
@@ -241,20 +210,7 @@ class PlanDBManager(CouchDBHandler):
         doc = self.fetch_document_by_id(doc_id)
         if not doc:
             return None
-
-        plan_data = doc.get("plan")
-        if not plan_data:
-            self._logger.warning("Plan document '%s' has no 'plan' field", doc_id)
-            return None
-
-        try:
-            # Note: Path reconstruction is handled by Engine via coerce_params_to_signature_types()
-            # (from yggdrasil.flow.utils.typing_coerce) based on step function type hints.
-            # Params remain as strings in the persisted document.
-            return Plan.from_dict(plan_data)
-        except (KeyError, TypeError) as e:
-            self._logger.error("Failed to deserialize plan '%s': %s", doc_id, e)
-            return None
+        return plan_model_from_document(doc, self._logger)
 
     def update_executed_token(
         self,
@@ -325,7 +281,7 @@ class PlanDBManager(CouchDBHandler):
         """
         Query all approved plans that are pending execution.
 
-        Used for startup recovery when checkpoint is missing.
+        Reserved for future daemon-startup recovery.
         Returns plans where: status='approved' AND run_token > executed_run_token
 
         Note: This is a full scan (O(n)). For large databases, consider
@@ -435,12 +391,4 @@ class PlanDBManager(CouchDBHandler):
         doc = self.fetch_document_by_id(doc_id)
         if not doc:
             return None
-        return {
-            "status": doc.get("status", "unknown"),
-            "execution_authority": doc.get("execution_authority", "daemon"),
-            "execution_owner": doc.get("execution_owner"),
-            "updated_at": doc.get("updated_at", "unknown"),
-            "realm": doc.get("realm", "unknown"),
-            "run_token": doc.get("run_token", 0),
-            "executed_run_token": doc.get("executed_run_token", -1),
-        }
+        return plan_summary_from_document(doc)

--- a/lib/couchdb/yggdrasil_db_manager.py
+++ b/lib/couchdb/yggdrasil_db_manager.py
@@ -55,6 +55,7 @@ class YggdrasilDBManager(CouchDBHandler):
         url: str | None = None,
         user_env: str | None = None,
         pass_env: str | None = None,
+        db_name: str = "yggdrasil",
         logger: logging.Logger | None = None,
     ) -> None:
         self._logger = logger or custom_logger(f"{__name__}.{type(self).__name__}")
@@ -66,7 +67,7 @@ class YggdrasilDBManager(CouchDBHandler):
         )
 
         super().__init__(
-            "yggdrasil",
+            db_name,
             url=params.url,
             user_env=params.user_env,
             pass_env=params.pass_env,

--- a/lib/couchdb/yggdrasil_document.py
+++ b/lib/couchdb/yggdrasil_document.py
@@ -255,7 +255,7 @@ class YggdrasilDocument:
         return True
 
     # NOTE: This is not supposed to be used by Yggdrasil, but by the user interface
-    # NOTE: When a responsible reviews the sample, Genstat will update the QC status
+    # NOTE: A sample-review integration updates the QC status after review.
     def set_sample_qc_status(self, sample_id: str, qc_value: str) -> None:
         """
         Sets the QC status (Passed/Failed/Pending) for a sample.

--- a/lib/handlers/bp_analysis_handler.py
+++ b/lib/handlers/bp_analysis_handler.py
@@ -1,4 +1,10 @@
 # lib/handlers/project_handler.py
+#
+# DEAD CODE — not wired anywhere (no entry point or core path constructs
+# BestPracticeAnalysisHandler). Constructs YggdrasilDBManager directly,
+# bypassing the internal-storage bundle. Scheduled for removal with the
+# legacy project-realm / run-doc deprecation cleanup.
+# See docs/TECH_DEBT_LEDGER.md #15.
 
 import asyncio
 

--- a/lib/ops/consumer_service.py
+++ b/lib/ops/consumer_service.py
@@ -2,21 +2,44 @@ from __future__ import annotations
 
 import asyncio
 import os
-from pathlib import Path
 
+from lib.core_utils.runtime_paths import resolve_event_spool
 from lib.ops.consumer import FileSpoolConsumer
 from lib.ops.sinks.couch import OpsWriter
+from lib.storage.protocols import OpsSnapshotSink
 
 # TODO: consider moving to lib/ops/services/ when more services land.
 
 
 class OpsConsumerService:
-    def __init__(self, interval_sec: float = 2.0, db_name: str | None = None):
+    """Periodic event-spool consumer writing plan_status snapshots.
+
+    The snapshot sink is normally injected by YggdrasilCore from its
+    InternalStorageBundle. Bare construction falls back to the legacy
+    CouchDB ``OpsWriter`` (honoring ``OPS_DB``, deprecated).
+    """
+
+    def __init__(
+        self,
+        interval_sec: float = 2.0,
+        db_name: str | None = None,
+        *,
+        writer: OpsSnapshotSink | None = None,
+    ):
+        """
+        Args:
+            interval_sec: Seconds between spool consumption cycles.
+            db_name: Legacy CouchDB ops database name override; only used
+                when no ``writer`` is injected.
+            writer: Injected snapshot sink (backend-neutral).
+        """
         self.interval = interval_sec
-        self.spool = Path(os.environ.get("YGG_EVENT_SPOOL") or "/tmp/ygg_events")
-        self.writer = OpsWriter(
-            db_name=db_name or os.environ.get("OPS_DB") or "yggdrasil_ops"
-        )
+        self.spool = resolve_event_spool()
+        if writer is None:
+            writer = OpsWriter(
+                db_name=db_name or os.environ.get("OPS_DB") or "yggdrasil_ops"
+            )
+        self.writer = writer
         self._task: asyncio.Task | None = None
         self._stop = asyncio.Event()
 

--- a/lib/ops/sinks/couch.py
+++ b/lib/ops/sinks/couch.py
@@ -95,7 +95,7 @@ class OpsWriter(CouchDBHandler):
             "notes": draft.notes,
             "preview": draft.preview,
             "auto_run": draft.auto_run,
-            "approved": False,  # flipped by a human in Genstat / ops UI
+            "approved": False,  # flipped by a human through an operations UI
             "approvals_required": draft.approvals_required,
             "plan": {
                 "plan_id": plan.plan_id,

--- a/lib/realms/test_realm/watcher.py
+++ b/lib/realms/test_realm/watcher.py
@@ -3,6 +3,12 @@ Test realm watcher for monitoring test scenario documents.
 
 ScenarioDocWatcher monitors the 'yggdrasil' database for documents with
 type="ygg_test_scenario" and emits TEST_SCENARIO_CHANGE events.
+
+DEAD CODE — not wired anywhere: test_realm registers generic WatchSpecs
+instead (see lib/realms/test_realm/__init__.py). Constructs
+YggdrasilDBManager / CouchDBCheckpointStore directly, bypassing the
+internal-storage bundle. Scheduled for removal with the deprecation
+cleanup. See docs/TECH_DEBT_LEDGER.md #15.
 """
 
 import asyncio

--- a/lib/storage/__init__.py
+++ b/lib/storage/__init__.py
@@ -1,0 +1,41 @@
+"""Backend-neutral internal storage for Yggdrasil Core.
+
+This package defines a narrow boundary between Core and the databases that
+hold Yggdrasil's *internal* state: plan documents, watcher checkpoints, and
+operations snapshots. Core consumes the :class:`InternalStorageBundle`
+protocols only and never constructs backend clients directly.
+
+Backends:
+    - CouchDB (production; wraps the existing ``lib/couchdb`` managers)
+    - SQLite (explicit configuration, effective dev mode or tests only)
+
+External data sources (the ``projects`` database, realm watch sources,
+realm ``DataAccess`` providers) are *not* part of internal storage and keep
+their existing resolution paths.
+"""
+
+from lib.storage.config import (
+    CouchInternalStorageConfig,
+    SQLiteInternalStorageConfig,
+    default_sqlite_path,
+    resolve_internal_storage_config,
+)
+from lib.storage.factory import build_internal_storage
+from lib.storage.protocols import (
+    InternalStorageBundle,
+    OpsSnapshotSink,
+    PlanChangeSource,
+    PlanStore,
+)
+
+__all__ = [
+    "CouchInternalStorageConfig",
+    "InternalStorageBundle",
+    "OpsSnapshotSink",
+    "PlanChangeSource",
+    "PlanStore",
+    "SQLiteInternalStorageConfig",
+    "build_internal_storage",
+    "default_sqlite_path",
+    "resolve_internal_storage_config",
+]

--- a/lib/storage/config.py
+++ b/lib/storage/config.py
@@ -1,0 +1,191 @@
+"""Configuration resolution for internal storage.
+
+Reads the optional ``internal_storage`` block from the loaded main
+configuration and resolves it into a typed config object:
+
+- ``backend: "couchdb"`` — each logical database role is assigned one named
+  ``external_systems`` connection; URL and auth env-var names come from the
+  referenced endpoint. Credentials, URLs, and database names are never
+  duplicated under ``internal_storage``.
+- ``backend: "sqlite"`` — accepted only in effective dev mode (or explicit
+  test injection). ``path: null`` selects the workspace default.
+- Absent block — legacy implicit CouchDB construction (deprecated).
+
+Invalid explicit configuration is fatal; Yggdrasil never falls back to a
+different backend than the one configured.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, ClassVar
+
+from lib.core_utils.common import YggdrasilUtilities as Ygg
+from lib.core_utils.errors import InternalStorageConfigurationError
+from lib.core_utils.external_systems_resolver import (
+    ResolvedConnection,
+    resolve_connection,
+)
+from lib.core_utils.ygg_session import YggSession
+
+# Logical database roles that must each map to a named connection.
+_COUCH_ROLES = ("coordination", "plans", "operations")
+
+
+@dataclass(frozen=True)
+class CouchInternalStorageConfig:
+    """Explicit CouchDB internal-storage configuration.
+
+    Attributes:
+        coordination: Connection for the coordination database (checkpoints).
+        plans: Connection for the plan documents database.
+        operations: Connection for the operations snapshots database.
+    """
+
+    coordination: ResolvedConnection
+    plans: ResolvedConnection
+    operations: ResolvedConnection
+
+    backend: ClassVar[str] = "couchdb"
+
+
+@dataclass(frozen=True)
+class SQLiteInternalStorageConfig:
+    """Explicit SQLite internal-storage configuration (dev/tests only).
+
+    Attributes:
+        path: Absolute path of the SQLite database file.
+    """
+
+    path: Path
+
+    backend: ClassVar[str] = "sqlite"
+
+
+def default_sqlite_path() -> Path:
+    """Return the default dev SQLite database path inside the workspace."""
+    return Ygg.workspace_path() / "internal_state" / "dev" / "yggdrasil.sqlite3"
+
+
+def resolve_internal_storage_config(
+    config: Mapping[str, Any],
+    *,
+    dev_mode: bool | None = None,
+) -> CouchInternalStorageConfig | SQLiteInternalStorageConfig | None:
+    """Resolve the ``internal_storage`` block of the main configuration.
+
+    Args:
+        config: The full loaded main configuration mapping.
+        dev_mode: Effective dev mode override for tests. Defaults to
+            ``YggSession.is_dev()``.
+
+    Returns:
+        A typed config object, or None when the block is absent (legacy
+        implicit CouchDB construction applies).
+
+    Raises:
+        InternalStorageConfigurationError: On any invalid explicit
+            configuration (unknown backend, missing/malformed connection
+            references, non-CouchDB endpoints, SQLite outside dev mode, or a
+            non-absolute SQLite path).
+    """
+    block = config.get("internal_storage")
+    if block is None:
+        return None
+
+    if not isinstance(block, Mapping):
+        raise InternalStorageConfigurationError(
+            "internal_storage must be an object, got " f"{type(block).__name__}"
+        )
+
+    backend = block.get("backend")
+    if backend == "couchdb":
+        return _resolve_couchdb(block, config)
+    if backend == "sqlite":
+        return _resolve_sqlite(block, dev_mode=dev_mode)
+
+    raise InternalStorageConfigurationError(
+        f"internal_storage.backend must be 'couchdb' or 'sqlite', got {backend!r}"
+    )
+
+
+def _resolve_couchdb(
+    block: Mapping[str, Any],
+    config: Mapping[str, Any],
+) -> CouchInternalStorageConfig:
+    """Resolve the explicit CouchDB role→connection assignments."""
+    couch_block = block.get("couchdb")
+    if not isinstance(couch_block, Mapping):
+        raise InternalStorageConfigurationError(
+            "internal_storage.couchdb must be an object with a 'connections' map"
+        )
+    role_map = couch_block.get("connections")
+    if not isinstance(role_map, Mapping):
+        raise InternalStorageConfigurationError(
+            "internal_storage.couchdb.connections must map roles "
+            f"{list(_COUCH_ROLES)} to external_systems connection names"
+        )
+
+    missing = [role for role in _COUCH_ROLES if not role_map.get(role)]
+    if missing:
+        raise InternalStorageConfigurationError(
+            f"internal_storage.couchdb.connections is missing roles: {missing}"
+        )
+
+    ext_cfg = dict(config.get("external_systems") or {})
+
+    resolved: dict[str, ResolvedConnection] = {}
+    for role in _COUCH_ROLES:
+        connection_name = role_map[role]
+        try:
+            conn = resolve_connection(str(connection_name), ext_cfg)
+        except (KeyError, ValueError) as e:
+            raise InternalStorageConfigurationError(
+                f"internal_storage role '{role}': {e}"
+            ) from e
+        if conn.endpoint.backend_type != "couchdb":
+            raise InternalStorageConfigurationError(
+                f"internal_storage role '{role}' resolves to endpoint "
+                f"'{conn.endpoint.name}' with backend "
+                f"'{conn.endpoint.backend_type}'; a CouchDB endpoint is required"
+            )
+        resolved[role] = conn
+
+    return CouchInternalStorageConfig(
+        coordination=resolved["coordination"],
+        plans=resolved["plans"],
+        operations=resolved["operations"],
+    )
+
+
+def _resolve_sqlite(
+    block: Mapping[str, Any],
+    *,
+    dev_mode: bool | None,
+) -> SQLiteInternalStorageConfig:
+    """Resolve the explicit SQLite configuration (dev-mode gated)."""
+    effective_dev = YggSession.is_dev() if dev_mode is None else dev_mode
+    if not effective_dev:
+        raise InternalStorageConfigurationError(
+            "internal_storage.backend='sqlite' is only supported in dev mode "
+            "(run with --dev) or tests; production uses CouchDB"
+        )
+
+    sqlite_block = block.get("sqlite") or {}
+    if not isinstance(sqlite_block, Mapping):
+        raise InternalStorageConfigurationError(
+            "internal_storage.sqlite must be an object"
+        )
+
+    raw_path = sqlite_block.get("path")
+    if raw_path is None:
+        return SQLiteInternalStorageConfig(path=default_sqlite_path())
+
+    path = Path(str(raw_path))
+    if not path.is_absolute():
+        raise InternalStorageConfigurationError(
+            f"internal_storage.sqlite.path must be absolute, got {raw_path!r}"
+        )
+    return SQLiteInternalStorageConfig(path=path)

--- a/lib/storage/couch.py
+++ b/lib/storage/couch.py
@@ -1,0 +1,149 @@
+"""CouchDB internal-storage bundle.
+
+Wraps the existing CouchDB implementations (``PlanDBManager``,
+``ChangesFetcher``, ``CouchDBCheckpointStore``, ``OpsWriter``) behind the
+internal-storage protocols. Database and document IDs, plan JSON and
+``_rev`` handling, ``_changes`` semantics, checkpoint documents, and
+snapshot upserts are all preserved — the adapters only translate shapes.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import AsyncIterator
+
+from lib.core_utils.logging_utils import custom_logger
+from lib.couchdb.changes_fetcher import ChangesFetcher
+from lib.couchdb.plan_db_manager import PlanDBManager
+from lib.couchdb.yggdrasil_db_manager import YggdrasilDBManager
+from lib.ops.sinks.couch import OpsWriter
+from lib.storage.config import CouchInternalStorageConfig
+from lib.storage.protocols import InternalStorageBundle
+from lib.watchers.backends.base import RawWatchEvent
+from lib.watchers.backends.checkpoint_store import CouchDBCheckpointStore
+
+logger = custom_logger(__name__)
+
+_LEGACY_OPS_DB = "yggdrasil_ops"
+
+
+class CouchPlanChangeSource:
+    """Adapts ``ChangesFetcher`` dict changes to ``RawWatchEvent`` objects.
+
+    Attributes:
+        _fetcher: The underlying ChangesFetcher (bound to the plans DB,
+            include_docs=True).
+    """
+
+    def __init__(self, changes_fetcher: ChangesFetcher) -> None:
+        """Initialize with a ChangesFetcher bound to the plans database."""
+        self._fetcher = changes_fetcher
+
+    async def stream_changes_continuously(
+        self,
+        *,
+        since: str | int,
+        poll_interval_sec: float,
+    ) -> AsyncIterator[RawWatchEvent]:
+        """Stream plan changes as backend-agnostic events.
+
+        Args:
+            since: CouchDB sequence cursor, or "now" for the current head.
+            poll_interval_sec: Seconds between _changes polls.
+
+        Yields:
+            RawWatchEvent per change entry; ``meta`` carries the remaining
+            CouchDB change-entry fields for diagnostics only.
+        """
+        async for change in self._fetcher.stream_changes_continuously(
+            since=str(since),
+            poll_interval_sec=poll_interval_sec,
+        ):
+            yield RawWatchEvent(
+                id=str(change.get("id", "")),
+                doc=change.get("doc"),
+                seq=change.get("seq"),
+                deleted=bool(change.get("deleted", False)),
+                meta={
+                    k: v
+                    for k, v in change.items()
+                    if k not in ("id", "doc", "seq", "deleted")
+                },
+            )
+
+
+def build_couchdb_bundle(
+    cfg: CouchInternalStorageConfig | None,
+    *,
+    log: logging.Logger | None = None,
+) -> InternalStorageBundle:
+    """Build the CouchDB internal-storage bundle.
+
+    Args:
+        cfg: Explicit configuration, or None for the legacy implicit path
+            (deprecated): fixed database names resolved through the default
+            ``couchdb`` endpoint, with ``OPS_DB`` honored for the operations
+            database name.
+        log: Optional logger override.
+
+    Returns:
+        InternalStorageBundle backed by CouchDB.
+    """
+    _log = log or logger
+
+    if cfg is None:
+        _log.warning(
+            "No 'internal_storage' block in configuration; using implicit "
+            "CouchDB internal storage (deprecated). Explicit configuration "
+            "will be required in a future release."
+        )
+        ops_db_env = os.environ.get("OPS_DB")
+        if ops_db_env:
+            _log.warning(
+                "OPS_DB=%s is honored only by the implicit legacy "
+                "configuration and is deprecated; set "
+                "internal_storage.couchdb.connections.operations instead.",
+                ops_db_env,
+            )
+        plans = PlanDBManager()
+        # Eagerly construct the coordination manager (matching pre-bundle Core
+        # behavior). A lazy CouchDBCheckpointStore() would defer the 'yggdrasil'
+        # connection until first checkpoint load, where failures are swallowed
+        # (returning None) and PlanWatcher silently starts at "now" — failing
+        # open instead of failing fast at startup.
+        checkpoints = CouchDBCheckpointStore(db_manager=YggdrasilDBManager())
+        ops_snapshots = OpsWriter(db_name=ops_db_env or _LEGACY_OPS_DB)
+    else:
+        plans = PlanDBManager(
+            url=cfg.plans.endpoint.url,
+            user_env=cfg.plans.endpoint.user_env,
+            pass_env=cfg.plans.endpoint.pass_env,
+            db_name=cfg.plans.db_name,
+        )
+        coordination_dbm = YggdrasilDBManager(
+            url=cfg.coordination.endpoint.url,
+            user_env=cfg.coordination.endpoint.user_env,
+            pass_env=cfg.coordination.endpoint.pass_env,
+            db_name=cfg.coordination.db_name,
+        )
+        checkpoints = CouchDBCheckpointStore(db_manager=coordination_dbm)
+        # Explicit configuration is authoritative: OPS_DB is ignored here.
+        ops_snapshots = OpsWriter(
+            db_name=cfg.operations.db_name,
+            url=cfg.operations.endpoint.url,
+            user_env=cfg.operations.endpoint.user_env,
+            pass_env=cfg.operations.endpoint.pass_env,
+        )
+
+    plan_changes = CouchPlanChangeSource(
+        ChangesFetcher(db_handler=plans, include_docs=True)
+    )
+
+    return InternalStorageBundle(
+        backend="couchdb",
+        plans=plans,
+        plan_changes=plan_changes,
+        checkpoints=checkpoints,
+        ops_snapshots=ops_snapshots,
+    )

--- a/lib/storage/factory.py
+++ b/lib/storage/factory.py
@@ -1,0 +1,49 @@
+"""Composition root: build the internal-storage bundle from configuration."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from lib.core_utils.logging_utils import custom_logger
+from lib.storage.config import (
+    CouchInternalStorageConfig,
+    resolve_internal_storage_config,
+)
+from lib.storage.protocols import InternalStorageBundle
+
+logger = custom_logger(__name__)
+
+
+def build_internal_storage(
+    config: Mapping[str, Any],
+    *,
+    dev_mode: bool | None = None,
+) -> InternalStorageBundle:
+    """Resolve configuration and build the internal-storage bundle.
+
+    Args:
+        config: The full loaded main configuration mapping.
+        dev_mode: Effective dev mode override for tests. Defaults to
+            ``YggSession.is_dev()``.
+
+    Returns:
+        InternalStorageBundle for the configured backend (CouchDB when the
+        ``internal_storage`` block is absent — the deprecated implicit path).
+
+    Raises:
+        InternalStorageConfigurationError: On invalid explicit configuration.
+    """
+    resolved = resolve_internal_storage_config(config, dev_mode=dev_mode)
+
+    if resolved is None or isinstance(resolved, CouchInternalStorageConfig):
+        from lib.storage.couch import build_couchdb_bundle
+
+        bundle = build_couchdb_bundle(resolved)
+    else:
+        from lib.storage.sqlite import build_sqlite_bundle
+
+        bundle = build_sqlite_bundle(resolved)
+
+    logger.info("Internal storage backend: %s", bundle.backend)
+    return bundle

--- a/lib/storage/plan_documents.py
+++ b/lib/storage/plan_documents.py
@@ -1,0 +1,167 @@
+"""Backend-neutral plan-document construction and interpretation.
+
+Single source of truth for the plan document shape so the CouchDB and SQLite
+plan stores cannot drift. Extracted from ``PlanDBManager`` (which now
+delegates here) — the document schema is unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from yggdrasil.flow.model import Plan
+
+# Valid values for the execution_authority field
+VALID_EXECUTION_AUTHORITIES = frozenset({"daemon", "run_once"})
+
+
+def json_safe(value: Any) -> Any:
+    """Recursively coerce plan documents into JSON-serializable structures.
+
+    Realm planners can return pathlib.Path (or other non-JSON types) inside
+    params or preview payloads. This helper walks the structure and converts:
+    - Path -> str
+    - set/tuple -> list
+    - dict/list elements recursively
+    """
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, dict):
+        return {k: json_safe(v) for k, v in value.items()}
+    if isinstance(value, list | tuple | set):
+        return [json_safe(v) for v in value]
+    return value
+
+
+def validate_execution_authority(authority: str) -> None:
+    """Raise ValueError if execution_authority is invalid."""
+    if authority not in VALID_EXECUTION_AUTHORITIES:
+        raise ValueError(
+            f"Invalid execution_authority: {authority!r}. "
+            f"Must be one of: {sorted(VALID_EXECUTION_AUTHORITIES)}"
+        )
+
+
+def utc_now_iso() -> str:
+    """Return current UTC timestamp in ISO-8601 format."""
+    return datetime.now(UTC).isoformat(timespec="seconds")
+
+
+def build_plan_document(
+    plan: Plan,
+    realm: str,
+    scope: dict[str, Any],
+    *,
+    auto_run: bool = False,
+    execution_authority: str = "daemon",
+    execution_owner: str | None = None,
+    preview: dict[str, Any] | None = None,
+    source_doc_id: str | None = None,
+    source_doc_rev: str | None = None,
+    notes: str | None = None,
+    existing: dict[str, Any] | None = None,
+    now: str | None = None,
+) -> dict[str, Any]:
+    """Build the canonical plan document for persistence.
+
+    On regeneration (``existing`` provided), execution tokens are reset so the
+    new plan is eligible for execution, while ``created_at`` is preserved.
+    Backend-specific fields (``_rev``) are the caller's responsibility.
+
+    Args:
+        plan: The Plan object to persist (plan.plan_id is used as _id).
+        realm: Realm identifier.
+        scope: Scope dict with 'kind' and 'id' keys.
+        auto_run: If True, set status='approved'; else status='draft'.
+        execution_authority: "daemon" (default) or "run_once".
+        execution_owner: Unique token for run_once isolation.
+        preview: Optional preview data for UI display.
+        source_doc_id: Optional source document ID that triggered this plan.
+        source_doc_rev: Optional source document revision.
+        notes: Optional notes about the plan.
+        existing: Previously persisted document, if any (for created_at).
+        now: ISO-8601 timestamp override; defaults to current UTC time.
+
+    Returns:
+        dict: JSON-safe plan document including ``_id``.
+
+    Raises:
+        ValueError: If execution_authority is invalid or plan.plan_id missing.
+    """
+    validate_execution_authority(execution_authority)
+    doc_id = plan.plan_id
+    if not doc_id:
+        raise ValueError("plan.plan_id is required for persistence")
+
+    timestamp = now or utc_now_iso()
+
+    plan_doc: dict[str, Any] = {
+        "_id": doc_id,
+        "realm": realm,
+        "scope": scope,
+        "status": "approved" if auto_run else "draft",
+        "plan": plan.to_dict(),
+        "preview": preview or {},
+        "run_token": 0,
+        "executed_run_token": -1,
+        "execution_authority": execution_authority,
+        "execution_owner": execution_owner,
+        "created_at": (
+            existing.get("created_at", timestamp) if existing else timestamp
+        ),
+        "updated_at": timestamp,
+    }
+
+    if source_doc_id:
+        plan_doc["source_doc_id"] = source_doc_id
+    if source_doc_rev:
+        plan_doc["source_doc_rev"] = source_doc_rev
+    if notes:
+        plan_doc["notes"] = notes
+
+    return json_safe(plan_doc)
+
+
+def plan_model_from_document(
+    doc: dict[str, Any],
+    logger: logging.Logger,
+) -> Plan | None:
+    """Deserialize the ``plan`` field of a plan document into a Plan model.
+
+    Args:
+        doc: The persisted plan document.
+        logger: Logger for warnings/errors.
+
+    Returns:
+        Plan or None if the document has no plan field or fails to parse.
+    """
+    doc_id = doc.get("_id", "<unknown>")
+    plan_data = doc.get("plan")
+    if not plan_data:
+        logger.warning("Plan document '%s' has no 'plan' field", doc_id)
+        return None
+
+    try:
+        # Path reconstruction is handled by Engine via
+        # coerce_params_to_signature_types() based on step type hints;
+        # params remain strings in the persisted document.
+        return Plan.from_dict(plan_data)
+    except (KeyError, TypeError) as e:
+        logger.error("Failed to deserialize plan '%s': %s", doc_id, e)
+        return None
+
+
+def plan_summary_from_document(doc: dict[str, Any]) -> dict[str, Any]:
+    """Extract the minimal display summary from a plan document."""
+    return {
+        "status": doc.get("status", "unknown"),
+        "execution_authority": doc.get("execution_authority", "daemon"),
+        "execution_owner": doc.get("execution_owner"),
+        "updated_at": doc.get("updated_at", "unknown"),
+        "realm": doc.get("realm", "unknown"),
+        "run_token": doc.get("run_token", 0),
+        "executed_run_token": doc.get("executed_run_token", -1),
+    }

--- a/lib/storage/protocols.py
+++ b/lib/storage/protocols.py
@@ -1,0 +1,144 @@
+"""Protocols and the composition-root bundle for internal storage.
+
+These protocols capture exactly the capabilities Core already uses today.
+The CouchDB implementations (``PlanDBManager``, ``OpsWriter``,
+``CouchDBCheckpointStore``) satisfy them structurally; the SQLite backend
+implements them against a single local database file.
+
+The bundle intentionally has no coordination-document ("state") store: the
+only live internal consumer of the ``yggdrasil`` coordination database in the
+modern daemon path is checkpoint persistence, which is covered by
+``CheckpointStore``. The legacy ``YggdrasilDocument`` operations are used only
+by unwired legacy code (see ``docs/TECH_DEBT_LEDGER.md``) and are excluded
+until a live consumer exists.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from lib.watchers.backends.base import CheckpointStore, RawWatchEvent
+from yggdrasil.flow.model import Plan
+
+
+@runtime_checkable
+class PlanStore(Protocol):
+    """Storage for plan documents (intent + approval state).
+
+    Mirrors the existing ``PlanDBManager`` contract exactly. Plan
+    eligibility, regeneration, run tokens, execution authority, ownership,
+    and document shapes are identical across backends.
+    """
+
+    def save_plan(
+        self,
+        plan: Plan,
+        realm: str,
+        scope: dict[str, Any],
+        *,
+        auto_run: bool = False,
+        execution_authority: str = "daemon",
+        execution_owner: str | None = None,
+        preview: dict[str, Any] | None = None,
+        source_doc_id: str | None = None,
+        source_doc_rev: str | None = None,
+        notes: str | None = None,
+    ) -> str:
+        """Persist a plan document; returns the document ID."""
+        ...
+
+    def fetch_plan(self, doc_id: str) -> dict[str, Any] | None:
+        """Fetch a plan document by ID, or None if not found."""
+        ...
+
+    def fetch_plan_as_model(self, doc_id: str) -> Plan | None:
+        """Fetch a plan document and deserialize its Plan model."""
+        ...
+
+    def update_executed_token(
+        self,
+        doc_id: str,
+        run_token: int,
+        *,
+        max_retries: int = 3,
+    ) -> bool:
+        """Record a successful execution of ``run_token`` for the plan."""
+        ...
+
+    def query_approved_pending(self) -> list[dict[str, Any]]:
+        """Return all plans eligible for a full recovery scan."""
+        ...
+
+    def delete_plan(self, doc_id: str) -> bool:
+        """Delete a plan document (testing/cleanup)."""
+        ...
+
+    def plan_exists(self, doc_id: str) -> bool:
+        """Return True if the plan document exists."""
+        ...
+
+    def get_plan_summary(self, doc_id: str) -> dict[str, Any] | None:
+        """Return a minimal display summary of the plan, or None."""
+        ...
+
+
+class PlanChangeSource(Protocol):
+    """Stream of plan-document changes, backend-agnostic.
+
+    Yields :class:`RawWatchEvent` objects where ``id`` is the plan ID,
+    ``doc`` is the current plan document (None for deletions), ``seq`` is an
+    opaque backend cursor, and ``deleted`` marks tombstones. Consumers never
+    inspect CouchDB change-response fields or SQLite rows directly.
+
+    Multiple mutations between polls may coalesce to the latest state: this
+    source provides current plan eligibility, not an audit feed.
+    """
+
+    def stream_changes_continuously(
+        self,
+        *,
+        since: str | int,
+        poll_interval_sec: float,
+    ) -> AsyncIterator[RawWatchEvent]:
+        """Stream plan changes after ``since`` indefinitely.
+
+        Args:
+            since: Opaque cursor from a previous event's ``seq``, or the
+                string ``"now"`` to start at the current head.
+            poll_interval_sec: Seconds to sleep between polls when idle.
+        """
+        ...
+
+
+class OpsSnapshotSink(Protocol):
+    """Sink for latest-state plan_status snapshots built from the event spool.
+
+    Matches the writer interface consumed by ``FileSpoolConsumer``.
+    """
+
+    def write(self, plan_dir: Path, snapshot: dict[str, Any]) -> None:
+        """Upsert the latest snapshot for one plan."""
+        ...
+
+
+@dataclass(frozen=True)
+class InternalStorageBundle:
+    """All internal-storage capabilities, resolved once at composition root.
+
+    Attributes:
+        backend: Backend identifier ("couchdb" or "sqlite"), for logging and
+            tests only — consumers must not branch on it.
+        plans: Plan document store.
+        plan_changes: Plan change stream for PlanWatcher.
+        checkpoints: Watcher checkpoint persistence.
+        ops_snapshots: Operations snapshot sink for the spool consumer.
+    """
+
+    backend: str
+    plans: PlanStore
+    plan_changes: PlanChangeSource
+    checkpoints: CheckpointStore
+    ops_snapshots: OpsSnapshotSink

--- a/lib/storage/sqlite.py
+++ b/lib/storage/sqlite.py
@@ -1,0 +1,803 @@
+"""SQLite internal-storage backend (dev mode and tests only).
+
+One SQLite file holds all internal state as JSON documents in namespaced
+rows — never pickle or opaque BLOBs. The document shapes are identical to
+the CouchDB backend (shared builders in ``lib/storage/plan_documents.py``),
+so dev-mode behavior stays representative of production.
+
+Threading model:
+    Consumers are concurrent asyncio tasks whose sync storage calls run on
+    ``asyncio.to_thread`` worker threads. Python ``sqlite3`` connections are
+    thread-bound, so this store opens a **fresh connection per operation**
+    (cheap with WAL) with a bounded busy timeout. Never cache a connection
+    across calls.
+
+Durability model:
+    WAL journal, short transactions. The database is *disposable dev state*:
+    if the file is deleted, fresh state is created at the next startup.
+    Reliable host-local storage is required — network filesystems are
+    unsupported for SQLite WAL.
+
+Change feed:
+    Every plan mutation increments a global plan-change counter
+    (``store_metadata['plan_change_seq']``) and stamps the new value on the
+    row in the same transaction. The change source polls rows with
+    ``change_seq > cursor``; multiple mutations between polls coalesce to
+    the latest state (current eligibility, not an audit feed). Deletions
+    are tombstones.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sqlite3
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+from lib.core_utils.errors import InternalStorageConfigurationError
+from lib.core_utils.logging_utils import custom_logger
+from lib.core_utils.plan_eligibility import is_plan_eligible
+from lib.couchdb.partitions import partition_key
+from lib.storage.config import SQLiteInternalStorageConfig
+from lib.storage.plan_documents import (
+    build_plan_document,
+    json_safe,
+    plan_model_from_document,
+    plan_summary_from_document,
+    utc_now_iso,
+    validate_execution_authority,
+)
+from lib.storage.protocols import InternalStorageBundle
+from lib.watchers.backends.base import Checkpoint, CheckpointStore, RawWatchEvent
+from yggdrasil.flow.model import Plan
+
+# "YGGD" — marks the file as an Yggdrasil internal-storage database.
+_APPLICATION_ID = 0x59474744
+_SCHEMA_VERSION = 1
+_PLAN_SEQ_KEY = "plan_change_seq"
+
+_NS_PLANS = "plans"
+_NS_CHECKPOINTS = "checkpoints"
+_NS_OPS = "operations_snapshots"
+
+# Individual statements so the fresh-init can run them inside one explicit
+# transaction (executescript would auto-commit and break atomicity).
+_SCHEMA_STATEMENTS = (
+    """
+    CREATE TABLE IF NOT EXISTS store_metadata (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS documents (
+        namespace TEXT NOT NULL,
+        document_id TEXT NOT NULL,
+        revision INTEGER NOT NULL,
+        change_seq INTEGER,
+        deleted INTEGER NOT NULL DEFAULT 0,
+        body_json TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (namespace, document_id)
+    )
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_documents_change_seq
+        ON documents (namespace, change_seq)
+    """,
+)
+
+
+class SQLiteStorageError(InternalStorageConfigurationError):
+    """A SQLite storage file failed lifecycle validation.
+
+    Subclasses :class:`InternalStorageConfigurationError` so the CLI's
+    startup handling prints one concise operator message. Never triggers
+    automatic deletion — resolving requires operator action.
+    """
+
+
+class SQLiteInternalStore:
+    """Low-level namespaced JSON document store on one SQLite file.
+
+    Attributes:
+        path: Absolute path of the database file.
+    """
+
+    def __init__(self, path: Path, *, logger: logging.Logger | None = None) -> None:
+        """Validate/create the database file and initialize the schema.
+
+        Args:
+            path: Absolute database file path.
+
+        Raises:
+            SQLiteStorageError: If an existing file is symlinked, owned by
+                another user, malformed, unrelated to Yggdrasil, or has an
+                unsupported schema version.
+        """
+        self._logger = logger or custom_logger(f"{__name__}.{type(self).__name__}")
+        self.path = Path(path)
+        self._initialize()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def _initialize(self) -> None:
+        """Prepare directory and file, then create or validate the schema."""
+        self._prepare_directory()
+        fresh = self._validate_file()
+
+        conn = self._connect()
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            if fresh:
+                # Atomic fresh-init: schema, seed metadata, and the identity
+                # PRAGMAs (application_id / user_version — both transactional)
+                # all commit together or not at all. This never leaves a marked
+                # file with missing tables. A crash mid-init leaves either a
+                # 0-byte file (treated as fresh on reopen) or a partially
+                # written file that reopen validation rejects as unrelated
+                # (application_id still unset) — i.e. it fails closed, requiring
+                # the operator to delete the disposable dev file and restart.
+                conn.execute("BEGIN IMMEDIATE")
+                try:
+                    for statement in _SCHEMA_STATEMENTS:
+                        conn.execute(statement)
+                    conn.execute(
+                        "INSERT OR IGNORE INTO store_metadata (key, value) "
+                        "VALUES (?, ?)",
+                        (_PLAN_SEQ_KEY, "0"),
+                    )
+                    conn.execute(
+                        "INSERT OR IGNORE INTO store_metadata (key, value) "
+                        "VALUES (?, ?)",
+                        ("created_at", utc_now_iso()),
+                    )
+                    conn.execute(f"PRAGMA application_id = {_APPLICATION_ID}")
+                    conn.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
+                    conn.execute("COMMIT")
+                except BaseException:
+                    conn.execute("ROLLBACK")
+                    raise
+                self._logger.info(
+                    "Created new disposable dev internal-storage database at %s",
+                    self.path,
+                )
+            else:
+                self._validate_schema(conn)
+        finally:
+            conn.close()
+
+        os.chmod(self.path, 0o600)
+
+    def _prepare_directory(self) -> None:
+        """Create missing parent directories with 0700 permissions."""
+        parent = self.path.parent
+        missing: list[Path] = []
+        probe = parent
+        while not probe.exists():
+            missing.append(probe)
+            probe = probe.parent
+        parent.mkdir(parents=True, exist_ok=True)
+        for created in missing:
+            os.chmod(created, 0o700)
+
+    def _validate_file(self) -> bool:
+        """Validate an existing database file, or mark a fresh one needed.
+
+        Returns:
+            True if the file must be freshly initialized.
+
+        Raises:
+            SQLiteStorageError: On symlink, foreign owner, malformed, or
+                unrelated files.
+        """
+        try:
+            st = os.lstat(self.path)
+        except FileNotFoundError:
+            # Create with restrictive permissions before SQLite touches it.
+            fd = os.open(self.path, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o600)
+            os.close(fd)
+            return True
+
+        if os.path.islink(self.path):
+            raise SQLiteStorageError(
+                f"Refusing symlinked internal-storage database: {self.path}"
+            )
+        if not os.path.isfile(self.path):
+            raise SQLiteStorageError(
+                f"Internal-storage path is not a regular file: {self.path}"
+            )
+        if st.st_uid != os.getuid():
+            raise SQLiteStorageError(
+                f"Internal-storage database {self.path} is owned by uid "
+                f"{st.st_uid}, not the current user (uid {os.getuid()})"
+            )
+        if st.st_size == 0:
+            return True
+
+        # Existing non-empty file: must be a SQLite DB carrying our marker.
+        try:
+            conn = self._connect()
+            try:
+                app_id = conn.execute("PRAGMA application_id").fetchone()[0]
+            finally:
+                conn.close()
+        except sqlite3.DatabaseError as e:
+            raise SQLiteStorageError(
+                f"Existing file {self.path} is not a valid SQLite database "
+                f"({e}). Move it aside, or delete it if it is disposable "
+                "dev state, then restart."
+            ) from e
+
+        if app_id != _APPLICATION_ID:
+            raise SQLiteStorageError(
+                f"Existing SQLite file {self.path} is not an Yggdrasil "
+                "internal-storage database (application_id mismatch). "
+                "Refusing to reuse an unrelated file."
+            )
+        return False
+
+    def _validate_schema(self, conn: sqlite3.Connection) -> None:
+        """Check schema version; migrate supported older versions.
+
+        Raises:
+            SQLiteStorageError: If the schema is newer than this build, or
+                older than any supported migration path.
+        """
+        version = conn.execute("PRAGMA user_version").fetchone()[0]
+        if version == _SCHEMA_VERSION:
+            return
+        if version > _SCHEMA_VERSION:
+            raise SQLiteStorageError(
+                f"Internal-storage database {self.path} has schema version "
+                f"{version}, newer than this build supports "
+                f"({_SCHEMA_VERSION}). Upgrade Yggdrasil."
+            )
+        self._migrate(conn, version)
+
+    def _migrate(self, conn: sqlite3.Connection, from_version: int) -> None:
+        """Migrate a supported older schema in one transaction.
+
+        No older supported schemas exist yet (v1 is the first). Future
+        migrations must run inside a transaction so failures roll back;
+        the database is never deleted automatically.
+
+        Raises:
+            SQLiteStorageError: Always, until a migration path exists.
+        """
+        raise SQLiteStorageError(
+            f"Internal-storage database {self.path} has unsupported schema "
+            f"version {from_version}. This dev database is disposable: "
+            "delete the file and restart to create fresh state."
+        )
+
+    # ------------------------------------------------------------------
+    # Connections (one per operation — see module docstring)
+    # ------------------------------------------------------------------
+
+    def _connect(self) -> sqlite3.Connection:
+        """Open a fresh connection with WAL-friendly settings."""
+        conn = sqlite3.connect(str(self.path), timeout=5.0, isolation_level=None)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA busy_timeout = 5000")
+        return conn
+
+    # ------------------------------------------------------------------
+    # Document operations
+    # ------------------------------------------------------------------
+
+    def get_document(self, namespace: str, doc_id: str) -> dict[str, Any] | None:
+        """Fetch a live document; tombstones and misses return None.
+
+        The stored body is returned with ``_rev`` injected (opaque
+        revision), mirroring CouchDB document shapes.
+        """
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT revision, deleted, body_json FROM documents "
+                "WHERE namespace = ? AND document_id = ?",
+                (namespace, doc_id),
+            ).fetchone()
+        finally:
+            conn.close()
+
+        if row is None or row["deleted"]:
+            return None
+        body: dict[str, Any] = json.loads(row["body_json"])
+        body["_rev"] = str(row["revision"])
+        return body
+
+    def put_document(
+        self,
+        namespace: str,
+        doc_id: str,
+        body: dict[str, Any],
+        *,
+        bump_plan_seq: bool = False,
+    ) -> None:
+        """Upsert a document; optionally advance the plan-change counter.
+
+        The revision increments on every write. ``_rev`` is stripped from
+        the stored body (it is derived state, exposed on read).
+        """
+        payload = dict(body)
+        payload.pop("_rev", None)
+        payload.setdefault("_id", doc_id)
+        body_json = json.dumps(json_safe(payload), sort_keys=True)
+        now = utc_now_iso()
+
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                "SELECT revision, change_seq FROM documents "
+                "WHERE namespace = ? AND document_id = ?",
+                (namespace, doc_id),
+            ).fetchone()
+            revision = (row["revision"] + 1) if row else 1
+            change_seq = row["change_seq"] if row else None
+            if bump_plan_seq:
+                change_seq = self._next_plan_seq(conn)
+            conn.execute(
+                "INSERT INTO documents "
+                "(namespace, document_id, revision, change_seq, deleted, "
+                " body_json, updated_at) "
+                "VALUES (?, ?, ?, ?, 0, ?, ?) "
+                "ON CONFLICT (namespace, document_id) DO UPDATE SET "
+                "revision = excluded.revision, "
+                "change_seq = excluded.change_seq, "
+                "deleted = 0, "
+                "body_json = excluded.body_json, "
+                "updated_at = excluded.updated_at",
+                (namespace, doc_id, revision, change_seq, body_json, now),
+            )
+            conn.execute("COMMIT")
+        except BaseException:
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.OperationalError:
+                pass
+            raise
+        finally:
+            conn.close()
+
+    def delete_document(
+        self,
+        namespace: str,
+        doc_id: str,
+        *,
+        bump_plan_seq: bool = False,
+    ) -> bool:
+        """Tombstone a document. Returns False if it does not exist."""
+        now = utc_now_iso()
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                "SELECT revision, deleted FROM documents "
+                "WHERE namespace = ? AND document_id = ?",
+                (namespace, doc_id),
+            ).fetchone()
+            if row is None or row["deleted"]:
+                conn.execute("COMMIT")
+                return False
+            change_seq = self._next_plan_seq(conn) if bump_plan_seq else None
+            conn.execute(
+                "UPDATE documents SET revision = ?, change_seq = "
+                "COALESCE(?, change_seq), deleted = 1, updated_at = ? "
+                "WHERE namespace = ? AND document_id = ?",
+                (row["revision"] + 1, change_seq, now, namespace, doc_id),
+            )
+            conn.execute("COMMIT")
+            return True
+        except BaseException:
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.OperationalError:
+                pass
+            raise
+        finally:
+            conn.close()
+
+    def touch_document(
+        self,
+        namespace: str,
+        doc_id: str,
+        *,
+        bump_plan_seq: bool = True,
+    ) -> bool:
+        """Advance document metadata without rewriting its JSON body.
+
+        The revision, storage timestamp, and optionally the global plan-change
+        counter advance in one ``BEGIN IMMEDIATE`` transaction. The stored
+        ``body_json`` remains byte-for-byte unchanged.
+
+        Returns:
+            False if the document is missing or tombstoned; otherwise True.
+        """
+        now = utc_now_iso()
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                "SELECT revision, deleted FROM documents "
+                "WHERE namespace = ? AND document_id = ?",
+                (namespace, doc_id),
+            ).fetchone()
+            if row is None or row["deleted"]:
+                conn.execute("COMMIT")
+                return False
+
+            change_seq = self._next_plan_seq(conn) if bump_plan_seq else None
+            conn.execute(
+                "UPDATE documents SET revision = ?, change_seq = "
+                "COALESCE(?, change_seq), updated_at = ? "
+                "WHERE namespace = ? AND document_id = ? AND deleted = 0",
+                (row["revision"] + 1, change_seq, now, namespace, doc_id),
+            )
+            conn.execute("COMMIT")
+            return True
+        except BaseException:
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.OperationalError:
+                pass
+            raise
+        finally:
+            conn.close()
+
+    def list_documents(self, namespace: str) -> list[dict[str, Any]]:
+        """Return all live documents in a namespace (with ``_rev``)."""
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT revision, body_json FROM documents "
+                "WHERE namespace = ? AND deleted = 0",
+                (namespace,),
+            ).fetchall()
+        finally:
+            conn.close()
+
+        docs: list[dict[str, Any]] = []
+        for row in rows:
+            body: dict[str, Any] = json.loads(row["body_json"])
+            body["_rev"] = str(row["revision"])
+            docs.append(body)
+        return docs
+
+    # ------------------------------------------------------------------
+    # Plan change feed
+    # ------------------------------------------------------------------
+
+    def _next_plan_seq(self, conn: sqlite3.Connection) -> int:
+        """Advance the global plan-change counter inside the caller's txn."""
+        current = int(
+            conn.execute(
+                "SELECT value FROM store_metadata WHERE key = ?",
+                (_PLAN_SEQ_KEY,),
+            ).fetchone()["value"]
+        )
+        nxt = current + 1
+        conn.execute(
+            "UPDATE store_metadata SET value = ? WHERE key = ?",
+            (str(nxt), _PLAN_SEQ_KEY),
+        )
+        return nxt
+
+    def current_plan_seq(self) -> int:
+        """Return the current head of the plan-change counter."""
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT value FROM store_metadata WHERE key = ?",
+                (_PLAN_SEQ_KEY,),
+            ).fetchone()
+        finally:
+            conn.close()
+        return int(row["value"]) if row else 0
+
+    def plan_changes_after(
+        self, cursor: int, limit: int = 500
+    ) -> list[tuple[int, str, dict[str, Any] | None, bool]]:
+        """Return plan rows changed after ``cursor``, ordered by sequence.
+
+        Returns:
+            Tuples of (change_seq, document_id, body-or-None, deleted).
+            Tombstones carry ``None`` bodies.
+        """
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT change_seq, document_id, revision, deleted, body_json "
+                "FROM documents WHERE namespace = ? AND change_seq > ? "
+                "ORDER BY change_seq ASC LIMIT ?",
+                (_NS_PLANS, cursor, limit),
+            ).fetchall()
+        finally:
+            conn.close()
+
+        changes: list[tuple[int, str, dict[str, Any] | None, bool]] = []
+        for row in rows:
+            deleted = bool(row["deleted"])
+            body: dict[str, Any] | None = None
+            if not deleted:
+                live_body: dict[str, Any] = json.loads(row["body_json"])
+                live_body["_rev"] = str(row["revision"])
+                body = live_body
+            changes.append((row["change_seq"], row["document_id"], body, deleted))
+        return changes
+
+
+class SQLitePlanStore:
+    """PlanStore over :class:`SQLiteInternalStore` (namespace ``plans``).
+
+    Document shapes, eligibility, regeneration, and token semantics are
+    shared with the CouchDB backend via ``lib/storage/plan_documents.py``.
+    """
+
+    def __init__(
+        self,
+        store: SQLiteInternalStore,
+        *,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        """Bind to the shared low-level store."""
+        self._store = store
+        self._logger = logger or custom_logger(f"{__name__}.{type(self).__name__}")
+
+    def save_plan(
+        self,
+        plan: Plan,
+        realm: str,
+        scope: dict[str, Any],
+        *,
+        auto_run: bool = False,
+        execution_authority: str = "daemon",
+        execution_owner: str | None = None,
+        preview: dict[str, Any] | None = None,
+        source_doc_id: str | None = None,
+        source_doc_rev: str | None = None,
+        notes: str | None = None,
+    ) -> str:
+        """Persist a plan document (see PlanStore protocol)."""
+        validate_execution_authority(execution_authority)
+        doc_id = plan.plan_id
+        if not doc_id:
+            raise ValueError("plan.plan_id is required for persistence")
+
+        existing = self._store.get_document(_NS_PLANS, doc_id)
+        plan_doc = build_plan_document(
+            plan,
+            realm,
+            scope,
+            auto_run=auto_run,
+            execution_authority=execution_authority,
+            execution_owner=execution_owner,
+            preview=preview,
+            source_doc_id=source_doc_id,
+            source_doc_rev=source_doc_rev,
+            notes=notes,
+            existing=existing,
+        )
+        self._store.put_document(_NS_PLANS, doc_id, plan_doc, bump_plan_seq=True)
+        self._logger.info(
+            "Saved plan '%s' (realm=%s, status=%s)",
+            doc_id,
+            realm,
+            plan_doc["status"],
+        )
+        return doc_id
+
+    def fetch_plan(self, doc_id: str) -> dict[str, Any] | None:
+        """Fetch a plan document by ID, or None."""
+        return self._store.get_document(_NS_PLANS, doc_id)
+
+    def fetch_plan_as_model(self, doc_id: str) -> Plan | None:
+        """Fetch and deserialize the Plan model, or None."""
+        doc = self._store.get_document(_NS_PLANS, doc_id)
+        if not doc:
+            return None
+        return plan_model_from_document(doc, self._logger)
+
+    def update_executed_token(
+        self,
+        doc_id: str,
+        run_token: int,
+        *,
+        max_retries: int = 3,
+    ) -> bool:
+        """Record a successful execution of ``run_token``.
+
+        ``max_retries`` is accepted for protocol parity; local transactions
+        cannot hit CouchDB-style revision conflicts.
+        """
+        doc = self._store.get_document(_NS_PLANS, doc_id)
+        if not doc:
+            self._logger.error("Cannot update token: plan '%s' not found", doc_id)
+            return False
+        doc["executed_run_token"] = run_token
+        doc["last_executed_at"] = utc_now_iso()
+        doc["updated_at"] = utc_now_iso()
+        self._store.put_document(_NS_PLANS, doc_id, doc, bump_plan_seq=True)
+        self._logger.debug(
+            "Updated executed_run_token=%d for plan '%s'", run_token, doc_id
+        )
+        return True
+
+    def query_approved_pending(self) -> list[dict[str, Any]]:
+        """Return all plans eligible for execution (recovery)."""
+        docs = self._store.list_documents(_NS_PLANS)
+        eligible = [doc for doc in docs if is_plan_eligible(doc)]
+        self._logger.info(
+            "Found %d eligible plans (of %d total) for recovery",
+            len(eligible),
+            len(docs),
+        )
+        return eligible
+
+    def delete_plan(self, doc_id: str) -> bool:
+        """Tombstone a plan document (testing/cleanup)."""
+        deleted = self._store.delete_document(_NS_PLANS, doc_id, bump_plan_seq=True)
+        if deleted:
+            self._logger.info("Deleted plan '%s'", doc_id)
+        else:
+            self._logger.warning("Cannot delete: plan '%s' not found", doc_id)
+        return deleted
+
+    def plan_exists(self, doc_id: str) -> bool:
+        """Return True if the plan document exists."""
+        return self._store.get_document(_NS_PLANS, doc_id) is not None
+
+    def get_plan_summary(self, doc_id: str) -> dict[str, Any] | None:
+        """Return the minimal display summary, or None."""
+        doc = self._store.get_document(_NS_PLANS, doc_id)
+        if not doc:
+            return None
+        return plan_summary_from_document(doc)
+
+
+class SQLitePlanChangeSource:
+    """PlanChangeSource polling the SQLite plan-change counter."""
+
+    def __init__(
+        self,
+        store: SQLiteInternalStore,
+        *,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        """Bind to the shared low-level store."""
+        self._store = store
+        self._logger = logger or custom_logger(f"{__name__}.{type(self).__name__}")
+
+    async def stream_changes_continuously(
+        self,
+        *,
+        since: str | int,
+        poll_interval_sec: float,
+    ) -> AsyncIterator[RawWatchEvent]:
+        """Stream plan changes after ``since`` indefinitely.
+
+        Blocking SQLite reads run on worker threads via ``asyncio.to_thread``.
+        """
+        cursor = await asyncio.to_thread(self._resolve_since, since)
+        while True:
+            rows = await asyncio.to_thread(self._store.plan_changes_after, cursor)
+            for seq, doc_id, body, deleted in rows:
+                yield RawWatchEvent(id=doc_id, doc=body, seq=seq, deleted=deleted)
+                cursor = seq
+            if not rows:
+                await asyncio.sleep(poll_interval_sec)
+
+    def _resolve_since(self, since: str | int) -> int:
+        """Resolve an opaque cursor to an integer sequence.
+
+        ``"now"`` resolves to the current head. An unparseable cursor (e.g.
+        a checkpoint written by a different backend) also starts at the
+        current head with a warning. Callers requiring lossless recovery
+        must coordinate the recovery scan and cursor handoff described in
+        Tech Debt #17.
+        """
+        if since == "now":
+            return self._store.current_plan_seq()
+        try:
+            return int(since)
+        except (TypeError, ValueError):
+            head = self._store.current_plan_seq()
+            self._logger.warning(
+                "Unparseable plan-change cursor %r for SQLite backend; "
+                "starting from current head %d",
+                since,
+                head,
+            )
+            return head
+
+
+class SQLiteCheckpointStore(CheckpointStore):
+    """CheckpointStore over namespace ``checkpoints``."""
+
+    def __init__(
+        self,
+        store: SQLiteInternalStore,
+        *,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        """Bind to the shared low-level store."""
+        self._store = store
+        self._logger = logger or custom_logger(f"{__name__}.{type(self).__name__}")
+
+    def load(self, backend_key: str) -> Checkpoint | None:
+        """Load the checkpoint for ``backend_key``, or None."""
+        doc = self._store.get_document(_NS_CHECKPOINTS, backend_key)
+        if doc is None:
+            return None
+        return Checkpoint(
+            backend_key=doc.get("backend_key", backend_key),
+            value=doc.get("value"),
+            updated_at=doc.get("updated_at"),
+        )
+
+    def save(self, checkpoint: Checkpoint) -> None:
+        """Persist (overwrite) the checkpoint."""
+        self._store.put_document(
+            _NS_CHECKPOINTS,
+            checkpoint.backend_key,
+            {
+                "backend_key": checkpoint.backend_key,
+                "value": checkpoint.value,
+                "updated_at": checkpoint.updated_at,
+            },
+        )
+
+
+class SQLiteOpsSnapshotSink:
+    """OpsSnapshotSink over namespace ``operations_snapshots``.
+
+    Document IDs mirror the CouchDB sink
+    (``<partition>:plan_status:<realm>:<plan_id>``) so dev snapshots stay
+    representative.
+    """
+
+    def __init__(
+        self,
+        store: SQLiteInternalStore,
+        *,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        """Bind to the shared low-level store."""
+        self._store = store
+        self._logger = logger or custom_logger(f"{__name__}.{type(self).__name__}")
+
+    def write(self, plan_dir: Path, snapshot: dict[str, Any]) -> None:
+        """Upsert the latest plan_status snapshot (plan_dir unused)."""
+        part = partition_key(snapshot.get("scope") or {})
+        doc_id = f"{part}:plan_status:{snapshot['realm']}:{snapshot['plan_id']}"
+        payload = dict(snapshot)
+        payload["_id"] = doc_id
+        self._store.put_document(_NS_OPS, doc_id, payload)
+
+
+def build_sqlite_bundle(cfg: SQLiteInternalStorageConfig) -> InternalStorageBundle:
+    """Build the SQLite internal-storage bundle (dev mode/tests only).
+
+    Args:
+        cfg: Resolved SQLite configuration (dev-mode gating already applied
+            by the config resolver).
+
+    Returns:
+        InternalStorageBundle backed by one SQLite database file.
+    """
+    store = SQLiteInternalStore(cfg.path)
+    return InternalStorageBundle(
+        backend="sqlite",
+        plans=SQLitePlanStore(store),
+        plan_changes=SQLitePlanChangeSource(store),
+        checkpoints=SQLiteCheckpointStore(store),
+        ops_snapshots=SQLiteOpsSnapshotSink(store),
+    )

--- a/lib/watchers/plan_watcher.py
+++ b/lib/watchers/plan_watcher.py
@@ -17,16 +17,19 @@ Key design principles:
 import logging
 from collections.abc import Callable
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, cast
 
 from lib.core_utils.event_types import EventType
 from lib.core_utils.logging_utils import custom_logger
 from lib.core_utils.plan_eligibility import get_eligibility_reason, is_plan_eligible
 from lib.couchdb.changes_fetcher import ChangesFetcher
+from lib.couchdb.couchdb_connection import CouchDBHandler
 from lib.couchdb.plan_db_manager import PlanDBManager
 from lib.couchdb.yggdrasil_db_manager import YggdrasilDBManager
+from lib.storage.couch import CouchPlanChangeSource
+from lib.storage.protocols import PlanChangeSource, PlanStore
 from lib.watchers.abstract_watcher import AbstractWatcher, YggdrasilEvent
-from lib.watchers.backends.base import Checkpoint
+from lib.watchers.backends.base import Checkpoint, CheckpointStore, RawWatchEvent
 from lib.watchers.backends.checkpoint_store import CouchDBCheckpointStore
 
 
@@ -39,15 +42,19 @@ class PlanWatcher(AbstractWatcher):
     - Filters changes to only process eligible plans
     - Emits PLAN_EXECUTION_EVENT for each eligible plan
     - Persists checkpoint after each successful emit
-    - Supports startup recovery via query_approved_pending()
+    - Supports targeted run-once and future daemon-startup recovery
 
     The watcher does NOT execute plans directly. It emits events that
     YggdrasilCore handles via execute_approved_plan().
 
+    Storage is backend-neutral: YggdrasilCore injects the plan store, change
+    source, and checkpoint store from its InternalStorageBundle. Bare
+    construction (no injection) falls back to the legacy CouchDB wiring.
+
     Attributes:
-        plan_db: PlanDBManager for accessing yggdrasil_plans
-        checkpoint_store: CouchDBCheckpointStore for checkpoint persistence
-        changes_fetcher: ChangesFetcher for streaming _changes
+        plan_db: PlanStore for plan documents
+        checkpoint_store: CheckpointStore for checkpoint persistence
+        change_source: PlanChangeSource streaming RawWatchEvents
         poll_interval_sec: Seconds between poll cycles
     """
 
@@ -58,6 +65,9 @@ class PlanWatcher(AbstractWatcher):
         on_event: Callable[[YggdrasilEvent], None],
         poll_interval_sec: float = 5.0,
         *,
+        plan_store: PlanStore | None = None,
+        change_source: PlanChangeSource | None = None,
+        checkpoint_store: CheckpointStore | None = None,
         execution_authority_filter: str | None = None,
         execution_owner_filter: str | None = None,
         logger: logging.Logger | None = None,
@@ -67,7 +77,12 @@ class PlanWatcher(AbstractWatcher):
 
         Args:
             on_event: Callback to invoke when eligible plan is detected
-            poll_interval_sec: Seconds between _changes poll cycles (default 5.0)
+            poll_interval_sec: Seconds between change poll cycles (default 5.0)
+            plan_store: Injected plan store; legacy default is PlanDBManager.
+            change_source: Injected plan change source; legacy default wraps a
+                ChangesFetcher on the plan store (requires a CouchDB store).
+            checkpoint_store: Injected checkpoint store; legacy default is
+                CouchDBCheckpointStore on the yggdrasil database.
             execution_authority_filter: If set, only process plans with this origin.
                 - "daemon": Normal daemon operation (skips run_once plans)
                 - "run_once": Scoped run-once operation
@@ -88,19 +103,26 @@ class PlanWatcher(AbstractWatcher):
         self.execution_authority_filter = execution_authority_filter
         self.execution_owner_filter = execution_owner_filter
 
-        # Initialize DB managers
-        self.plan_db = PlanDBManager()
-        self._yggdrasil_db = YggdrasilDBManager()
+        # Storage wiring: injected by YggdrasilCore, or legacy CouchDB
+        # defaults for bare construction. Partial injection that pairs a
+        # non-CouchDB plan store with a default change source is unsupported.
+        if plan_store is None:
+            plan_store = PlanDBManager()
+        self.plan_db = plan_store
 
-        # Initialize checkpoint store (persists to yggdrasil DB)
-        self.checkpoint_store = CouchDBCheckpointStore(
-            db_manager=self._yggdrasil_db,
-        )
+        if checkpoint_store is None:
+            self._yggdrasil_db = YggdrasilDBManager()
+            checkpoint_store = CouchDBCheckpointStore(
+                db_manager=self._yggdrasil_db,
+            )
+        self.checkpoint_store = checkpoint_store
 
-        # Initialize changes fetcher (reads from yggdrasil_plans DB)
-        self.changes_fetcher = ChangesFetcher(
-            db_handler=self.plan_db, include_docs=True
-        )
+        if change_source is None:
+            self.changes_fetcher = ChangesFetcher(
+                db_handler=cast(CouchDBHandler, self.plan_db), include_docs=True
+            )
+            change_source = CouchPlanChangeSource(self.changes_fetcher)
+        self.change_source = change_source
 
         self._logger.debug(
             "PlanWatcher initialized (poll_interval=%.1fs, authority_filter=%r, owner_filter=%r)",
@@ -116,8 +138,8 @@ class PlanWatcher(AbstractWatcher):
         Resumes from checkpoint if available; otherwise starts from current head.
         Runs until stop() is called.
 
-        Uses ChangesFetcher.stream_changes_continuously() as the canonical
-        polling/backoff path.
+        Uses the injected PlanChangeSource's stream_changes_continuously()
+        as the canonical polling/backoff path.
         """
         if self._running:
             self._logger.warning("PlanWatcher already running; ignoring start()")
@@ -137,7 +159,7 @@ class PlanWatcher(AbstractWatcher):
             current_seq = "now"
 
         try:
-            async for change in self.changes_fetcher.stream_changes_continuously(
+            async for change in self.change_source.stream_changes_continuously(
                 since=current_seq,
                 poll_interval_sec=self.poll_interval_sec,
             ):
@@ -148,7 +170,7 @@ class PlanWatcher(AbstractWatcher):
                 await self._evaluate_change(change)
 
                 # Update current_seq and checkpoint after each change
-                new_seq = change.get("seq")
+                new_seq = change.seq
                 if new_seq is not None:
                     current_seq = str(new_seq)
                     try:
@@ -162,7 +184,7 @@ class PlanWatcher(AbstractWatcher):
                     except Exception as e:
                         self._logger.error(
                             "Failed to save PlanWatcher checkpoint for change id=%r seq=%r; continuing: %s",
-                            change.get("id"),
+                            change.id,
                             current_seq,
                             e,
                             exc_info=True,
@@ -187,25 +209,25 @@ class PlanWatcher(AbstractWatcher):
         self._logger.info("Stopping PlanWatcher...")
         self._running = False
 
-    async def _evaluate_change(self, change: dict[str, Any]) -> None:
+    async def _evaluate_change(self, change: RawWatchEvent) -> None:
         """
-        Evaluate a single change entry from _changes feed.
+        Evaluate a single plan change event.
 
         Applies filtering criteria (origin, owner), checks eligibility,
         and emits event if plan is ready for execution.
 
         Args:
-            change: Change entry with 'id', 'seq', 'doc' fields
+            change: Backend-agnostic plan change event.
         """
-        doc_id = change.get("id", "")
-        doc = change.get("doc")
+        doc_id = change.id
+        doc = change.doc
 
-        # Skip deleted documents
-        if change.get("deleted"):
+        # Skip deleted documents (tombstones)
+        if change.deleted:
             self._logger.debug("Skipping deleted document: %s", doc_id)
             return
 
-        # Skip if doc not included (shouldn't happen with include_docs=True)
+        # Skip if doc not included (shouldn't happen; sources include docs)
         if not doc:
             self._logger.warning("Change has no 'doc' field: %s", doc_id)
             return
@@ -264,28 +286,61 @@ class PlanWatcher(AbstractWatcher):
             reason = get_eligibility_reason(doc)
             self._logger.debug("Skipping ineligible plan: %s (%s)", doc_id, reason)
 
-    async def recover_pending_plans(self) -> list[dict[str, Any]]:
-        """
-        Query and emit events for all approved pending plans.
+    async def recover_pending_plans(
+        self, plan_ids: list[str] | None = None
+    ) -> list[dict[str, Any]]:
+        """Query, filter, and emit currently eligible plans.
 
-        This is the startup recovery fallback when checkpoint is missing.
-        It queries all plans where status='approved' and run_token > executed_run_token,
-        then applies execution_authority and execution_owner filters.
+        Scoped run-once recovery supplies ``plan_ids`` so only plans created
+        by that invocation are fetched. Passing ``None`` retains the full
+        eligible-plan scan needed by a future daemon-startup recovery path.
+        Both paths apply the configured authority and owner filters.
+
+        This method does not load or save checkpoints, and it does not
+        coordinate a recovery scan with the live change-feed cursor.
 
         Returns:
-            list: Plan documents that were emitted for execution
-
-        Note:
-            This method is called by YggdrasilCore during startup recovery,
-            NOT during normal watcher operation. It does NOT update checkpoints;
-            the caller is responsible for checkpoint management after recovery.
+            Plan documents that were emitted for execution.
         """
-        self._logger.info(
-            "Running startup recovery: querying approved pending plans..."
-        )
-
-        # Get all eligible plans (approval + token logic)
-        all_eligible = self.plan_db.query_approved_pending()
+        if plan_ids is None:
+            self._logger.info(
+                "Running eligible-plan recovery: querying all approved "
+                "pending plans..."
+            )
+            # Preserve the full-scan branch for future daemon-startup recovery.
+            all_eligible = self.plan_db.query_approved_pending()
+        else:
+            self._logger.info(
+                "Running scoped eligible-plan recovery for %d plan(s)...",
+                len(plan_ids),
+            )
+            all_eligible = []
+            # A full scan can return each document only once. Preserve that
+            # behavior while retaining the caller's order.
+            for plan_id in dict.fromkeys(plan_ids):
+                try:
+                    plan_doc = self.plan_db.fetch_plan(plan_id)
+                except Exception as exc:
+                    self._logger.error(
+                        "Recovery: failed to fetch requested plan %s: %s",
+                        plan_id,
+                        exc,
+                        exc_info=True,
+                    )
+                    continue
+                if plan_doc is None:
+                    self._logger.warning(
+                        "Recovery: requested plan %s was not found", plan_id
+                    )
+                    continue
+                if not is_plan_eligible(plan_doc):
+                    self._logger.debug(
+                        "Recovery: requested plan %s is not eligible (%s)",
+                        plan_id,
+                        get_eligibility_reason(plan_doc),
+                    )
+                    continue
+                all_eligible.append(plan_doc)
 
         # Apply origin and owner filters
         filtered_plans: list[dict[str, Any]] = []

--- a/tests/test_approval_workflow_e2e.py
+++ b/tests/test_approval_workflow_e2e.py
@@ -8,7 +8,7 @@ All tests use mocked components (no live CouchDB required).
 
 Test Scenarios:
 1. Auto-Run Plan: Handler → auto_run=True → immediate execution
-2. Approval Required: Handler → auto_run=False → Genstat approval → execution
+2. Approval Required: Handler → auto_run=False → external approval → execution
 3. Manual Re-Run: executed plan → increment run_token → re-execution
 4. Startup Recovery: restart → recover pending approved plans
 """
@@ -20,6 +20,7 @@ import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from lib.core_utils.singleton_decorator import SingletonMeta
+from lib.watchers.backends.base import RawWatchEvent
 
 
 class TestAutoRunPlanE2E(unittest.TestCase):
@@ -52,11 +53,12 @@ class TestAutoRunPlanE2E(unittest.TestCase):
         shutil.rmtree(self.work_root, ignore_errors=True)
         shutil.rmtree(self.spool_dir, ignore_errors=True)
 
+    @patch("lib.core_utils.yggdrasil_core.build_internal_storage")
     @patch("lib.core_utils.yggdrasil_core.YggdrasilCore._init_db_managers")
     @patch("lib.core_utils.yggdrasil_core.Engine")
     @patch("lib.core_utils.yggdrasil_core.OpsConsumerService")
     def test_auto_run_plan_executes_immediately(
-        self, mock_ops, mock_engine_cls, mock_init_db
+        self, mock_ops, mock_engine_cls, mock_init_db, mock_build_storage
     ):
         """Test that auto_run=True plans execute without human approval."""
         from yggdrasil.flow.model import Plan, StepSpec
@@ -125,7 +127,7 @@ class TestApprovalRequiredE2E(unittest.TestCase):
     2. Core persists with status='draft'
     3. PlanWatcher detects plan; filters (status != 'approved')
     4. Plan remains in draft
-    5. Genstat approves: updates status='approved'
+    5. An external actor approves: updates status='approved'
     6. PlanWatcher detects status change
     7. Plan executed
 
@@ -167,7 +169,7 @@ class TestApprovalRequiredE2E(unittest.TestCase):
         """Test that approving a plan makes it eligible."""
         from lib.core_utils.plan_eligibility import is_plan_eligible
 
-        # Plan approved by Genstat
+        # Plan approved by an external actor
         approved_plan_doc = {
             "_id": "pln_approval_001",
             "status": "approved",  # Now approved
@@ -215,7 +217,15 @@ class TestApprovalRequiredE2E(unittest.TestCase):
             },
         }
 
-        asyncio.run(watcher._evaluate_change(draft_change))
+        asyncio.run(
+            watcher._evaluate_change(
+                RawWatchEvent(
+                    id=draft_change["id"],
+                    doc=draft_change["doc"],
+                    seq=draft_change["seq"],
+                )
+            )
+        )
 
         # No events should be emitted for draft plans
         self.assertEqual(len(events_emitted), 0)
@@ -256,7 +266,15 @@ class TestApprovalRequiredE2E(unittest.TestCase):
             },
         }
 
-        asyncio.run(watcher._evaluate_change(approved_change))
+        asyncio.run(
+            watcher._evaluate_change(
+                RawWatchEvent(
+                    id=approved_change["id"],
+                    doc=approved_change["doc"],
+                    seq=approved_change["seq"],
+                )
+            )
+        )
 
         # Should emit one event
         self.assertEqual(len(events_emitted), 1)
@@ -269,7 +287,7 @@ class TestManualReRunE2E(unittest.TestCase):
 
     Flow:
     1. Plan executed (executed_run_token=1, run_token=1)
-    2. Genstat re-run: increments run_token=2
+    2. External re-run request: increments run_token=2
     3. PlanWatcher detects run_token > executed_run_token
     4. Plan executes again
     5. executed_run_token updated to 2
@@ -294,11 +312,11 @@ class TestManualReRunE2E(unittest.TestCase):
         """Test that incrementing run_token makes plan eligible again."""
         from lib.core_utils.plan_eligibility import is_plan_eligible
 
-        # After Genstat increments run_token
+        # After an external actor increments run_token
         rerun_plan = {
             "_id": "pln_rerun_001",
             "status": "approved",
-            "run_token": 2,  # Incremented by Genstat
+            "run_token": 2,  # Incremented by an external actor
             "executed_run_token": 1,  # Still at previous value
             "run_requested_at": "2026-01-16T14:00:00Z",
             "run_requested_by": "user@example.com",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,10 @@ from unittest.mock import MagicMock, Mock, call, patch
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from lib.core_utils.daemon_lock import DaemonLockError
-from lib.core_utils.errors import ExternalSystemUnavailableError
+from lib.core_utils.errors import (
+    ExternalSystemUnavailableError,
+    InternalStorageConfigurationError,
+)
 from lib.couchdb.couchdb_connection import CouchDBClientFactory
 from lib.watchers.config_validation import (
     WatcherConfigurationError,
@@ -183,6 +186,26 @@ class TestYggdrasilCLI(unittest.TestCase):
             self.assertEqual(context.exception.code, 1)
             mock_core_class.assert_not_called()
             mock_asyncio_run.assert_not_called()
+
+    def test_invalid_internal_storage_config_exits_cleanly(self):
+        """Invalid internal_storage config exits 1 (no uncaught traceback)."""
+        sys.argv = ["yggdrasil", "daemon"]
+
+        with (
+            patch("yggdrasil.cli.ConfigLoader") as mock_config_loader,
+            patch("yggdrasil.cli.YggdrasilCore") as mock_core_class,
+            patch("yggdrasil.cli.DaemonLock.acquire"),
+            patch("asyncio.run"),
+        ):
+            mock_config_loader.return_value.load_config.return_value = self.mock_config
+            mock_core_class.side_effect = InternalStorageConfigurationError(
+                "internal_storage.backend='sqlite' is only supported in dev mode"
+            )
+
+            with self.assertRaises(SystemExit) as context:
+                main()
+
+            self.assertEqual(context.exception.code, 1)
 
     def test_daemon_watcher_config_error_exits_cleanly(self):
         """Watcher config errors are logged without starting the daemon."""

--- a/tests/test_daemon_lock.py
+++ b/tests/test_daemon_lock.py
@@ -23,7 +23,7 @@ class TestDaemonLock(unittest.TestCase):
                 ) as lock:
                     metadata = json.loads(lock.lock_path.read_text())
 
-                self.assertEqual(lock.lock_path, Path(tmpdir) / "daemon.lock")
+                self.assertEqual(lock.lock_path, Path(tmpdir) / "daemon-dev.lock")
                 self.assertTrue(metadata["dev_mode"])
                 self.assertEqual(metadata["config_path"], "/tmp/dev_main.json")
                 self.assertIn("pid", metadata)
@@ -44,8 +44,25 @@ class TestDaemonLock(unittest.TestCase):
                     context.exception.lock_path, Path(tmpdir) / "daemon.lock"
                 )
                 self.assertIn("pid", context.exception.existing_metadata)
+                self.assertIn("prod mode", str(context.exception))
 
-    def test_dev_and_normal_use_same_local_lock_path(self):
+    def test_second_dev_acquire_fails_with_dev_mode_in_message(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch(
+                "lib.core_utils.daemon_lock.appdirs.user_runtime_dir",
+                return_value=tmpdir,
+                create=True,
+            ):
+                with DaemonLock.acquire(dev_mode=True, config_path=None):
+                    with self.assertRaises(DaemonLockError) as context:
+                        DaemonLock.acquire(dev_mode=True, config_path=None)
+
+                self.assertEqual(
+                    context.exception.lock_path, Path(tmpdir) / "daemon-dev.lock"
+                )
+                self.assertIn("dev mode", str(context.exception))
+
+    def test_dev_and_prod_use_distinct_lock_paths(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             with patch(
                 "lib.core_utils.daemon_lock.appdirs.user_runtime_dir",
@@ -58,7 +75,23 @@ class TestDaemonLock(unittest.TestCase):
                 with DaemonLock.acquire(dev_mode=True, config_path=None) as dev:
                     dev_path = dev.lock_path
 
-                self.assertEqual(normal_path, dev_path)
+                self.assertEqual(normal_path, Path(tmpdir) / "daemon.lock")
+                self.assertEqual(dev_path, Path(tmpdir) / "daemon-dev.lock")
+                self.assertNotEqual(normal_path, dev_path)
+
+    def test_prod_and_dev_locks_held_concurrently(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch(
+                "lib.core_utils.daemon_lock.appdirs.user_runtime_dir",
+                return_value=tmpdir,
+                create=True,
+            ):
+                # Both modes acquire and hold simultaneously — no error.
+                with DaemonLock.acquire(dev_mode=False, config_path=None):
+                    with DaemonLock.acquire(dev_mode=True, config_path=None) as dev:
+                        self.assertEqual(
+                            dev.lock_path, Path(tmpdir) / "daemon-dev.lock"
+                        )
 
     def test_fallback_runtime_dir_is_created_with_restrictive_permissions(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_internal_storage_config.py
+++ b/tests/test_internal_storage_config.py
@@ -1,0 +1,172 @@
+"""Unit tests for internal-storage configuration resolution."""
+
+import unittest
+from pathlib import Path
+
+from lib.core_utils.errors import InternalStorageConfigurationError
+from lib.storage.config import (
+    CouchInternalStorageConfig,
+    SQLiteInternalStorageConfig,
+    default_sqlite_path,
+    resolve_internal_storage_config,
+)
+
+
+def _couch_config(role_map: dict | None = None) -> dict:
+    """Build a full config with explicit CouchDB internal storage."""
+    return {
+        "internal_storage": {
+            "backend": "couchdb",
+            "couchdb": {
+                "connections": role_map
+                or {
+                    "coordination": "yggdrasil_db",
+                    "plans": "yggdrasil_plans_db",
+                    "operations": "yggdrasil_ops_db",
+                }
+            },
+        },
+        "external_systems": {
+            "endpoints": {
+                "couchdb": {
+                    "backend": "couchdb",
+                    "url": "https://couch.example.org:5984",
+                    "auth": {"user_env": "TEST_USER", "pass_env": "TEST_PASS"},
+                },
+                "pg": {
+                    "backend": "postgres",
+                    "url": "pg.example.org:5432",
+                },
+            },
+            "connections": {
+                "yggdrasil_db": {
+                    "endpoint": "couchdb",
+                    "resource": {"db": "yggdrasil"},
+                },
+                "yggdrasil_plans_db": {
+                    "endpoint": "couchdb",
+                    "resource": {"db": "yggdrasil_plans"},
+                },
+                "yggdrasil_ops_db": {
+                    "endpoint": "couchdb",
+                    "resource": {"db": "yggdrasil_ops"},
+                },
+                "pg_conn": {
+                    "endpoint": "pg",
+                    "resource": {"db": "whatever"},
+                },
+            },
+        },
+    }
+
+
+class TestResolveInternalStorageConfig(unittest.TestCase):
+    """Tests for resolve_internal_storage_config()."""
+
+    def test_absent_block_returns_none(self):
+        self.assertIsNone(resolve_internal_storage_config({}))
+
+    def test_unknown_backend_rejected(self):
+        with self.assertRaises(InternalStorageConfigurationError):
+            resolve_internal_storage_config({"internal_storage": {"backend": "redis"}})
+
+    def test_non_mapping_block_rejected(self):
+        with self.assertRaises(InternalStorageConfigurationError):
+            resolve_internal_storage_config({"internal_storage": "couchdb"})
+
+    # ------------------------------------------------------------------
+    # Explicit CouchDB
+    # ------------------------------------------------------------------
+
+    def test_explicit_couchdb_resolves_all_roles(self):
+        resolved = resolve_internal_storage_config(_couch_config())
+        self.assertIsInstance(resolved, CouchInternalStorageConfig)
+        self.assertEqual(resolved.coordination.db_name, "yggdrasil")
+        self.assertEqual(resolved.plans.db_name, "yggdrasil_plans")
+        self.assertEqual(resolved.operations.db_name, "yggdrasil_ops")
+        # Endpoint auth/url come from the referenced endpoint
+        self.assertEqual(resolved.plans.endpoint.user_env, "TEST_USER")
+        self.assertEqual(resolved.plans.endpoint.pass_env, "TEST_PASS")
+        self.assertTrue(resolved.plans.endpoint.url.startswith("https://"))
+
+    def test_missing_role_rejected(self):
+        config = _couch_config(role_map={"plans": "yggdrasil_plans_db"})
+        with self.assertRaises(InternalStorageConfigurationError) as ctx:
+            resolve_internal_storage_config(config)
+        self.assertIn("coordination", str(ctx.exception))
+
+    def test_unknown_connection_rejected(self):
+        config = _couch_config(
+            role_map={
+                "coordination": "nope_db",
+                "plans": "yggdrasil_plans_db",
+                "operations": "yggdrasil_ops_db",
+            }
+        )
+        with self.assertRaises(InternalStorageConfigurationError) as ctx:
+            resolve_internal_storage_config(config)
+        self.assertIn("nope_db", str(ctx.exception))
+
+    def test_non_couchdb_endpoint_rejected(self):
+        config = _couch_config(
+            role_map={
+                "coordination": "pg_conn",
+                "plans": "yggdrasil_plans_db",
+                "operations": "yggdrasil_ops_db",
+            }
+        )
+        with self.assertRaises(InternalStorageConfigurationError) as ctx:
+            resolve_internal_storage_config(config)
+        self.assertIn("postgres", str(ctx.exception))
+
+    def test_missing_connections_map_rejected(self):
+        config = {"internal_storage": {"backend": "couchdb", "couchdb": {}}}
+        with self.assertRaises(InternalStorageConfigurationError):
+            resolve_internal_storage_config(config)
+
+    # ------------------------------------------------------------------
+    # Explicit SQLite (dev-gated)
+    # ------------------------------------------------------------------
+
+    def test_sqlite_rejected_outside_dev_mode(self):
+        config = {"internal_storage": {"backend": "sqlite", "sqlite": {"path": None}}}
+        with self.assertRaises(InternalStorageConfigurationError) as ctx:
+            resolve_internal_storage_config(config, dev_mode=False)
+        self.assertIn("dev mode", str(ctx.exception))
+
+    def test_sqlite_default_path_in_dev_mode(self):
+        config = {"internal_storage": {"backend": "sqlite", "sqlite": {"path": None}}}
+        resolved = resolve_internal_storage_config(config, dev_mode=True)
+        self.assertIsInstance(resolved, SQLiteInternalStorageConfig)
+        self.assertEqual(resolved.path, default_sqlite_path())
+        self.assertTrue(str(resolved.path).endswith("yggdrasil.sqlite3"))
+
+    def test_sqlite_missing_block_uses_default_path(self):
+        config = {"internal_storage": {"backend": "sqlite"}}
+        resolved = resolve_internal_storage_config(config, dev_mode=True)
+        self.assertEqual(resolved.path, default_sqlite_path())
+
+    def test_sqlite_explicit_absolute_path(self):
+        config = {
+            "internal_storage": {
+                "backend": "sqlite",
+                "sqlite": {"path": "/var/tmp/ygg_dev.sqlite3"},
+            }
+        }
+        resolved = resolve_internal_storage_config(config, dev_mode=True)
+        self.assertEqual(resolved.path, Path("/var/tmp/ygg_dev.sqlite3"))
+
+    def test_sqlite_relative_path_rejected(self):
+        config = {
+            "internal_storage": {
+                "backend": "sqlite",
+                "sqlite": {"path": "relative/ygg.sqlite3"},
+            }
+        }
+        with self.assertRaises(InternalStorageConfigurationError) as ctx:
+            resolve_internal_storage_config(config, dev_mode=True)
+        self.assertIn("absolute", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_internal_storage_integration.py
+++ b/tests/test_internal_storage_integration.py
@@ -1,0 +1,185 @@
+"""Integration tests for the internal-storage factory and SQLite watcher path."""
+
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from lib.core_utils.event_types import EventType
+from lib.storage import build_internal_storage
+from lib.storage.config import CouchInternalStorageConfig
+from lib.watchers.backends.base import Checkpoint
+from lib.watchers.plan_watcher import PlanWatcher
+from yggdrasil.flow.model import Plan, StepSpec
+
+
+def _sqlite_config(path: Path) -> dict:
+    return {
+        "internal_storage": {
+            "backend": "sqlite",
+            "sqlite": {"path": str(path)},
+        }
+    }
+
+
+class TestInternalStorageFactory(unittest.TestCase):
+    """Backend selection through build_internal_storage()."""
+
+    def test_sqlite_mode_constructs_no_couch_bundle(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("lib.storage.couch.build_couchdb_bundle") as mock_couch:
+                bundle = build_internal_storage(
+                    _sqlite_config(Path(tmp) / "ygg.sqlite3"), dev_mode=True
+                )
+        self.assertEqual(bundle.backend, "sqlite")
+        mock_couch.assert_not_called()
+
+    def test_absent_block_uses_legacy_couch_path(self):
+        with patch("lib.storage.couch.build_couchdb_bundle") as mock_couch:
+            mock_couch.return_value = MagicMock(backend="couchdb")
+            bundle = build_internal_storage({})
+        mock_couch.assert_called_once_with(None)
+        self.assertEqual(bundle.backend, "couchdb")
+
+    def test_legacy_bundle_constructs_coordination_manager_eagerly(self):
+        """Legacy implicit path must not defer the coordination DB.
+
+        A lazy checkpoint store would fail open (checkpoint load returns None,
+        PlanWatcher starts at "now") if the 'yggdrasil' DB is unreachable,
+        instead of failing fast at startup like pre-bundle Core did.
+        """
+        from lib.storage.couch import build_couchdb_bundle
+
+        with (
+            patch("lib.storage.couch.PlanDBManager"),
+            patch("lib.storage.couch.OpsWriter"),
+            patch("lib.storage.couch.ChangesFetcher"),
+            patch("lib.storage.couch.YggdrasilDBManager") as mock_ydm,
+            patch("lib.storage.couch.CouchDBCheckpointStore") as mock_cp,
+        ):
+            build_couchdb_bundle(None)
+
+        mock_ydm.assert_called_once()  # coordination manager constructed eagerly
+        _, kwargs = mock_cp.call_args
+        self.assertIs(kwargs["db_manager"], mock_ydm.return_value)
+
+    def test_explicit_couch_passes_resolved_config(self):
+        config = {
+            "internal_storage": {
+                "backend": "couchdb",
+                "couchdb": {
+                    "connections": {
+                        "coordination": "ygg_db",
+                        "plans": "plans_db",
+                        "operations": "ops_db",
+                    }
+                },
+            },
+            "external_systems": {
+                "endpoints": {
+                    "couchdb": {
+                        "backend": "couchdb",
+                        "url": "https://couch.example.org:5984",
+                        "auth": {"user_env": "U", "pass_env": "P"},
+                    }
+                },
+                "connections": {
+                    "ygg_db": {"endpoint": "couchdb", "resource": {"db": "yggdrasil"}},
+                    "plans_db": {
+                        "endpoint": "couchdb",
+                        "resource": {"db": "yggdrasil_plans"},
+                    },
+                    "ops_db": {
+                        "endpoint": "couchdb",
+                        "resource": {"db": "yggdrasil_ops"},
+                    },
+                },
+            },
+        }
+        with patch("lib.storage.couch.build_couchdb_bundle") as mock_couch:
+            mock_couch.return_value = MagicMock(backend="couchdb")
+            build_internal_storage(config)
+        (resolved,), _ = mock_couch.call_args
+        self.assertIsInstance(resolved, CouchInternalStorageConfig)
+        self.assertEqual(resolved.plans.db_name, "yggdrasil_plans")
+
+
+class TestPlanWatcherWithSQLite(unittest.TestCase):
+    """PlanWatcher runs end-to-end on the SQLite bundle (no CouchDB)."""
+
+    def test_watcher_emits_and_checkpoints_on_sqlite(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            bundle = build_internal_storage(
+                _sqlite_config(Path(tmp) / "ygg.sqlite3"), dev_mode=True
+            )
+
+            # Deterministic start: seed the checkpoint at 0 so the watcher
+            # replays every change instead of starting at "now".
+            bundle.checkpoints.save(
+                Checkpoint(backend_key=PlanWatcher.CHECKPOINT_KEY, value="0")
+            )
+
+            plan = Plan(
+                plan_id="pln_it_P1_v1",
+                realm="test_realm",
+                scope={"kind": "project", "id": "P1"},
+                steps=[
+                    StepSpec(
+                        step_id="s1",
+                        name="echo",
+                        fn_ref="tests.integration.mock_steps:echo_step",
+                        params={},
+                    )
+                ],
+            )
+            bundle.plans.save_plan(
+                plan,
+                "test_realm",
+                {"kind": "project", "id": "P1"},
+                auto_run=True,
+            )
+
+            events = []
+            got_event = asyncio.Event()
+
+            def on_event(event):
+                events.append(event)
+                got_event.set()
+
+            watcher = PlanWatcher(
+                on_event=on_event,
+                poll_interval_sec=0.01,
+                plan_store=bundle.plans,
+                change_source=bundle.plan_changes,
+                checkpoint_store=bundle.checkpoints,
+                execution_authority_filter="daemon",
+            )
+
+            async def _run():
+                task = asyncio.create_task(watcher.start())
+                # Generous timeout: the SQLite change source polls via
+                # asyncio.to_thread, so event delivery is sensitive to
+                # thread-pool scheduling under a loaded parallel test suite.
+                await asyncio.wait_for(got_event.wait(), timeout=30.0)
+                await watcher.stop()
+                task.cancel()
+                await asyncio.gather(task, return_exceptions=True)
+
+            asyncio.run(_run())
+
+            self.assertEqual(len(events), 1)
+            self.assertEqual(events[0].event_type, EventType.PLAN_EXECUTION)
+            self.assertEqual(events[0].payload["plan_doc_id"], "pln_it_P1_v1")
+            self.assertEqual(
+                events[0].payload["plan_doc"]["status"],
+                "approved",
+            )
+
+            # Checkpoint advanced past the seeded value
+            checkpoint = bundle.checkpoints.load(PlanWatcher.CHECKPOINT_KEY)
+            self.assertNotEqual(checkpoint.value, "0")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -9,6 +9,7 @@ from lib.core_utils.logging_utils import (
     configure_logging,
     custom_logger,
 )
+from lib.core_utils.ygg_session import YggSession
 
 
 class TestLoggingUtils(unittest.TestCase):
@@ -24,6 +25,14 @@ class TestLoggingUtils(unittest.TestCase):
         # Backup original logging handlers and level
         self.original_handlers = logging.getLogger().handlers.copy()
         self.original_level = logging.getLogger().level
+
+        # Force a known YggSession mode (filename carries a dev marker)
+        self._saved_session_state = (
+            YggSession._YggSession__dev_mode,
+            YggSession._YggSession__dev_already_set,
+        )
+        YggSession._YggSession__dev_mode = False
+        YggSession._YggSession__dev_already_set = False
 
         # Clear existing handlers
         logging.getLogger().handlers = []
@@ -63,6 +72,12 @@ class TestLoggingUtils(unittest.TestCase):
         logging.getLogger().handlers = self.original_handlers
         logging.getLogger().level = self.original_level
 
+        # Restore YggSession state
+        (
+            YggSession._YggSession__dev_mode,
+            YggSession._YggSession__dev_already_set,
+        ) = self._saved_session_state
+
         # Stop all patches
         self.patcher_config_loader.stop()
         self.patcher_datetime.stop()
@@ -78,7 +93,8 @@ class TestLoggingUtils(unittest.TestCase):
 
                 expected_log_dir = Path(self.mock_configs["yggdrasil"]["log_dir"])
                 expected_log_file = (
-                    expected_log_dir / "yggdrasil_2021-01-01_12.00.00.log"
+                    expected_log_dir
+                    / f"yggdrasil_2021-01-01_12.00.00_{os.getpid()}.log"
                 )
                 expected_log_level = logging.INFO
                 # Accept either the rich or non-rich format
@@ -169,7 +185,9 @@ class TestLoggingUtils(unittest.TestCase):
     def test_configure_logging_logs_to_correct_file(self):
         configure_logging()
         expected_log_dir = Path(self.mock_configs["yggdrasil"]["log_dir"])
-        expected_log_file = expected_log_dir / "yggdrasil_2021-01-01_12.00.00.log"
+        expected_log_file = (
+            expected_log_dir / f"yggdrasil_2021-01-01_12.00.00_{os.getpid()}.log"
+        )
         self.mock_filehandler.assert_called_once_with(expected_log_file)
 
     def test_custom_logger_returns_logger(self):
@@ -290,7 +308,9 @@ class TestLoggingUtils(unittest.TestCase):
         configure_logging()
         expected_timestamp = "2021-01-01_12.00.00"
         expected_log_dir = Path(self.mock_configs["yggdrasil"]["log_dir"])
-        expected_log_file = expected_log_dir / f"yggdrasil_{expected_timestamp}.log"
+        expected_log_file = (
+            expected_log_dir / f"yggdrasil_{expected_timestamp}_{os.getpid()}.log"
+        )
         self.mock_filehandler.assert_called_with(expected_log_file)
 
     @patch("lib.core_utils.logging_utils.datetime")
@@ -302,7 +322,21 @@ class TestLoggingUtils(unittest.TestCase):
         configure_logging()
         expected_timestamp = "2022-02-02_14.30.00"
         expected_log_dir = Path(self.mock_configs["yggdrasil"]["log_dir"])
-        expected_log_file = expected_log_dir / f"yggdrasil_{expected_timestamp}.log"
+        expected_log_file = (
+            expected_log_dir / f"yggdrasil_{expected_timestamp}_{os.getpid()}.log"
+        )
+        self.mock_filehandler.assert_called_with(expected_log_file)
+
+    def test_configure_logging_dev_mode_filename_marker(self):
+        YggSession._YggSession__dev_mode = True
+        YggSession._YggSession__dev_already_set = True
+
+        configure_logging(debug=True)
+
+        expected_log_dir = Path(self.mock_configs["yggdrasil"]["log_dir"])
+        expected_log_file = (
+            expected_log_dir / f"yggdrasil_dev_2021-01-01_12.00.00_{os.getpid()}.log"
+        )
         self.mock_filehandler.assert_called_with(expected_log_file)
 
     def test_configure_logging_invalid_configs_type(self):

--- a/tests/test_plan_eligibility_edge_cases.py
+++ b/tests/test_plan_eligibility_edge_cases.py
@@ -450,15 +450,15 @@ class TestPlanEligibilityRealWorldScenarios(unittest.TestCase):
         }
         self.assertFalse(is_plan_eligible(doc))
 
-    def test_plan_after_genstat_approval(self):
-        """Test plan after Genstat approves it."""
+    def test_plan_after_external_approval(self):
+        """Test a plan after an external actor approves it."""
         from lib.core_utils.plan_eligibility import is_plan_eligible
 
         doc = {
             "_id": "pln_tenx_P12345_v1",
             "realm": "tenx",
             "scope": {"kind": "project", "id": "P12345"},
-            "status": "approved",  # Changed by Genstat
+            "status": "approved",  # Changed by an external approval actor
             "auto_run": False,
             "run_token": 1,
             "executed_run_token": 0,
@@ -483,7 +483,7 @@ class TestPlanEligibilityRealWorldScenarios(unittest.TestCase):
         self.assertFalse(is_plan_eligible(doc))
 
     def test_plan_after_rerun_request(self):
-        """Test plan after Genstat requests re-run."""
+        """Test a plan after an external actor requests a re-run."""
         from lib.core_utils.plan_eligibility import is_plan_eligible
 
         doc = {
@@ -492,7 +492,7 @@ class TestPlanEligibilityRealWorldScenarios(unittest.TestCase):
             "scope": {"kind": "project", "id": "P12345"},
             "status": "approved",
             "auto_run": True,
-            "run_token": 2,  # Incremented by Genstat
+            "run_token": 2,  # Incremented by an external approval actor
             "executed_run_token": 1,  # Still at previous value
             "run_requested_at": "2026-01-16T14:00:00Z",
             "run_requested_by": "user@example.com",

--- a/tests/test_plan_watcher.py
+++ b/tests/test_plan_watcher.py
@@ -11,7 +11,18 @@ import unittest
 from unittest.mock import MagicMock, Mock, patch
 
 from lib.core_utils.event_types import EventType
+from lib.watchers.backends.base import RawWatchEvent
 from lib.watchers.plan_watcher import PlanWatcher
+
+
+def _raw(change: dict) -> RawWatchEvent:
+    """Convert a CouchDB-style change dict to the RawWatchEvent shape."""
+    return RawWatchEvent(
+        id=str(change.get("id", "")),
+        doc=change.get("doc"),
+        seq=change.get("seq"),
+        deleted=bool(change.get("deleted", False)),
+    )
 
 
 class MockApiException(Exception):
@@ -109,7 +120,7 @@ class TestPlanWatcher(unittest.TestCase):
         """Test that design documents are skipped."""
         change = {"id": "_design/views", "seq": "1", "doc": {"views": {}}}
 
-        asyncio.run(self.watcher._evaluate_change(change))
+        asyncio.run(self.watcher._evaluate_change(_raw(change)))
 
         self.mock_on_event.assert_not_called()
 
@@ -117,7 +128,7 @@ class TestPlanWatcher(unittest.TestCase):
         """Test that deleted documents are skipped."""
         change = {"id": "pln_tenx_P12345_v1", "seq": "1", "deleted": True}
 
-        asyncio.run(self.watcher._evaluate_change(change))
+        asyncio.run(self.watcher._evaluate_change(_raw(change)))
 
         self.mock_on_event.assert_not_called()
 
@@ -125,7 +136,7 @@ class TestPlanWatcher(unittest.TestCase):
         """Test that changes without doc are skipped."""
         change = {"id": "pln_tenx_P12345_v1", "seq": "1"}  # no 'doc' field
 
-        asyncio.run(self.watcher._evaluate_change(change))
+        asyncio.run(self.watcher._evaluate_change(_raw(change)))
 
         self.mock_on_event.assert_not_called()
 
@@ -140,7 +151,7 @@ class TestPlanWatcher(unittest.TestCase):
         }
         change = {"id": "pln_tenx_P12345_v1", "seq": "1", "doc": eligible_doc}
 
-        asyncio.run(self.watcher._evaluate_change(change))
+        asyncio.run(self.watcher._evaluate_change(_raw(change)))
 
         # Verify emit was called
         self.mock_on_event.assert_called_once()
@@ -160,7 +171,7 @@ class TestPlanWatcher(unittest.TestCase):
         }
         change = {"id": "pln_tenx_P12345_v1", "seq": "1", "doc": draft_doc}
 
-        asyncio.run(self.watcher._evaluate_change(change))
+        asyncio.run(self.watcher._evaluate_change(_raw(change)))
 
         self.mock_on_event.assert_not_called()
 
@@ -175,7 +186,7 @@ class TestPlanWatcher(unittest.TestCase):
         }
         change = {"id": "pln_tenx_P12345_v1", "seq": "1", "doc": executed_doc}
 
-        asyncio.run(self.watcher._evaluate_change(change))
+        asyncio.run(self.watcher._evaluate_change(_raw(change)))
 
         self.mock_on_event.assert_not_called()
 
@@ -190,7 +201,7 @@ class TestPlanWatcher(unittest.TestCase):
         }
         change = {"id": "pln_tenx_P12345_v1", "seq": "1", "doc": rerun_doc}
 
-        asyncio.run(self.watcher._evaluate_change(change))
+        asyncio.run(self.watcher._evaluate_change(_raw(change)))
 
         self.mock_on_event.assert_called_once()
 
@@ -205,6 +216,7 @@ class TestPlanWatcher(unittest.TestCase):
         asyncio.run(self.watcher.recover_pending_plans())
 
         self.mock_plan_db.query_approved_pending.assert_called_once()
+        self.mock_plan_db.fetch_plan.assert_not_called()
 
     def test_recover_pending_plans_emits_for_each(self):
         """Test that recovery emits events for all eligible plans."""
@@ -240,6 +252,76 @@ class TestPlanWatcher(unittest.TestCase):
 
         self.assertEqual(result, [])
         self.mock_on_event.assert_not_called()
+
+    def test_scoped_recovery_fetches_only_requested_eligible_plans(self):
+        """Scoped recovery avoids a full scan and keeps all safety filters."""
+        owner = "run_once:this-session"
+        watcher = PlanWatcher(
+            on_event=self.mock_on_event,
+            poll_interval_sec=0.1,
+            execution_authority_filter="run_once",
+            execution_owner_filter=owner,
+        )
+        documents = {
+            "matching": {
+                "_id": "matching",
+                "status": "approved",
+                "run_token": 1,
+                "executed_run_token": 0,
+                "execution_authority": "run_once",
+                "execution_owner": owner,
+            },
+            "ineligible": {
+                "_id": "ineligible",
+                "status": "draft",
+                "run_token": 1,
+                "executed_run_token": 0,
+                "execution_authority": "run_once",
+                "execution_owner": owner,
+            },
+            "wrong-owner": {
+                "_id": "wrong-owner",
+                "status": "approved",
+                "run_token": 1,
+                "executed_run_token": 0,
+                "execution_authority": "run_once",
+                "execution_owner": "run_once:other-session",
+            },
+            "wrong-authority": {
+                "_id": "wrong-authority",
+                "status": "approved",
+                "run_token": 1,
+                "executed_run_token": 0,
+                "execution_authority": "daemon",
+                "execution_owner": owner,
+            },
+        }
+
+        def _fetch_plan(plan_id):
+            if plan_id == "failed":
+                raise RuntimeError("temporary fetch failure")
+            return documents.get(plan_id)
+
+        self.mock_plan_db.fetch_plan.side_effect = _fetch_plan
+        plan_ids = [
+            "matching",
+            "ineligible",
+            "wrong-owner",
+            "wrong-authority",
+            "missing",
+            "failed",
+            "matching",
+        ]
+
+        result = asyncio.run(watcher.recover_pending_plans(plan_ids=plan_ids))
+
+        self.mock_plan_db.query_approved_pending.assert_not_called()
+        self.assertEqual(
+            [call.args[0] for call in self.mock_plan_db.fetch_plan.call_args_list],
+            plan_ids[:-1],
+        )
+        self.assertEqual(result, [documents["matching"]])
+        self.mock_on_event.assert_called_once()
 
     # ==========================================
     # start/stop Tests
@@ -448,7 +530,7 @@ class TestPlanWatcherIntegration(unittest.TestCase):
 
         async def test():
             for change in changes:
-                await watcher._evaluate_change(change)
+                await watcher._evaluate_change(_raw(change))
 
         asyncio.run(test())
 
@@ -501,7 +583,7 @@ class TestPlanWatcherIntegration(unittest.TestCase):
             watcher._running = True
             async for change in watcher.changes_fetcher.fetch_changes(since="0"):
                 new_seq = change.get("seq")
-                await watcher._evaluate_change(change)
+                await watcher._evaluate_change(_raw(change))
                 if new_seq:
                     watcher.checkpoint_store.save(Mock(value=new_seq))
             watcher._running = False
@@ -578,7 +660,7 @@ class TestPlanWatcherFiltering(unittest.TestCase):
         }
         change = {"id": "pln_tenx_P12345_v1", "seq": "1", "doc": run_once_doc}
 
-        asyncio.run(watcher._evaluate_change(change))
+        asyncio.run(watcher._evaluate_change(_raw(change)))
 
         self.mock_on_event.assert_not_called()
 
@@ -599,7 +681,7 @@ class TestPlanWatcherFiltering(unittest.TestCase):
         }
         change = {"id": "pln_tenx_P12345_v1", "seq": "1", "doc": daemon_doc}
 
-        asyncio.run(watcher._evaluate_change(change))
+        asyncio.run(watcher._evaluate_change(_raw(change)))
 
         self.mock_on_event.assert_called_once()
 
@@ -623,7 +705,7 @@ class TestPlanWatcherFiltering(unittest.TestCase):
         }
         change = {"id": "pln_tenx_P12345_v1", "seq": "1", "doc": my_doc}
 
-        asyncio.run(watcher._evaluate_change(change))
+        asyncio.run(watcher._evaluate_change(_raw(change)))
 
         self.mock_on_event.assert_called_once()
 
@@ -647,7 +729,7 @@ class TestPlanWatcherFiltering(unittest.TestCase):
         }
         change = {"id": "pln_tenx_P12345_v1", "seq": "1", "doc": other_doc}
 
-        asyncio.run(watcher._evaluate_change(change))
+        asyncio.run(watcher._evaluate_change(_raw(change)))
 
         self.mock_on_event.assert_not_called()
 
@@ -668,7 +750,7 @@ class TestPlanWatcherFiltering(unittest.TestCase):
         }
         change = {"id": "pln_tenx_P12345_v1", "seq": "1", "doc": legacy_doc}
 
-        asyncio.run(watcher._evaluate_change(change))
+        asyncio.run(watcher._evaluate_change(_raw(change)))
 
         self.mock_on_event.assert_not_called()
 
@@ -698,12 +780,12 @@ class TestPlanWatcherFiltering(unittest.TestCase):
 
         asyncio.run(
             watcher._evaluate_change(
-                {"id": "pln_tenx_P1_v1", "seq": "1", "doc": daemon_doc}
+                _raw({"id": "pln_tenx_P1_v1", "seq": "1", "doc": daemon_doc})
             )
         )
         asyncio.run(
             watcher._evaluate_change(
-                {"id": "pln_tenx_P2_v1", "seq": "2", "doc": run_once_doc}
+                _raw({"id": "pln_tenx_P2_v1", "seq": "2", "doc": run_once_doc})
             )
         )
 

--- a/tests/test_run_once_watcher.py
+++ b/tests/test_run_once_watcher.py
@@ -9,13 +9,16 @@ Tests the CLI's --run-once execution mode which:
 """
 
 import asyncio
+import signal
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from lib.core_utils.event_types import EventType
 from lib.core_utils.yggdrasil_core import (  # type: ignore[attr-defined]
     YggdrasilCore,
     _generate_run_once_owner,
 )
+from lib.watchers.abstract_watcher import YggdrasilEvent
 
 
 class TestGenerateRunOnceOwner(unittest.TestCase):
@@ -47,11 +50,16 @@ class TestCheckPlanOverwrite(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         YggdrasilCore._instance = None
+        self.storage_patcher = patch(
+            "lib.core_utils.yggdrasil_core.build_internal_storage"
+        )
+        self.mock_storage = self.storage_patcher.start().return_value
         self.mock_config = {"work_root": "/tmp/ygg_test"}
         self.mock_plan_dbm = MagicMock()
 
     def tearDown(self):
         """Clean up singleton."""
+        self.storage_patcher.stop()
         YggdrasilCore._instance = None
 
     @patch("lib.core_utils.yggdrasil_core.OpsConsumerService")
@@ -136,10 +144,15 @@ class TestRunOnceWithWatcher(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         YggdrasilCore._instance = None
+        self.storage_patcher = patch(
+            "lib.core_utils.yggdrasil_core.build_internal_storage"
+        )
+        self.mock_storage = self.storage_patcher.start().return_value
         self.mock_config = {"work_root": "/tmp/ygg_test"}
 
     def tearDown(self):
         """Clean up singleton."""
+        self.storage_patcher.stop()
         YggdrasilCore._instance = None
 
     @patch("lib.ops.sinks.couch.OpsWriter")
@@ -409,11 +422,16 @@ class TestRunOnceWatcherLoop(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         YggdrasilCore._instance = None
+        self.storage_patcher = patch(
+            "lib.core_utils.yggdrasil_core.build_internal_storage"
+        )
+        self.mock_storage = self.storage_patcher.start().return_value
         self.mock_config = {"work_root": "/tmp/ygg_test"}
         self.mock_plan_dbm = MagicMock()
 
     def tearDown(self):
         """Clean up singleton."""
+        self.storage_patcher.stop()
         YggdrasilCore._instance = None
 
     @patch("lib.core_utils.yggdrasil_core.PlanWatcher")
@@ -436,6 +454,7 @@ class TestRunOnceWatcherLoop(unittest.TestCase):
         mock_watcher = MagicMock()
         mock_watcher.start = AsyncMock()  # Never emits events
         mock_watcher.stop = AsyncMock()
+        mock_watcher.recover_pending_plans = AsyncMock(return_value=[])
         mock_watcher_cls.return_value = mock_watcher
 
         core = YggdrasilCore(self.mock_config)
@@ -457,6 +476,160 @@ class TestRunOnceWatcherLoop(unittest.TestCase):
 
         # Assert
         self.assertEqual(result, 1)
+        mock_watcher.recover_pending_plans.assert_awaited_once_with(
+            plan_ids=pending_plan_ids
+        )
+
+    @patch("lib.core_utils.yggdrasil_core.PlanWatcher")
+    @patch("lib.core_utils.yggdrasil_core.is_plan_eligible")
+    @patch("lib.core_utils.yggdrasil_core.OpsConsumerService")
+    @patch("lib.core_utils.yggdrasil_core.FileSpoolEmitter")
+    @patch("lib.core_utils.yggdrasil_core.Engine")
+    @patch("lib.core_utils.yggdrasil_core.YggdrasilCore._init_db_managers")
+    def test_interrupt_during_recovery_skips_remaining_plans(
+        self,
+        mock_init_db,
+        mock_engine_class,
+        mock_emitter,
+        mock_ops,
+        mock_eligible,
+        mock_watcher_cls,
+    ):
+        """Ctrl+C during the recovery pass finishes the current plan but
+        skips subsequent recovered plans (they stay pending)."""
+        mock_eligible.return_value = True
+        execution_owner = "run_once:test-uuid"
+
+        def _event(plan_id: str) -> YggdrasilEvent:
+            doc = {
+                "_id": plan_id,
+                "status": "approved",
+                "run_token": 1,
+                "executed_run_token": 0,
+                "execution_authority": "run_once",
+                "execution_owner": execution_owner,
+            }
+            return YggdrasilEvent(
+                EventType.PLAN_EXECUTION,
+                {"plan_doc_id": plan_id, "plan_doc": doc},
+                "test",
+            )
+
+        # recover_pending_plans drives the real on_event callback for two
+        # plans; the callback is captured from the PlanWatcher constructor.
+        def _recover_side_effect(*, plan_ids):
+            self.assertEqual(plan_ids, ["pln_1", "pln_2"])
+            on_event = mock_watcher_cls.call_args.kwargs["on_event"]
+            on_event(_event("pln_1"))
+            on_event(_event("pln_2"))
+            return []
+
+        mock_watcher = MagicMock()
+        mock_watcher.start = AsyncMock()
+        mock_watcher.stop = AsyncMock()
+        mock_watcher.recover_pending_plans = AsyncMock(side_effect=_recover_side_effect)
+        mock_watcher_cls.return_value = mock_watcher
+
+        core = YggdrasilCore(self.mock_config)
+        core.plan_dbm = self.mock_plan_dbm
+        self.mock_plan_dbm.fetch_plan_as_model.return_value = MagicMock()
+
+        # The first executed plan raises SIGINT (delivered to the loop's own
+        # interrupt handler, installed before recovery); the second must be
+        # skipped by the interrupt guard.
+        executed: list[str] = []
+
+        def _engine_run(plan):
+            executed.append("run")
+            if len(executed) == 1:
+                signal.raise_signal(signal.SIGINT)
+
+        core.engine.run.side_effect = _engine_run
+
+        original = signal.getsignal(signal.SIGINT)
+        try:
+            result = asyncio.run(
+                core._run_once_watcher_loop(
+                    pending_plan_ids=["pln_1", "pln_2"],
+                    execution_owner=execution_owner,
+                    timeout_seconds=5.0,
+                )
+            )
+        finally:
+            signal.signal(signal.SIGINT, original)
+
+        # Only the first recovered plan executed; the second was skipped.
+        self.assertEqual(len(executed), 1)
+        self.assertEqual(core.engine.run.call_count, 1)
+        self.assertEqual(result, 130)
+
+    @patch("lib.core_utils.yggdrasil_core.PlanWatcher")
+    @patch("lib.core_utils.yggdrasil_core.is_plan_eligible")
+    @patch("lib.core_utils.yggdrasil_core.OpsConsumerService")
+    @patch("lib.core_utils.yggdrasil_core.FileSpoolEmitter")
+    @patch("lib.core_utils.yggdrasil_core.Engine")
+    @patch("lib.core_utils.yggdrasil_core.YggdrasilCore._init_db_managers")
+    def test_interrupt_while_loading_plan_prevents_execution(
+        self,
+        mock_init_db,
+        mock_engine_class,
+        mock_emitter,
+        mock_ops,
+        mock_eligible,
+        mock_watcher_cls,
+    ):
+        """Ctrl+C while loading a plan prevents the subsequent Engine call."""
+        mock_eligible.return_value = True
+        execution_owner = "run_once:test-uuid"
+        plan_doc = {
+            "_id": "pln_1",
+            "status": "approved",
+            "run_token": 1,
+            "executed_run_token": 0,
+            "execution_authority": "run_once",
+            "execution_owner": execution_owner,
+        }
+
+        def _recover_side_effect(*, plan_ids):
+            self.assertEqual(plan_ids, ["pln_1"])
+            on_event = mock_watcher_cls.call_args.kwargs["on_event"]
+            on_event(
+                YggdrasilEvent(
+                    EventType.PLAN_EXECUTION,
+                    {"plan_doc_id": "pln_1", "plan_doc": plan_doc},
+                    "test",
+                )
+            )
+            return []
+
+        mock_watcher = MagicMock()
+        mock_watcher.start = AsyncMock()
+        mock_watcher.stop = AsyncMock()
+        mock_watcher.recover_pending_plans = AsyncMock(side_effect=_recover_side_effect)
+        mock_watcher_cls.return_value = mock_watcher
+
+        core = YggdrasilCore(self.mock_config)
+        core.plan_dbm = self.mock_plan_dbm
+        core.engine.run.reset_mock(side_effect=True)
+
+        def _fetch_plan_as_model(plan_id):
+            self.assertEqual(plan_id, "pln_1")
+            signal.raise_signal(signal.SIGINT)
+            return MagicMock()
+
+        self.mock_plan_dbm.fetch_plan_as_model.side_effect = _fetch_plan_as_model
+
+        result = asyncio.run(
+            core._run_once_watcher_loop(
+                pending_plan_ids=["pln_1"],
+                execution_owner=execution_owner,
+                timeout_seconds=5.0,
+            )
+        )
+
+        core.engine.run.assert_not_called()
+        self.mock_plan_dbm.update_executed_token.assert_not_called()
+        self.assertEqual(result, 130)
 
 
 class TestCreateRunOncePlanForHandler(unittest.TestCase):
@@ -465,11 +638,16 @@ class TestCreateRunOncePlanForHandler(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         YggdrasilCore._instance = None
+        self.storage_patcher = patch(
+            "lib.core_utils.yggdrasil_core.build_internal_storage"
+        )
+        self.mock_storage = self.storage_patcher.start().return_value
         self.mock_config = {"work_root": "/tmp/ygg_test"}
         self.mock_plan_dbm = MagicMock()
 
     def tearDown(self):
         """Clean up singleton."""
+        self.storage_patcher.stop()
         YggdrasilCore._instance = None
 
     @patch("lib.core_utils.yggdrasil_core.OpsConsumerService")
@@ -500,19 +678,16 @@ class TestCreateRunOncePlanForHandler(unittest.TestCase):
 
         self.assertEqual(result, [])
 
-    @patch("lib.core_utils.yggdrasil_core.PlanDBManager")
     @patch("lib.core_utils.yggdrasil_core.OpsConsumerService")
     @patch("lib.core_utils.yggdrasil_core.FileSpoolEmitter")
     @patch("lib.core_utils.yggdrasil_core.Engine")
     @patch("lib.core_utils.yggdrasil_core.YggdrasilCore._init_db_managers")
     def test_returns_plan_doc_id_on_success(
-        self, mock_init_db, mock_engine, mock_emitter, mock_ops, mock_plan_dbm_cls
+        self, mock_init_db, mock_engine, mock_emitter, mock_ops
     ):
         """Test that method returns plan_doc_id on successful creation."""
         core = YggdrasilCore(self.mock_config)
 
-        # Mock the PlanDBManager class to return our mock instance
-        mock_plan_dbm_cls.return_value = self.mock_plan_dbm
         core.plan_dbm = (
             self.mock_plan_dbm
         )  # Assign mock since _init_db_managers is patched

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -1,0 +1,89 @@
+"""Unit tests for mode-aware runtime path resolution."""
+
+import os
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from lib.core_utils.runtime_paths import (
+    default_event_spool,
+    default_work_root,
+    resolve_event_spool,
+    resolve_work_root,
+)
+from lib.core_utils.ygg_session import YggSession
+
+
+class RuntimePathsTestBase(unittest.TestCase):
+    """Controls YggSession mode and the relevant environment variables."""
+
+    def setUp(self):
+        self._saved_session_state = (
+            YggSession._YggSession__dev_mode,
+            YggSession._YggSession__dev_already_set,
+        )
+        self._set_dev(False)
+        self._env_patcher = patch.dict(os.environ, {}, clear=False)
+        self._env_patcher.start()
+        os.environ.pop("YGG_WORK_ROOT", None)
+        os.environ.pop("YGG_EVENT_SPOOL", None)
+
+    def tearDown(self):
+        self._env_patcher.stop()
+        (
+            YggSession._YggSession__dev_mode,
+            YggSession._YggSession__dev_already_set,
+        ) = self._saved_session_state
+
+    @staticmethod
+    def _set_dev(dev: bool) -> None:
+        setattr(YggSession, "_YggSession__dev_mode", dev)
+        setattr(YggSession, "_YggSession__dev_already_set", dev)
+
+
+class TestModeDefaults(RuntimePathsTestBase):
+    def test_prod_defaults_unchanged(self):
+        self.assertEqual(default_work_root(), Path("/tmp/ygg_work"))
+        self.assertEqual(default_event_spool(), Path("/tmp/ygg_events"))
+
+    def test_dev_defaults_are_suffixed(self):
+        self._set_dev(True)
+        self.assertEqual(default_work_root(), Path("/tmp/ygg_work_dev"))
+        self.assertEqual(default_event_spool(), Path("/tmp/ygg_events_dev"))
+
+
+class TestResolveWorkRoot(RuntimePathsTestBase):
+    def test_config_beats_env(self):
+        os.environ["YGG_WORK_ROOT"] = "/env/work"
+        resolved = resolve_work_root({"work_root": "/config/work"})
+        self.assertEqual(resolved, Path("/config/work"))
+
+    def test_env_beats_mode_default(self):
+        os.environ["YGG_WORK_ROOT"] = "/env/work"
+        self._set_dev(True)
+        self.assertEqual(resolve_work_root(), Path("/env/work"))
+
+    def test_mode_default_when_unset(self):
+        self.assertEqual(resolve_work_root({}), Path("/tmp/ygg_work"))
+        self._set_dev(True)
+        self.assertEqual(resolve_work_root({}), Path("/tmp/ygg_work_dev"))
+
+    def test_falsy_config_value_ignored(self):
+        os.environ["YGG_WORK_ROOT"] = "/env/work"
+        self.assertEqual(resolve_work_root({"work_root": ""}), Path("/env/work"))
+
+
+class TestResolveEventSpool(RuntimePathsTestBase):
+    def test_env_beats_mode_default(self):
+        os.environ["YGG_EVENT_SPOOL"] = "/env/spool"
+        self._set_dev(True)
+        self.assertEqual(resolve_event_spool(), Path("/env/spool"))
+
+    def test_mode_default_when_unset(self):
+        self.assertEqual(resolve_event_spool(), Path("/tmp/ygg_events"))
+        self._set_dev(True)
+        self.assertEqual(resolve_event_spool(), Path("/tmp/ygg_events_dev"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_setup_realms.py
+++ b/tests/test_setup_realms.py
@@ -105,9 +105,13 @@ class TestSetupRealms(unittest.TestCase):
         self.db_patcher = patch(
             "lib.core_utils.yggdrasil_core.YggdrasilCore._init_db_managers"
         )
+        self.storage_patcher = patch(
+            "lib.core_utils.yggdrasil_core.build_internal_storage"
+        )
         self.mock_ops = self.ops_patcher.start()
         self.mock_engine = self.engine_patcher.start()
         self.mock_db = self.db_patcher.start()
+        self.mock_storage = self.storage_patcher.start().return_value
 
         ops_inst = Mock()
         ops_inst.start = Mock()
@@ -121,6 +125,7 @@ class TestSetupRealms(unittest.TestCase):
         self.ops_patcher.stop()
         self.engine_patcher.stop()
         self.db_patcher.stop()
+        self.storage_patcher.stop()
         SingletonMeta._instances.clear()
 
     def _make_core(self) -> YggdrasilCore:
@@ -472,9 +477,13 @@ class TestHandleEventRouting(unittest.TestCase):
         self.db_patcher = patch(
             "lib.core_utils.yggdrasil_core.YggdrasilCore._init_db_managers"
         )
+        self.storage_patcher = patch(
+            "lib.core_utils.yggdrasil_core.build_internal_storage"
+        )
         self.mock_ops = self.ops_patcher.start()
         self.mock_engine = self.engine_patcher.start()
         self.mock_db = self.db_patcher.start()
+        self.mock_storage = self.storage_patcher.start().return_value
 
         ops_inst = Mock()
         ops_inst.start = Mock()
@@ -488,6 +497,7 @@ class TestHandleEventRouting(unittest.TestCase):
         self.ops_patcher.stop()
         self.engine_patcher.stop()
         self.db_patcher.stop()
+        self.storage_patcher.stop()
         SingletonMeta._instances.clear()
 
     def _make_core_with_handlers(self):
@@ -661,9 +671,13 @@ class TestGetRealmHelpers(unittest.TestCase):
         self.db_patcher = patch(
             "lib.core_utils.yggdrasil_core.YggdrasilCore._init_db_managers"
         )
+        self.storage_patcher = patch(
+            "lib.core_utils.yggdrasil_core.build_internal_storage"
+        )
         self.mock_ops = self.ops_patcher.start()
         self.mock_engine = self.engine_patcher.start()
         self.mock_db = self.db_patcher.start()
+        self.mock_storage = self.storage_patcher.start().return_value
 
         ops_inst = Mock()
         ops_inst.start = Mock()
@@ -674,6 +688,7 @@ class TestGetRealmHelpers(unittest.TestCase):
         self.ops_patcher.stop()
         self.engine_patcher.stop()
         self.db_patcher.stop()
+        self.storage_patcher.stop()
         SingletonMeta._instances.clear()
 
     def test_get_realm_handler_ids(self):

--- a/tests/test_sqlite_change_source.py
+++ b/tests/test_sqlite_change_source.py
@@ -1,0 +1,167 @@
+"""Unit tests for the SQLite plan change source (cursor semantics)."""
+
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+
+from lib.storage.sqlite import (
+    SQLiteInternalStore,
+    SQLitePlanChangeSource,
+    SQLitePlanStore,
+)
+from yggdrasil.flow.model import Plan, StepSpec
+
+
+def _make_plan(plan_id: str) -> Plan:
+    return Plan(
+        plan_id=plan_id,
+        realm="test_realm",
+        scope={"kind": "project", "id": "P1"},
+        steps=[
+            StepSpec(
+                step_id="s1",
+                name="echo",
+                fn_ref="tests.integration.mock_steps:echo_step",
+                params={},
+            )
+        ],
+    )
+
+
+def _collect(source: SQLitePlanChangeSource, since, count: int, timeout: float = 5.0):
+    """Collect ``count`` events from the (infinite) stream."""
+
+    async def _run():
+        events = []
+
+        async def consume():
+            async for event in source.stream_changes_continuously(
+                since=since, poll_interval_sec=0.01
+            ):
+                events.append(event)
+                if len(events) >= count:
+                    return
+
+        await asyncio.wait_for(consume(), timeout)
+        return events
+
+    return asyncio.run(_run())
+
+
+class TestSQLitePlanChangeSource(unittest.TestCase):
+    """Cursor resolution, resume, coalescing, and tombstones."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.store = SQLiteInternalStore(Path(self._tmp.name) / "ygg.sqlite3")
+        self.plans = SQLitePlanStore(self.store)
+        self.source = SQLitePlanChangeSource(self.store)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _save(self, plan_id: str, *, auto_run: bool = True) -> None:
+        self.plans.save_plan(
+            _make_plan(plan_id),
+            "test_realm",
+            {"kind": "project", "id": "P1"},
+            auto_run=auto_run,
+        )
+
+    def test_since_zero_replays_from_start(self):
+        self._save("pln_a")
+        self._save("pln_b")
+        events = _collect(self.source, 0, 2)
+        self.assertEqual([e.id for e in events], ["pln_a", "pln_b"])
+        self.assertEqual(events[0].doc["_id"], "pln_a")
+        self.assertFalse(events[0].deleted)
+
+    def test_since_now_skips_existing_changes(self):
+        self._save("pln_before")
+        head = self.store.current_plan_seq()
+
+        async def _run():
+            events = []
+
+            async def consume():
+                async for event in self.source.stream_changes_continuously(
+                    since="now", poll_interval_sec=0.01
+                ):
+                    events.append(event)
+                    return
+
+            # Save a new plan while the stream is idle at the head
+            async def mutate():
+                await asyncio.sleep(0.05)
+                await asyncio.to_thread(self._save, "pln_after")
+
+            await asyncio.wait_for(asyncio.gather(consume(), mutate()), timeout=30.0)
+            return events
+
+        events = asyncio.run(_run())
+        self.assertEqual([e.id for e in events], ["pln_after"])
+        self.assertGreater(events[0].seq, head)
+
+    def test_opaque_cursor_resume(self):
+        self._save("pln_a")
+        self._save("pln_b")
+        first = _collect(self.source, 0, 1)[0]
+        resumed = _collect(self.source, first.seq, 1)
+        self.assertEqual([e.id for e in resumed], ["pln_b"])
+
+    def test_mutations_coalesce_to_latest_state(self):
+        self._save("pln_a", auto_run=False)  # draft
+        self._save("pln_a", auto_run=True)  # regenerated as approved
+        events = _collect(self.source, 0, 1)
+        # One event, carrying the latest document state
+        self.assertEqual(events[0].id, "pln_a")
+        self.assertEqual(events[0].doc["status"], "approved")
+        self.assertEqual(events[0].seq, self.store.current_plan_seq())
+
+    def test_tombstone_emits_deleted_event(self):
+        self._save("pln_a")
+        self.plans.delete_plan("pln_a")
+        events = _collect(self.source, 0, 1)
+        self.assertEqual(events[0].id, "pln_a")
+        self.assertTrue(events[0].deleted)
+        self.assertIsNone(events[0].doc)
+
+    def test_unparseable_cursor_starts_at_head(self):
+        self._save("pln_before")
+
+        # A CouchDB-style cursor cannot be parsed; stream starts at head
+        # and only observes new changes.
+        async def _run():
+            events = []
+
+            async def consume():
+                async for event in self.source.stream_changes_continuously(
+                    since="123-abcdef", poll_interval_sec=0.01
+                ):
+                    events.append(event)
+                    return
+
+            async def mutate():
+                await asyncio.sleep(0.05)
+                await asyncio.to_thread(self._save, "pln_after")
+
+            await asyncio.wait_for(asyncio.gather(consume(), mutate()), timeout=30.0)
+            return events
+
+        events = asyncio.run(_run())
+        self.assertEqual([e.id for e in events], ["pln_after"])
+
+    def test_restart_preserves_document_and_cursor_state(self):
+        self._save("pln_a")
+        head = self.store.current_plan_seq()
+        # Reopen the same file (new store instance = daemon restart)
+        store2 = SQLiteInternalStore(self.store.path)
+        source2 = SQLitePlanChangeSource(store2)
+        self.assertEqual(store2.current_plan_seq(), head)
+        events = _collect(source2, 0, 1)
+        self.assertEqual(events[0].id, "pln_a")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sqlite_storage.py
+++ b/tests/test_sqlite_storage.py
@@ -1,0 +1,381 @@
+"""Unit tests for the SQLite internal-storage backend.
+
+Uses real temporary SQLite files (the backend is local and fast); no
+CouchDB involvement anywhere.
+"""
+
+import os
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+from lib.storage.config import SQLiteInternalStorageConfig
+from lib.storage.sqlite import (
+    SQLiteCheckpointStore,
+    SQLiteInternalStore,
+    SQLiteOpsSnapshotSink,
+    SQLitePlanStore,
+    SQLiteStorageError,
+    build_sqlite_bundle,
+)
+from lib.watchers.backends.base import Checkpoint
+from yggdrasil.flow.model import Plan, StepSpec
+
+
+def _make_plan(plan_id: str = "pln_test_P1_v1") -> Plan:
+    """Build a minimal but real Plan model."""
+    return Plan(
+        plan_id=plan_id,
+        realm="test_realm",
+        scope={"kind": "project", "id": "P1"},
+        steps=[
+            StepSpec(
+                step_id="s1",
+                name="echo",
+                fn_ref="tests.integration.mock_steps:echo_step",
+                params={"message": "hi"},
+            )
+        ],
+    )
+
+
+class SQLiteStoreTestBase(unittest.TestCase):
+    """Shared temp-dir setup."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.db_path = Path(self._tmp.name) / "internal_state" / "dev" / "ygg.sqlite3"
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+
+class TestSQLiteLifecycle(SQLiteStoreTestBase):
+    """File/dir creation, permissions, and rejection paths."""
+
+    def test_creates_file_and_dirs_with_restrictive_permissions(self):
+        store = SQLiteInternalStore(self.db_path)
+        self.assertTrue(store.path.is_file())
+        self.assertEqual(os.stat(self.db_path).st_mode & 0o777, 0o600)
+        self.assertEqual(os.stat(self.db_path.parent).st_mode & 0o777, 0o700)
+        self.assertEqual(os.stat(self.db_path.parent.parent).st_mode & 0o777, 0o700)
+
+    def test_reopens_existing_database(self):
+        SQLiteInternalStore(self.db_path).put_document("plans", "d1", {"a": 1})
+        store2 = SQLiteInternalStore(self.db_path)
+        self.assertEqual(store2.get_document("plans", "d1")["a"], 1)
+
+    def test_deleted_database_recreated_fresh(self):
+        store = SQLiteInternalStore(self.db_path)
+        store.put_document("plans", "d1", {"a": 1}, bump_plan_seq=True)
+        self.db_path.unlink()
+        store2 = SQLiteInternalStore(self.db_path)
+        self.assertIsNone(store2.get_document("plans", "d1"))
+        self.assertEqual(store2.current_plan_seq(), 0)
+
+    def test_rejects_symlinked_database(self):
+        real = Path(self._tmp.name) / "real.sqlite3"
+        real.touch()
+        self.db_path.parent.mkdir(parents=True)
+        self.db_path.symlink_to(real)
+        with self.assertRaises(SQLiteStorageError):
+            SQLiteInternalStore(self.db_path)
+
+    def test_rejects_malformed_file(self):
+        self.db_path.parent.mkdir(parents=True)
+        self.db_path.write_text("this is not a sqlite database, not even close")
+        with self.assertRaises(SQLiteStorageError):
+            SQLiteInternalStore(self.db_path)
+
+    def test_rejects_unrelated_sqlite_file(self):
+        self.db_path.parent.mkdir(parents=True)
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("CREATE TABLE unrelated (x INTEGER)")
+        conn.commit()
+        conn.close()
+        with self.assertRaises(SQLiteStorageError) as ctx:
+            SQLiteInternalStore(self.db_path)
+        self.assertIn("application_id", str(ctx.exception))
+
+    def test_rejects_newer_schema_version(self):
+        SQLiteInternalStore(self.db_path)
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("PRAGMA user_version = 99")
+        conn.close()
+        with self.assertRaises(SQLiteStorageError) as ctx:
+            SQLiteInternalStore(self.db_path)
+        self.assertIn("Upgrade", str(ctx.exception))
+
+
+class TestSQLiteDocuments(SQLiteStoreTestBase):
+    """Low-level document semantics."""
+
+    def setUp(self):
+        super().setUp()
+        self.store = SQLiteInternalStore(self.db_path)
+
+    def test_get_missing_returns_none(self):
+        self.assertIsNone(self.store.get_document("plans", "nope"))
+
+    def test_put_get_roundtrip_injects_rev(self):
+        self.store.put_document("plans", "d1", {"x": 1})
+        doc = self.store.get_document("plans", "d1")
+        self.assertEqual(doc["x"], 1)
+        self.assertEqual(doc["_id"], "d1")
+        self.assertEqual(doc["_rev"], "1")
+
+    def test_rev_increments_and_is_not_stored_in_body(self):
+        self.store.put_document("plans", "d1", {"x": 1})
+        doc = self.store.get_document("plans", "d1")
+        doc["x"] = 2
+        self.store.put_document("plans", "d1", doc)  # carries _rev "1"
+        doc2 = self.store.get_document("plans", "d1")
+        self.assertEqual(doc2["_rev"], "2")
+        self.assertEqual(doc2["x"], 2)
+
+    def test_delete_tombstones_document(self):
+        self.store.put_document("plans", "d1", {"x": 1})
+        self.assertTrue(self.store.delete_document("plans", "d1"))
+        self.assertIsNone(self.store.get_document("plans", "d1"))
+        self.assertFalse(self.store.delete_document("plans", "d1"))
+
+    def test_namespaces_are_isolated(self):
+        self.store.put_document("plans", "d1", {"ns": "plans"})
+        self.store.put_document("checkpoints", "d1", {"ns": "checkpoints"})
+        self.assertEqual(self.store.get_document("plans", "d1")["ns"], "plans")
+        self.assertEqual(
+            self.store.get_document("checkpoints", "d1")["ns"], "checkpoints"
+        )
+
+    def test_plan_seq_bumps_only_when_requested(self):
+        self.store.put_document("checkpoints", "c1", {"v": 1})
+        self.assertEqual(self.store.current_plan_seq(), 0)
+        self.store.put_document("plans", "p1", {"v": 1}, bump_plan_seq=True)
+        self.assertEqual(self.store.current_plan_seq(), 1)
+
+    def test_touch_advances_metadata_without_rewriting_body(self):
+        self.store.put_document(
+            "plans",
+            "p1",
+            {"status": "approved", "executed_run_token": -1},
+            bump_plan_seq=True,
+        )
+        conn = sqlite3.connect(self.db_path)
+        before = conn.execute(
+            "SELECT revision, change_seq, body_json, updated_at "
+            "FROM documents WHERE namespace = 'plans' AND document_id = 'p1'"
+        ).fetchone()
+        conn.close()
+
+        self.assertTrue(self.store.touch_document("plans", "p1"))
+
+        conn = sqlite3.connect(self.db_path)
+        after = conn.execute(
+            "SELECT revision, change_seq, body_json, updated_at "
+            "FROM documents WHERE namespace = 'plans' AND document_id = 'p1'"
+        ).fetchone()
+        conn.close()
+        self.assertEqual(after[0], before[0] + 1)
+        self.assertEqual(after[1], before[1] + 1)
+        self.assertEqual(after[2], before[2])
+        self.assertGreaterEqual(after[3], before[3])
+        self.assertEqual(self.store.current_plan_seq(), after[1])
+
+    def test_touch_missing_or_tombstoned_document_is_noop(self):
+        self.assertFalse(self.store.touch_document("plans", "missing"))
+        self.assertEqual(self.store.current_plan_seq(), 0)
+
+        self.store.put_document("plans", "p1", {"x": 1}, bump_plan_seq=True)
+        self.store.delete_document("plans", "p1", bump_plan_seq=True)
+        seq_after_delete = self.store.current_plan_seq()
+
+        self.assertFalse(self.store.touch_document("plans", "p1"))
+        self.assertEqual(self.store.current_plan_seq(), seq_after_delete)
+
+
+class TestSQLitePlanStoreContract(SQLiteStoreTestBase):
+    """PlanStore behavioral contract against a real temp SQLite file."""
+
+    def setUp(self):
+        super().setUp()
+        self.plans = SQLitePlanStore(SQLiteInternalStore(self.db_path))
+
+    def test_save_plan_draft_shape(self):
+        doc_id = self.plans.save_plan(
+            _make_plan(), "test_realm", {"kind": "project", "id": "P1"}
+        )
+        doc = self.plans.fetch_plan(doc_id)
+        self.assertEqual(doc["status"], "draft")
+        self.assertEqual(doc["run_token"], 0)
+        self.assertEqual(doc["executed_run_token"], -1)
+        self.assertEqual(doc["execution_authority"], "daemon")
+        self.assertIn("created_at", doc)
+
+    def test_save_plan_auto_run_is_approved(self):
+        doc_id = self.plans.save_plan(
+            _make_plan(), "test_realm", {"kind": "project", "id": "P1"}, auto_run=True
+        )
+        self.assertEqual(self.plans.fetch_plan(doc_id)["status"], "approved")
+
+    def test_regeneration_resets_tokens_and_keeps_created_at(self):
+        doc_id = self.plans.save_plan(
+            _make_plan(), "test_realm", {"kind": "project", "id": "P1"}, auto_run=True
+        )
+        self.plans.update_executed_token(doc_id, 0)
+        created_at = self.plans.fetch_plan(doc_id)["created_at"]
+
+        self.plans.save_plan(
+            _make_plan(), "test_realm", {"kind": "project", "id": "P1"}
+        )
+        doc = self.plans.fetch_plan(doc_id)
+        self.assertEqual(doc["executed_run_token"], -1)
+        self.assertEqual(doc["run_token"], 0)
+        self.assertEqual(doc["created_at"], created_at)
+
+    def test_invalid_execution_authority_rejected(self):
+        with self.assertRaises(ValueError):
+            self.plans.save_plan(
+                _make_plan(),
+                "test_realm",
+                {"kind": "project", "id": "P1"},
+                execution_authority="bogus",
+            )
+
+    def test_fetch_plan_as_model_roundtrip(self):
+        plan = _make_plan()
+        doc_id = self.plans.save_plan(
+            plan, "test_realm", {"kind": "project", "id": "P1"}
+        )
+        model = self.plans.fetch_plan_as_model(doc_id)
+        self.assertIsNotNone(model)
+        self.assertEqual(model.plan_id, plan.plan_id)
+        self.assertEqual(model.steps[0].step_id, "s1")
+
+    def test_update_executed_token(self):
+        doc_id = self.plans.save_plan(
+            _make_plan(), "test_realm", {"kind": "project", "id": "P1"}, auto_run=True
+        )
+        self.assertTrue(self.plans.update_executed_token(doc_id, 0))
+        doc = self.plans.fetch_plan(doc_id)
+        self.assertEqual(doc["executed_run_token"], 0)
+        self.assertIn("last_executed_at", doc)
+
+    def test_update_executed_token_missing_plan(self):
+        self.assertFalse(self.plans.update_executed_token("nope", 0))
+
+    def test_query_approved_pending_filters_eligibility(self):
+        self.plans.save_plan(
+            _make_plan("pln_a"), "test_realm", {"kind": "project", "id": "P1"}
+        )  # draft — not eligible
+        self.plans.save_plan(
+            _make_plan("pln_b"),
+            "test_realm",
+            {"kind": "project", "id": "P1"},
+            auto_run=True,
+        )  # approved + pending — eligible
+        executed = self.plans.save_plan(
+            _make_plan("pln_c"),
+            "test_realm",
+            {"kind": "project", "id": "P1"},
+            auto_run=True,
+        )
+        self.plans.update_executed_token(executed, 0)  # executed — not eligible
+
+        eligible = self.plans.query_approved_pending()
+        self.assertEqual([d["_id"] for d in eligible], ["pln_b"])
+
+    def test_delete_and_exists(self):
+        doc_id = self.plans.save_plan(
+            _make_plan(), "test_realm", {"kind": "project", "id": "P1"}
+        )
+        self.assertTrue(self.plans.plan_exists(doc_id))
+        self.assertTrue(self.plans.delete_plan(doc_id))
+        self.assertFalse(self.plans.plan_exists(doc_id))
+        self.assertFalse(self.plans.delete_plan(doc_id))
+
+    def test_get_plan_summary(self):
+        doc_id = self.plans.save_plan(
+            _make_plan(), "test_realm", {"kind": "project", "id": "P1"}
+        )
+        summary = self.plans.get_plan_summary(doc_id)
+        self.assertEqual(summary["status"], "draft")
+        self.assertEqual(summary["realm"], "test_realm")
+        self.assertEqual(summary["run_token"], 0)
+        self.assertIsNone(self.plans.get_plan_summary("nope"))
+
+
+class TestSQLiteCheckpointStore(SQLiteStoreTestBase):
+    """CheckpointStore contract."""
+
+    def setUp(self):
+        super().setUp()
+        self.checkpoints = SQLiteCheckpointStore(SQLiteInternalStore(self.db_path))
+
+    def test_load_missing_returns_none(self):
+        self.assertIsNone(self.checkpoints.load("couchdb:projects_db"))
+
+    def test_save_and_load_roundtrip(self):
+        self.checkpoints.save(
+            Checkpoint(
+                backend_key="couchdb:projects_db",
+                value="42-abc",
+                updated_at="2026-07-17T00:00:00+00:00",
+            )
+        )
+        cp = self.checkpoints.load("couchdb:projects_db")
+        self.assertEqual(cp.backend_key, "couchdb:projects_db")
+        self.assertEqual(cp.value, "42-abc")
+
+    def test_save_overwrites(self):
+        for value in ("1", "2"):
+            self.checkpoints.save(
+                Checkpoint(backend_key="watcher:PlanWatcher", value=value)
+            )
+        self.assertEqual(self.checkpoints.load("watcher:PlanWatcher").value, "2")
+
+
+class TestSQLiteOpsSnapshotSink(SQLiteStoreTestBase):
+    """OpsSnapshotSink contract."""
+
+    def setUp(self):
+        super().setUp()
+        self.store = SQLiteInternalStore(self.db_path)
+        self.sink = SQLiteOpsSnapshotSink(self.store)
+
+    def test_write_upserts_latest_snapshot(self):
+        snapshot = {
+            "type": "plan_status",
+            "realm": "test_realm",
+            "plan_id": "pln_x",
+            "scope": {"kind": "project", "id": "P1"},
+            "steps": {"s1": {"state": "step.started"}},
+        }
+        self.sink.write(Path("/unused"), snapshot)
+        snapshot2 = dict(snapshot)
+        snapshot2["steps"] = {"s1": {"state": "step.succeeded"}}
+        self.sink.write(Path("/unused"), snapshot2)
+
+        doc_id = "proj-P1:plan_status:test_realm:pln_x"
+        doc = self.store.get_document("operations_snapshots", doc_id)
+        self.assertEqual(doc["steps"]["s1"]["state"], "step.succeeded")
+        self.assertEqual(doc["_rev"], "2")
+
+
+class TestBuildSQLiteBundle(SQLiteStoreTestBase):
+    """Bundle composition."""
+
+    def test_bundle_shares_one_store(self):
+        bundle = build_sqlite_bundle(SQLiteInternalStorageConfig(path=self.db_path))
+        self.assertEqual(bundle.backend, "sqlite")
+        doc_id = bundle.plans.save_plan(
+            _make_plan(), "test_realm", {"kind": "project", "id": "P1"}, auto_run=True
+        )
+        # The checkpoint store and ops sink hit the same file
+        bundle.checkpoints.save(Checkpoint(backend_key="k", value="v"))
+        self.assertTrue(bundle.plans.plan_exists(doc_id))
+        self.assertEqual(bundle.checkpoints.load("k").value, "v")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_yggdrasil_core.py
+++ b/tests/test_yggdrasil_core.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import os
 import unittest
-from unittest.mock import AsyncMock, Mock, call, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
 
 from lib.core_utils.event_types import EventType
 from lib.core_utils.singleton_decorator import SingletonMeta
@@ -54,6 +54,14 @@ class TestYggdrasilCore(unittest.TestCase):
         self.mock_ops_service_class = self.ops_patcher.start()
         self.mock_engine = self.engine_patcher.start()
 
+        # Patch internal-storage bundle construction (no real backends)
+        self.storage_patcher = patch(
+            "lib.core_utils.yggdrasil_core.build_internal_storage"
+        )
+        self.mock_build_storage = self.storage_patcher.start()
+        self.mock_storage = MagicMock()
+        self.mock_build_storage.return_value = self.mock_storage
+
         # Configure the OpsConsumerService mock instance with async methods
         self.mock_ops_service_instance = Mock()
         self.mock_ops_service_instance.start = Mock()
@@ -86,6 +94,7 @@ class TestYggdrasilCore(unittest.TestCase):
         # Stop patchers
         self.ops_patcher.stop()
         self.engine_patcher.stop()
+        self.storage_patcher.stop()
         # Clear singleton state after each test
         SingletonMeta._instances.clear()
 
@@ -139,31 +148,24 @@ class TestYggdrasilCore(unittest.TestCase):
             self.assertEqual(core2.config, self.test_config)
             self.assertEqual(core2._logger, self.mock_logger)
 
-    @patch("lib.couchdb.yggdrasil_db_manager.YggdrasilDBManager")
     @patch("lib.core_utils.yggdrasil_core.ProjectDBManager")
-    @patch("lib.core_utils.yggdrasil_core.PlanDBManager")
-    def test_init_db_managers_success(
-        self, mock_plan_dbm_class, mock_pdm_class, mock_ydm_class
-    ):
-        """Test successful database manager initialization."""
+    def test_init_db_managers_success(self, mock_pdm_class):
+        """Plan store comes from the bundle; ProjectDBManager stays lazy."""
         # Arrange
         mock_pdm_instance = Mock()
-        mock_ydm_instance = Mock()
-        mock_plan_dbm_instance = Mock()
         mock_pdm_class.return_value = mock_pdm_instance
-        mock_ydm_class.return_value = mock_ydm_instance
-        mock_plan_dbm_class.return_value = mock_plan_dbm_instance
 
         # Act
         core = YggdrasilCore(self.test_config, self.mock_logger)
 
-        # Assert
-        self.assertEqual(core.pdm, mock_pdm_instance)
-        self.assertEqual(core.ydm, mock_ydm_instance)
-        self.assertEqual(core.plan_dbm, mock_plan_dbm_instance)
+        # Assert: plan store wired from the internal-storage bundle
+        self.assertIs(core.plan_dbm, self.mock_storage.plans)
+
+        # ProjectDBManager is NOT constructed during initialization...
+        mock_pdm_class.assert_not_called()
+        # ...only on first access (run-doc paths)
+        self.assertIs(core.pdm, mock_pdm_instance)
         mock_pdm_class.assert_called_once()
-        mock_ydm_class.assert_called_once()
-        mock_plan_dbm_class.assert_called_once()
 
         expected_calls = [
             call("Initializing DB managers..."),
@@ -172,15 +174,10 @@ class TestYggdrasilCore(unittest.TestCase):
         ]
         self.mock_logger.info.assert_has_calls(expected_calls)
 
-    @patch("lib.core_utils.yggdrasil_core.PlanDBManager")
-    @patch("lib.couchdb.yggdrasil_db_manager.YggdrasilDBManager")
-    @patch("lib.core_utils.yggdrasil_core.ProjectDBManager")
-    def test_init_db_managers_exception(
-        self, mock_pdm_class, mock_ydm_class, mock_plan_dbm_class
-    ):
-        """Test database manager initialization with exception."""
-        # Arrange - make ProjectDBManager raise exception
-        mock_pdm_class.side_effect = Exception("DB connection failed")
+    def test_init_storage_exception_propagates(self):
+        """Internal-storage construction failure aborts initialization."""
+        # Arrange - make bundle construction raise
+        self.mock_build_storage.side_effect = Exception("DB connection failed")
 
         # Act & Assert
         with self.assertRaises(Exception) as context:

--- a/yggdrasil/cli.py
+++ b/yggdrasil/cli.py
@@ -4,7 +4,10 @@ from pathlib import Path
 
 from lib.core_utils.config_loader import ConfigLoader
 from lib.core_utils.daemon_lock import DaemonLock, DaemonLockError
-from lib.core_utils.errors import ExternalSystemUnavailableError
+from lib.core_utils.errors import (
+    ExternalSystemUnavailableError,
+    InternalStorageConfigurationError,
+)
 from lib.core_utils.logging_utils import configure_logging, custom_logger
 from lib.core_utils.ygg_session import YggSession
 from lib.core_utils.yggdrasil_core import YggdrasilCore
@@ -207,7 +210,11 @@ Examples:
                 )
                 raise SystemExit(exit_code)
 
-    except (WatcherConfigurationError, ExternalSystemUnavailableError) as e:
+    except (
+        WatcherConfigurationError,
+        ExternalSystemUnavailableError,
+        InternalStorageConfigurationError,
+    ) as e:
         # Environment/config problems, not bugs: one concise operator-facing
         # line; full traceback only at debug level (enabled by --dev).
         # WatcherConfigurationError embeds its config path itself; for
@@ -220,8 +227,11 @@ Examples:
         raise SystemExit(1) from None
     except DaemonLockError as e:
         logger.error(
-            "Another local Yggdrasil daemon is already running. "
-            "Lock path: %s. Existing metadata: %s",
+            "Another local Yggdrasil daemon is already running in %s mode. "
+            "Lock path: %s. Existing metadata: %s. "
+            "(Prod and dev daemons may run side by side; duplicates of the "
+            "same mode may not.)",
+            "dev" if args.dev else "prod",
             e.lock_path,
             e.existing_metadata,
         )

--- a/yggdrasil/core/engine.py
+++ b/yggdrasil/core/engine.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from lib.core_utils.logging_utils import custom_logger
+from lib.core_utils.runtime_paths import resolve_work_root
 from yggdrasil.flow.errors import PermanentStepError, TransientStepError
 from yggdrasil.flow.events.emitter import EventEmitter, FileSpoolEmitter
 from yggdrasil.flow.model import Plan, StepResult, StepSpec
@@ -111,9 +112,9 @@ class Engine:
         logger: logging.Logger | None = None,
     ):
         self._logger = logger or custom_logger(f"{__name__}.{type(self).__name__}")
-        self.work_root = Path(
-            work_root or os.environ.get("YGG_WORK_ROOT") or "/tmp/ygg_work"
-        )
+        # Default resolution ($YGG_WORK_ROOT → mode default) is centralized
+        # in lib.core_utils.runtime_paths.
+        self.work_root = Path(work_root) if work_root else resolve_work_root()
         self.emitter = emitter or FileSpoolEmitter()
 
     def _scope_dir(self, plan_dir: Path) -> Path:

--- a/yggdrasil/flow/events/emitter.py
+++ b/yggdrasil/flow/events/emitter.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import json
-import os
 import uuid
 from pathlib import Path
 from typing import Any, Protocol
 
+from lib.core_utils.runtime_paths import resolve_event_spool
 from yggdrasil.flow.utils.jsonify import to_jsonable
 from yggdrasil.flow.utils.ygg_time import utcnow_iso
 
@@ -15,11 +15,10 @@ class EventEmitter(Protocol):
 
 
 class FileSpoolEmitter:
-    def __init__(self, spool_dir: str | None = None):
-        # TODO: Decide between env var `YGG_EVENT_SPOOL` or reading from config
-        self.root = Path(
-            spool_dir or os.environ.get("YGG_EVENT_SPOOL") or "/tmp/ygg_events"
-        )
+    def __init__(self, spool_dir: str | Path | None = None):
+        # Default resolution ($YGG_EVENT_SPOOL → mode default) is centralized
+        # in lib.core_utils.runtime_paths.
+        self.root = Path(spool_dir) if spool_dir else resolve_event_spool()
         self.root.mkdir(parents=True, exist_ok=True)
 
     def emit(self, event: dict[str, Any]) -> None:

--- a/yggdrasil/flow/planner/api.py
+++ b/yggdrasil/flow/planner/api.py
@@ -36,7 +36,7 @@ class PlanDraft:
     plan: Plan
     auto_run: bool = True  # False => hold for human approval
     approvals_required: list[str] = field(default_factory=list)
-    notes: str = ""  # human summary for Genstat
+    notes: str = ""  # human-readable plan summary
     preview: dict[str, Any] = field(default_factory=dict)  # structured UI data
 
 


### PR DESCRIPTION
This PR introduces a backend-neutral internal-storage boundary for plans, watcher checkpoints, and operations snapshots. CouchDB remains available in all modes and is required for production; SQLite is available only through explicit dev-mode configuration or test injection. Existing installations without internal_storage retain the deprecated legacy CouchDB construction with a warning.

**Internal Storage Architecture and Configuration:**
- Adds a new `internal_storage` block to `main.json` for explicit selection of CouchDB or SQLite as the backend for internal state (plans, checkpoints, ops snapshots), with CouchDB as the default if not specified (deprecation warning issued). SQLite is only allowed in dev mode and stores all state in a single local file. [[1]](diffhunk://#diff-52b2c122f82c7a5a045460b35ec736781bf54dfac583a3cb142e64fc3e7be94aR1-R265) [[2]](diffhunk://#diff-6af609a81d15b0302c76a9032958ea268e0820137f80e81a7696b1a17241a415L137-R231)
- Updates documentation to show that `dev_main.json` fully replaces `main.json` in dev mode, not just overlays it, and that all `dev_*.json` files are swapped accordingly. [[1]](diffhunk://#diff-1464d4e80b51b66c2c15abe25e12dde94cd5db7e4a11b12eab60b48156d644ebL23-R23) [[2]](diffhunk://#diff-6af609a81d15b0302c76a9032958ea268e0820137f80e81a7696b1a17241a415L14-R15) [[3]](diffhunk://#diff-5d6489f129e1970e2aa86c08cd84e7989185eb30d41a564ba2e323e62e2321fdL80-R81)

**Daemon and Logging Behavior:**
- Documents and implements per-mode (prod/dev) daemon lock files (`daemon.lock` for prod, `daemon-dev.lock` for dev), allowing one daemon per mode per user per host, and updates log file naming to include a mode marker and PID for safe coexistence. [[1]](diffhunk://#diff-1464d4e80b51b66c2c15abe25e12dde94cd5db7e4a11b12eab60b48156d644ebL52-R54) [[2]](diffhunk://#diff-6af609a81d15b0302c76a9032958ea268e0820137f80e81a7696b1a17241a415L137-R231)

**Manual Plan Approval and Operations:**
- Clarifies that Yggdrasil does not ship a plan-approval UI/command; operators must integrate with the configured plan store for approval. In SQLite mode, the integration must advance the plan change sequence transactionally for PlanWatcher to observe updates. [[1]](diffhunk://#diff-52b2c122f82c7a5a045460b35ec736781bf54dfac583a3cb142e64fc3e7be94aR1-R265) [[2]](diffhunk://#diff-6af609a81d15b0302c76a9032958ea268e0820137f80e81a7696b1a17241a415L137-R231) [[3]](diffhunk://#diff-cd8d0d196155087518a4d8b368224fec09974095bc89b24b70b16ab0996591e4L105-R117)

**Event Flow and Core Integration:**
- Updates the event flow documentation to show that plan persistence and change streaming are now backend-neutral, using the injected `InternalStorageBundle` (CouchDB or SQLite), and that PlanWatcher and Engine consume this bundle.

**Deprecations and Compatibility:**
- Deprecates the legacy `OPS_DB` environment variable and implicit CouchDB configuration; explicit configuration is now recommended and will be required in the future.

These changes collectively improve Yggdrasil's flexibility, developer experience, and operational safety when running production and dev daemons side by side.